### PR TITLE
feat: publish bw and c-plugin CLIs to JSR

### DIFF
--- a/.github/workflows/deploy-bw.yaml
+++ b/.github/workflows/deploy-bw.yaml
@@ -1,0 +1,27 @@
+name: Publish @totto2727/bw
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - js/app/bw/**
+      - .github/workflows/deploy-bw.yaml
+      - .github/actions/setup-typescript/**
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-typescript
+
+      - name: Publish jsr:@totto2727/bw
+        working-directory: js/app/bw
+        run: |
+          vpx jsr publish

--- a/.github/workflows/deploy-c-plugin.yaml
+++ b/.github/workflows/deploy-c-plugin.yaml
@@ -1,0 +1,27 @@
+name: Publish @totto2727/c-plugin
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - js/app/c-plugin/**
+      - .github/workflows/deploy-c-plugin.yaml
+      - .github/actions/setup-typescript/**
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-typescript
+
+      - name: Publish jsr:@totto2727/c-plugin
+        working-directory: js/app/c-plugin
+        run: |
+          vpx jsr publish

--- a/js/app/bw/jsr.json
+++ b/js/app/bw/jsr.json
@@ -1,0 +1,12 @@
+{
+  "name": "@totto2727/bw",
+  "version": "0.1.0",
+  "license": "MIT",
+  "publish": {
+    "include": ["src/**/*.ts", "package.json", "LICENSE", "README.md"],
+    "exclude": ["src/**/*.test.ts"]
+  },
+  "exports": {
+    ".": "./src/bin.ts"
+  }
+}

--- a/js/app/bw/package.json
+++ b/js/app/bw/package.json
@@ -1,6 +1,12 @@
 {
   "name": "bw",
   "version": "0.1.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/totto2727-org/monorepo",
+    "directory": "js/app/bw"
+  },
   "bin": {
     "bw": "./dist/bin.js"
   },
@@ -9,7 +15,9 @@
     "#@/*": "./src/*"
   },
   "scripts": {
-    "build": "vp pack"
+    "build": "vp pack",
+    "check": "pnpm run --parallel /check:.*/",
+    "check:slowtype": "vpx jsr publish --dry-run --allow-dirty"
   },
   "dependencies": {
     "@effect/platform-node": "catalog:effect",

--- a/js/app/c-plugin/jsr.json
+++ b/js/app/c-plugin/jsr.json
@@ -1,0 +1,12 @@
+{
+  "name": "@totto2727/c-plugin",
+  "version": "0.1.0",
+  "license": "MIT",
+  "publish": {
+    "include": ["src/**/*.ts", "package.json", "LICENSE", "README.md"],
+    "exclude": ["src/**/*.test.ts"]
+  },
+  "exports": {
+    ".": "./src/bin.ts"
+  }
+}

--- a/js/app/c-plugin/package.json
+++ b/js/app/c-plugin/package.json
@@ -1,6 +1,12 @@
 {
   "name": "c-plugin",
   "version": "0.1.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/totto2727-org/monorepo",
+    "directory": "js/app/c-plugin"
+  },
   "bin": {
     "c-plugin": "./dist/bin.js"
   },
@@ -10,7 +16,9 @@
   },
   "scripts": {
     "build": "vp pack",
-    "bin": "node dist/bin.mjs"
+    "bin": "node dist/bin.mjs",
+    "check": "pnpm run --parallel /check:.*/",
+    "check:slowtype": "vpx jsr publish --dry-run --allow-dirty"
   },
   "dependencies": {
     "@effect/platform-node": "catalog:effect",


### PR DESCRIPTION
## Summary
- Add `jsr.json` manifests for `bw` and `c-plugin` so they can be released as `@totto2727/bw` and `@totto2727/c-plugin` on JSR (`exports['.']` → `src/bin.ts`)
- Add `license` / `repository` metadata and `check` / `check:slowtype` (`vpx jsr publish --dry-run --allow-dirty`) scripts so the existing `vp run -r check` pipeline validates JSR publishability without further CI changes
- Add `.github/workflows/deploy-bw.yaml` and `deploy-c-plugin.yaml` mirroring the existing `deploy-totto2727-fp.yaml` flow (push-to-main with paths filter, OIDC `id-token: write`, `vpx jsr publish`)

## Test plan
- [x] Local: \`vp run --filter bw check:slowtype\` → \`Success Dry run complete\`
- [x] Local: \`vp run --filter c-plugin check:slowtype\` → \`Success Dry run complete\`
- [x] Verified \`vp run -r check\` picks up both new \`check:slowtype\` scripts (lint failures observed are pre-existing in \`rss-graphql\`, unrelated)
- [ ] Pre-merge user setup: create \`@totto2727/bw\` and \`@totto2727/c-plugin\` packages on JSR and authorize \`totto2727-org/monorepo\` for OIDC publishing
- [ ] After merge: confirm \`Publish @totto2727/bw\` and \`Publish @totto2727/c-plugin\` workflows publish 0.1.0 successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)