### PR TITLE
feat(plugin/totto2727): add bash command guard PreToolUse hook

### DIFF
--- a/doc/adr/2026-04-25-bash-command-guard-hook.md
+++ b/doc/adr/2026-04-25-bash-command-guard-hook.md
@@ -1,0 +1,151 @@
+---
+confirmed: false
+---
+
+# ADR: Bash Command Guard via PreToolUse Hook (Deno)
+
+## Context
+
+Repository-level constraints have accumulated that should never be bypassed locally — for
+example, never running with `CI=true`, never using `<package-manager> ci` outside the CI
+pipeline, and never using `git -C` (which forces ambiguous working-tree semantics and
+triggers permission prompts in this Claude Code setup).
+
+These rules currently live in MEMORY (`feedback_no_ci_env`) or in CLAUDE.md hints, which
+are advisory: a forgetful agent can still issue them. We want **enforcement**, not just
+advice, so the user does not need to repeat the same correction across sessions.
+
+Constraints shaping the design:
+
+1. **Plugin-local**: this guardrail belongs to `plugins/totto2727`, not to a per-project
+   tool — it should be opt-in by installing the plugin.
+2. **No Node/TS toolchain coupling**: the hook must run before any project install step
+   and must not depend on `pnpm`/`vp`/`vite` being available. The repo already uses Deno
+   for one-off scripts (cf. existing `**/.script/**` ignore pattern in `vite.config.ts`).
+3. **Zero external dependencies**: anything imported pulls a network fetch on first run,
+   which is undesirable for a hook that fires on every Bash tool call.
+4. **Per-rule testability**: rules are independent units of behavior; each one needs its
+   own tests so we can iterate on a single rule without touching the others.
+5. **Multi-hook future**: we expect more hooks under the same plugin (one per concern),
+   not a single megascript.
+
+## Decision
+
+### 1. Runtime: Deno
+
+Implement the guard as a Deno script invoked from a Claude Code `PreToolUse` hook with
+`matcher: "Bash"`. Deno is preferred over Node because:
+
+- It is already on PATH via devbox.
+- It runs `.ts` files directly, no build step.
+- Default-deny permissions mean the hook cannot read the filesystem or network even if
+  buggy; we pass `--no-prompt` and no `--allow-*` flags.
+- Built-in `Deno.test` removes the need for a test framework dependency.
+
+The script does not import anything outside its own directory, so first-run latency is
+just Deno's typecheck of the local files.
+
+### 2. Plugin Layout: `script/<hook-name>/`
+
+```
+plugins/totto2727/hooks/
+├── hooks.json                       # Claude Code hook registration
+└── script/
+    └── bash-guard/                  # one directory per hook
+        ├── deno.json
+        ├── main.ts                  # entrypoint
+        ├── lib/                     # shared helpers (tokenizer, etc.)
+        │   ├── shell.ts
+        │   └── shell.test.ts
+        └── rules/
+            ├── types.ts             # Rule / RuleViolation
+            ├── index.ts             # registry
+            ├── no-ci-env.{ts,test.ts}
+            ├── no-package-manager-ci.{ts,test.ts}
+            └── no-git-c.{ts,test.ts}
+```
+
+Each future hook gets its own sibling directory under `script/`, with its own
+`deno.json`, so hooks are independently versioned and testable.
+
+### 3. Rule Contract
+
+Each rule exports an object matching:
+
+```ts
+type Rule = {
+  readonly name: string
+  readonly check: (command: string) => RuleViolation | null
+}
+type RuleViolation = {
+  readonly rule: string
+  readonly message: string     // what is forbidden
+  readonly resolution: string  // how to comply
+}
+```
+
+Rules are free to use either regex or the shared shell tokenizer. They are aggregated in
+`rules/index.ts` and run in registration order; **all** matching rules surface their
+violations on a single deny response, so the user sees every problem at once.
+
+### 4. Shell Tokenizer (`lib/shell.ts`)
+
+A minimal tokenizer that respects single/double quotes, backslash escapes, and emits
+operator tokens (`;`, `&&`, `||`, `|`, `&`). It is **not** a full shell parser — it does
+not expand variables, evaluate substitutions, or handle redirections. The accompanying
+`splitCommands` utility splits an argv stream at operator boundaries so each rule can
+inspect each chained command independently. `skipEnvPrefix` normalizes leading
+`FOO=bar`/`export FOO=bar` prefixes.
+
+### 5. Hook I/O Contract
+
+`main.ts` reads the Claude Code PreToolUse JSON payload from stdin, ignores anything that
+is not a `Bash` tool call, and emits a single JSON document on stdout when one or more
+rules fire:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Bash command blocked by hook:\n\n[<rule>] <message>\n  Resolution: <resolution>"
+  }
+}
+```
+
+The script always exits 0 — the deny decision is encoded in the JSON, not the exit code.
+
+### 6. Initial Rules
+
+| Rule                       | Detection                                                                                                                  |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `no-ci-env`                | `CI=<truthy>` env-prefix tokens (and `export CI=<truthy>`); does not flag the literal inside quoted strings.               |
+| `no-package-manager-ci`    | `<pm> ci` for `pm ∈ {npm, pnpm, yarn, bun, vp}`, accounting for env prefixes and command chaining.                         |
+| `no-git-c`                 | `-C` token in `git`'s **global option region** (before the subcommand), regardless of order; skips value-taking options.   |
+
+`no-git-c` deliberately does not flag `-C` after the subcommand (e.g. `git diff -C`,
+`git log -C`) since those are different flags belonging to the subcommand.
+
+### 7. Toolchain Exclusion
+
+Add `**/hooks/script/**` to both `lint.ignorePatterns` and `fmt.ignorePatterns` in
+`vite.config.ts`. Verification of these files is performed exclusively via Deno:
+
+```bash
+deno lint   # in plugins/totto2727/hooks/script/bash-guard
+deno check main.ts rules/index.ts ...
+deno test
+```
+
+## Impact
+
+- New plugin component under `plugins/totto2727/hooks/script/bash-guard/` (13 files, 58
+  unit tests, 0 external dependencies).
+- `plugins/totto2727/hooks/hooks.json` gains a `PreToolUse` entry alongside existing
+  `SessionStart`/`Stop` exocortex hooks.
+- `vite.config.ts` ignore patterns extended so `vp check` skips Deno-only sources.
+- Anyone activating the `totto2727` plugin will have the three rules enforced on every
+  Bash invocation that Claude Code mediates. The hook does not affect commands run
+  outside Claude Code.
+- Future hooks can be added as siblings under `script/` (e.g. `script/<other-hook>/`)
+  without disturbing this one.

--- a/plugins/totto2727/hooks/hooks.json
+++ b/plugins/totto2727/hooks/hooks.json
@@ -1,6 +1,18 @@
 {
-  "description": "Exocortex integration for persistent knowledge management",
+  "description": "Exocortex integration for persistent knowledge management, plus Bash command guardrails",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "deno run --no-prompt ${CLAUDE_PLUGIN_ROOT}/hooks/script/bash-guard/main.ts",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "*",

--- a/plugins/totto2727/hooks/script/bash-guard/deno.json
+++ b/plugins/totto2727/hooks/script/bash-guard/deno.json
@@ -1,0 +1,19 @@
+{
+  "fmt": {
+    "useTabs": false,
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "singleQuote": true,
+    "semiColons": false
+  },
+  "lint": {
+    "rules": {
+      "tags": ["recommended"]
+    }
+  },
+  "tasks": {
+    "test": "deno test",
+    "lint": "deno lint",
+    "check": "deno check main.ts rules/index.ts"
+  }
+}

--- a/plugins/totto2727/hooks/script/bash-guard/lib/shell.test.ts
+++ b/plugins/totto2727/hooks/script/bash-guard/lib/shell.test.ts
@@ -1,0 +1,124 @@
+import { isEnvAssignment, skipEnvPrefix, splitCommands, tokenize } from './shell.ts'
+
+function assertEquals<T>(actual: T, expected: T, msg?: string): void {
+  const a = JSON.stringify(actual)
+  const e = JSON.stringify(expected)
+  if (a !== e) {
+    throw new Error(`${msg ?? 'assertEquals failed'}\n  expected: ${e}\n  actual:   ${a}`)
+  }
+}
+
+Deno.test('tokenize: simple words', () => {
+  assertEquals(
+    tokenize('npm test'),
+    [
+      { type: 'word', value: 'npm' },
+      { type: 'word', value: 'test' },
+    ],
+  )
+})
+
+Deno.test('tokenize: double-quoted string keeps spaces', () => {
+  assertEquals(
+    tokenize('echo "hello world"'),
+    [
+      { type: 'word', value: 'echo' },
+      { type: 'word', value: 'hello world' },
+    ],
+  )
+})
+
+Deno.test('tokenize: single quotes preserve content literally', () => {
+  assertEquals(
+    tokenize(`echo 'a b'`),
+    [
+      { type: 'word', value: 'echo' },
+      { type: 'word', value: 'a b' },
+    ],
+  )
+})
+
+Deno.test('tokenize: escape with backslash', () => {
+  assertEquals(
+    tokenize('echo a\\ b'),
+    [
+      { type: 'word', value: 'echo' },
+      { type: 'word', value: 'a b' },
+    ],
+  )
+})
+
+Deno.test('tokenize: && and || and ; operators', () => {
+  assertEquals(
+    tokenize('a && b || c ; d'),
+    [
+      { type: 'word', value: 'a' },
+      { type: 'op', value: '&&' },
+      { type: 'word', value: 'b' },
+      { type: 'op', value: '||' },
+      { type: 'word', value: 'c' },
+      { type: 'op', value: ';' },
+      { type: 'word', value: 'd' },
+    ],
+  )
+})
+
+Deno.test('tokenize: pipe', () => {
+  assertEquals(
+    tokenize('a | b'),
+    [
+      { type: 'word', value: 'a' },
+      { type: 'op', value: '|' },
+      { type: 'word', value: 'b' },
+    ],
+  )
+})
+
+Deno.test('tokenize: env var assignment kept as one token', () => {
+  assertEquals(
+    tokenize('CI=true npm test'),
+    [
+      { type: 'word', value: 'CI=true' },
+      { type: 'word', value: 'npm' },
+      { type: 'word', value: 'test' },
+    ],
+  )
+})
+
+Deno.test('splitCommands: splits at operators', () => {
+  const tokens = tokenize('a b && c d ; e')
+  assertEquals(splitCommands(tokens), [['a', 'b'], ['c', 'd'], ['e']])
+})
+
+Deno.test('splitCommands: empty input', () => {
+  assertEquals(splitCommands([]), [])
+})
+
+Deno.test('isEnvAssignment: matches FOO=bar', () => {
+  assertEquals(isEnvAssignment('FOO=bar'), true)
+  assertEquals(isEnvAssignment('CI=true'), true)
+  assertEquals(isEnvAssignment('_X=1'), true)
+  assertEquals(isEnvAssignment('foo=bar'), true)
+})
+
+Deno.test('isEnvAssignment: rejects non-assignment', () => {
+  assertEquals(isEnvAssignment('--foo=bar'), false)
+  assertEquals(isEnvAssignment('1FOO=bar'), false)
+  assertEquals(isEnvAssignment('FOO'), false)
+})
+
+Deno.test('skipEnvPrefix: skips leading assignments', () => {
+  assertEquals(skipEnvPrefix(['FOO=1', 'BAR=2', 'cmd', 'arg']), 2)
+})
+
+Deno.test('skipEnvPrefix: skips export form', () => {
+  assertEquals(skipEnvPrefix(['export', 'FOO=1', 'BAR=2']), 3)
+})
+
+Deno.test('skipEnvPrefix: no prefix returns 0', () => {
+  assertEquals(skipEnvPrefix(['cmd', 'arg']), 0)
+})
+
+Deno.test('skipEnvPrefix: empty', () => {
+  assertEquals(skipEnvPrefix([]), 0)
+})

--- a/plugins/totto2727/hooks/script/bash-guard/lib/shell.ts
+++ b/plugins/totto2727/hooks/script/bash-guard/lib/shell.ts
@@ -1,0 +1,144 @@
+/**
+ * Minimal shell tokenizer.
+ *
+ * Splits a command string into word tokens and operator tokens, respecting
+ * single/double quotes and backslash escapes. Operators are command separators
+ * such as `;`, `&&`, `||`, `|`, `&`.
+ *
+ * This is intentionally NOT a full shell parser — it does not expand variables,
+ * resolve subshells, evaluate command substitution, or handle redirections.
+ * It is sufficient for inspecting Bash commands at hook time.
+ */
+
+export type Token =
+  | { readonly type: 'word'; readonly value: string }
+  | { readonly type: 'op'; readonly value: ';' | '&&' | '||' | '|' | '&' }
+
+export function tokenize(command: string): Token[] {
+  const tokens: Token[] = []
+  let current = ''
+  let inSingle = false
+  let inDouble = false
+  let escaped = false
+  let i = 0
+
+  const flushWord = () => {
+    if (current.length > 0) {
+      tokens.push({ type: 'word', value: current })
+      current = ''
+    }
+  }
+
+  while (i < command.length) {
+    const ch = command[i]
+
+    if (escaped) {
+      current += ch
+      escaped = false
+      i++
+      continue
+    }
+
+    if (ch === '\\' && !inSingle) {
+      escaped = true
+      i++
+      continue
+    }
+
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle
+      i++
+      continue
+    }
+
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble
+      i++
+      continue
+    }
+
+    if (!inSingle && !inDouble) {
+      if (ch === '&' && command[i + 1] === '&') {
+        flushWord()
+        tokens.push({ type: 'op', value: '&&' })
+        i += 2
+        continue
+      }
+      if (ch === '|' && command[i + 1] === '|') {
+        flushWord()
+        tokens.push({ type: 'op', value: '||' })
+        i += 2
+        continue
+      }
+      if (ch === ';' || ch === '|' || ch === '&') {
+        flushWord()
+        tokens.push({ type: 'op', value: ch })
+        i++
+        continue
+      }
+      if (/\s/.test(ch)) {
+        flushWord()
+        i++
+        continue
+      }
+    }
+
+    current += ch
+    i++
+  }
+
+  flushWord()
+  return tokens
+}
+
+/**
+ * Splits a tokenized command stream into individual command argv arrays at
+ * operator boundaries (`;`, `&&`, `||`, `|`, `&`).
+ */
+export function splitCommands(tokens: readonly Token[]): string[][] {
+  const commands: string[][] = []
+  let current: string[] = []
+  for (const tok of tokens) {
+    if (tok.type === 'op') {
+      if (current.length > 0) {
+        commands.push(current)
+        current = []
+      }
+    } else {
+      current.push(tok.value)
+    }
+  }
+  if (current.length > 0) commands.push(current)
+  return commands
+}
+
+/**
+ * Returns true when a token has the shape of a shell environment variable
+ * assignment prefix (e.g. `FOO=bar`, `CI=true`).
+ */
+export function isEnvAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token)
+}
+
+/**
+ * Returns the index of the first non-prefix token in an argv array,
+ * skipping any leading env-assignment tokens and a single optional `export`
+ * keyword.
+ */
+export function skipEnvPrefix(argv: readonly string[]): number {
+  let i = 0
+  while (i < argv.length) {
+    const t = argv[i]
+    if (t === 'export') {
+      i++
+      while (i < argv.length && isEnvAssignment(argv[i])) i++
+      return i
+    }
+    if (isEnvAssignment(t)) {
+      i++
+      continue
+    }
+    return i
+  }
+  return i
+}

--- a/plugins/totto2727/hooks/script/bash-guard/main.ts
+++ b/plugins/totto2727/hooks/script/bash-guard/main.ts
@@ -1,0 +1,75 @@
+/**
+ * PreToolUse hook entrypoint.
+ *
+ * Reads the hook payload from stdin (JSON), runs each rule against the Bash
+ * `command` field, and emits a `permissionDecision: deny` JSON response on
+ * stdout when any rule fires. Exits 0 in all cases — Claude Code derives the
+ * deny decision from the JSON, not the exit code.
+ */
+
+import { rules } from './rules/index.ts'
+import type { RuleViolation } from './rules/types.ts'
+
+type HookInput = {
+  readonly hook_event_name?: string
+  readonly tool_name?: string
+  readonly tool_input?: { readonly command?: string }
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Uint8Array[] = []
+  const reader = Deno.stdin.readable.getReader()
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  let total = 0
+  for (const c of chunks) total += c.length
+  const buf = new Uint8Array(total)
+  let off = 0
+  for (const c of chunks) {
+    buf.set(c, off)
+    off += c.length
+  }
+  return new TextDecoder().decode(buf)
+}
+
+function formatReason(violations: readonly RuleViolation[]): string {
+  const blocks = violations.map(
+    (v) => `[${v.rule}] ${v.message}\n  Resolution: ${v.resolution}`,
+  )
+  return `Bash command blocked by hook:\n\n${blocks.join('\n\n')}`
+}
+
+function evaluate(command: string): RuleViolation[] {
+  const out: RuleViolation[] = []
+  for (const rule of rules) {
+    const v = rule.check(command)
+    if (v) out.push(v)
+  }
+  return out
+}
+
+async function main(): Promise<void> {
+  const raw = await readStdin()
+  const input: HookInput = raw.trim().length === 0 ? {} : JSON.parse(raw)
+
+  if (input.tool_name !== 'Bash') return
+  const command = input.tool_input?.command
+  if (typeof command !== 'string' || command.length === 0) return
+
+  const violations = evaluate(command)
+  if (violations.length === 0) return
+
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: formatReason(violations),
+    },
+  }
+  console.log(JSON.stringify(output))
+}
+
+await main()

--- a/plugins/totto2727/hooks/script/bash-guard/rules/index.ts
+++ b/plugins/totto2727/hooks/script/bash-guard/rules/index.ts
@@ -1,0 +1,6 @@
+import { noCiEnv } from './no-ci-env.ts'
+import { noGitC } from './no-git-c.ts'
+import { noPackageManagerCi } from './no-package-manager-ci.ts'
+import type { Rule } from './types.ts'
+
+export const rules: readonly Rule[] = [noCiEnv, noPackageManagerCi, noGitC]

--- a/plugins/totto2727/hooks/script/bash-guard/rules/no-ci-env.test.ts
+++ b/plugins/totto2727/hooks/script/bash-guard/rules/no-ci-env.test.ts
@@ -1,0 +1,61 @@
+import { noCiEnv } from './no-ci-env.ts'
+
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) throw new Error(msg)
+}
+
+Deno.test('blocks CI=true npm test', () => {
+  const r = noCiEnv.check('CI=true npm test')
+  assert(r !== null, 'expected violation')
+  assert(r.rule === 'no-ci-env', `wrong rule: ${r.rule}`)
+})
+
+Deno.test('blocks CI=1 cmd', () => {
+  assert(noCiEnv.check('CI=1 echo hi') !== null, 'expected violation')
+})
+
+Deno.test('blocks CI=yes cmd', () => {
+  assert(noCiEnv.check('CI=yes pnpm test') !== null, 'expected violation')
+})
+
+Deno.test('blocks export CI=true', () => {
+  assert(noCiEnv.check('export CI=true') !== null, 'expected violation')
+})
+
+Deno.test('blocks CI=true between other env prefixes', () => {
+  assert(noCiEnv.check('FOO=1 CI=true BAR=2 cmd') !== null, 'expected violation')
+})
+
+Deno.test('blocks CI=true in second segment of compound command', () => {
+  assert(noCiEnv.check('echo a && CI=true cmd') !== null, 'expected violation')
+})
+
+Deno.test('allows CI=false cmd', () => {
+  assert(noCiEnv.check('CI=false npm test') === null, 'unexpected violation')
+})
+
+Deno.test('allows plain npm test', () => {
+  assert(noCiEnv.check('npm test') === null, 'unexpected violation')
+})
+
+Deno.test('allows CI=true literal inside double quotes (echo)', () => {
+  assert(noCiEnv.check('echo "CI=true"') === null, 'unexpected violation')
+})
+
+Deno.test('allows CI=true literal inside single quotes', () => {
+  assert(noCiEnv.check(`echo 'CI=true'`) === null, 'unexpected violation')
+})
+
+Deno.test('allows CI_OTHER=true (different var name)', () => {
+  assert(noCiEnv.check('CI_OTHER=true cmd') === null, 'unexpected violation')
+})
+
+Deno.test('allows RECIPI=true (does not match CI=)', () => {
+  assert(noCiEnv.check('RECIPI=true cmd') === null, 'unexpected violation')
+})
+
+Deno.test('violation includes resolution', () => {
+  const r = noCiEnv.check('CI=true cmd')
+  assert(r !== null, 'expected violation')
+  assert(r.resolution.length > 0, 'resolution should be set')
+})

--- a/plugins/totto2727/hooks/script/bash-guard/rules/no-ci-env.ts
+++ b/plugins/totto2727/hooks/script/bash-guard/rules/no-ci-env.ts
@@ -1,0 +1,61 @@
+import { isEnvAssignment, splitCommands, tokenize } from '../lib/shell.ts'
+import type { Rule, RuleViolation } from './types.ts'
+
+const TRUTHY = new Set(['true', '1', 'yes', 'on', 'TRUE', 'YES', 'ON', 'True', 'Yes', 'On'])
+
+const CI_ASSIGNMENT = /^CI=(.+)$/
+
+/**
+ * Looks for `CI=<truthy>` assignment tokens that would actually be applied
+ * to a command — i.e. either a leading env-var prefix (`CI=true cmd ...`),
+ * or following the `export` keyword.
+ *
+ * Tokens inside quoted strings (e.g. `echo "CI=true"`) are not detected
+ * because they are not assignments.
+ */
+function scanCmd(argv: readonly string[]): RuleViolation | null {
+  let i = 0
+  while (i < argv.length) {
+    const t = argv[i]
+    if (t === 'export') {
+      i++
+      while (i < argv.length && isEnvAssignment(argv[i])) {
+        const v = checkToken(argv[i])
+        if (v) return v
+        i++
+      }
+      return null
+    }
+    if (isEnvAssignment(t)) {
+      const v = checkToken(t)
+      if (v) return v
+      i++
+      continue
+    }
+    return null
+  }
+  return null
+}
+
+function checkToken(token: string): RuleViolation | null {
+  const m = CI_ASSIGNMENT.exec(token)
+  if (!m) return null
+  if (!TRUTHY.has(m[1])) return null
+  return {
+    rule: 'no-ci-env',
+    message: `Setting \`${token}\` is forbidden in this repository.`,
+    resolution:
+      'Run the command without the CI environment variable. CI behavior should not be triggered locally — see MEMORY (feedback_no_ci_env).',
+  }
+}
+
+export const noCiEnv: Rule = {
+  name: 'no-ci-env',
+  check(command) {
+    for (const cmd of splitCommands(tokenize(command))) {
+      const v = scanCmd(cmd)
+      if (v) return v
+    }
+    return null
+  },
+}

--- a/plugins/totto2727/hooks/script/bash-guard/rules/no-git-c.test.ts
+++ b/plugins/totto2727/hooks/script/bash-guard/rules/no-git-c.test.ts
@@ -1,0 +1,69 @@
+import { noGitC } from './no-git-c.ts'
+
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) throw new Error(msg)
+}
+
+Deno.test('blocks git -C /path status', () => {
+  const r = noGitC.check('git -C /path status')
+  assert(r !== null, 'expected violation')
+  assert(r.rule === 'no-git-c', `wrong rule: ${r.rule}`)
+})
+
+Deno.test('blocks git -C with relative path', () => {
+  assert(noGitC.check('git -C ./sub status') !== null, 'expected violation')
+})
+
+Deno.test('blocks git --no-pager -C /path status (option order swapped)', () => {
+  assert(noGitC.check('git --no-pager -C /path status') !== null, 'expected violation')
+})
+
+Deno.test('blocks git -c user.name=foo -C /path status (after value-taking option)', () => {
+  assert(noGitC.check('git -c user.name=foo -C /path status') !== null, 'expected violation')
+})
+
+Deno.test('blocks git --git-dir /path/.git -C /work status', () => {
+  assert(noGitC.check('git --git-dir /path/.git -C /work status') !== null, 'expected violation')
+})
+
+Deno.test('blocks git -C inside compound command', () => {
+  assert(noGitC.check('echo a && git -C foo status') !== null, 'expected violation')
+})
+
+Deno.test('blocks git -C piped', () => {
+  assert(noGitC.check('git -C foo log | cat') !== null, 'expected violation')
+})
+
+Deno.test('blocks git -C with env prefix', () => {
+  assert(noGitC.check('GIT_PAGER=cat git -C foo status') !== null, 'expected violation')
+})
+
+Deno.test('allows plain git status', () => {
+  assert(noGitC.check('git status') === null, 'unexpected violation')
+})
+
+Deno.test('allows git diff -C (subcommand flag, not global)', () => {
+  assert(noGitC.check('git diff -C HEAD~1') === null, 'unexpected violation')
+})
+
+Deno.test('allows git log --grep -C (subcommand flag)', () => {
+  assert(noGitC.check('git log -C') === null, 'unexpected violation')
+})
+
+Deno.test('allows non-git command containing -C', () => {
+  assert(noGitC.check('grep -C 3 pattern file') === null, 'unexpected violation')
+})
+
+Deno.test('allows git with --no-pager only', () => {
+  assert(noGitC.check('git --no-pager log') === null, 'unexpected violation')
+})
+
+Deno.test('allows cd then git status (cd handled separately)', () => {
+  assert(noGitC.check('cd foo && git status') === null, 'unexpected violation')
+})
+
+Deno.test('resolution mentions cd alternative', () => {
+  const r = noGitC.check('git -C foo status')
+  assert(r !== null, 'expected violation')
+  assert(/cd/.test(r.resolution), 'resolution should mention cd alternative')
+})

--- a/plugins/totto2727/hooks/script/bash-guard/rules/no-git-c.ts
+++ b/plugins/totto2727/hooks/script/bash-guard/rules/no-git-c.ts
@@ -1,0 +1,65 @@
+import { skipEnvPrefix, splitCommands, tokenize } from '../lib/shell.ts'
+import type { Rule, RuleViolation } from './types.ts'
+
+const VALUE_TAKING_SHORT = new Set(['-c'])
+const VALUE_TAKING_LONG = new Set([
+  '--git-dir',
+  '--work-tree',
+  '--exec-path',
+  '--namespace',
+  '--super-prefix',
+  '--config-env',
+  '--list-cmds',
+])
+
+/**
+ * Returns true if `arg` is a git global option that takes a value as the
+ * NEXT token (not via `--key=value` form).
+ */
+function consumesNextValue(arg: string): boolean {
+  if (VALUE_TAKING_SHORT.has(arg)) return true
+  return VALUE_TAKING_LONG.has(arg)
+}
+
+/**
+ * Walks the global-option region of a `git ...` argv (i.e. the tokens between
+ * `git` and the subcommand), returning a violation if `-C` is found.
+ *
+ * Stops at the first non-flag token, which is treated as the subcommand.
+ * `-C <path>` after the subcommand belongs to that subcommand (e.g. `git diff
+ * -C` is a copy-detection flag) and is intentionally not flagged.
+ */
+function scanGitArgv(argv: readonly string[], gitIndex: number): RuleViolation | null {
+  let j = gitIndex + 1
+  while (j < argv.length) {
+    const t = argv[j]
+    if (t === '-C') {
+      return {
+        rule: 'no-git-c',
+        message: '`git -C <dir>` is forbidden in this repository.',
+        resolution:
+          'Run git from the directory it should operate on, or `cd` there first as a separate step. Avoid `-C` so the working tree of the command is unambiguous.',
+      }
+    }
+    if (!t.startsWith('-')) return null
+    if (consumesNextValue(t)) {
+      j += 2
+      continue
+    }
+    j++
+  }
+  return null
+}
+
+export const noGitC: Rule = {
+  name: 'no-git-c',
+  check(command) {
+    for (const cmd of splitCommands(tokenize(command))) {
+      const start = skipEnvPrefix(cmd)
+      if (cmd[start] !== 'git') continue
+      const v = scanGitArgv(cmd, start)
+      if (v) return v
+    }
+    return null
+  },
+}

--- a/plugins/totto2727/hooks/script/bash-guard/rules/no-package-manager-ci.test.ts
+++ b/plugins/totto2727/hooks/script/bash-guard/rules/no-package-manager-ci.test.ts
@@ -1,0 +1,69 @@
+import { noPackageManagerCi } from './no-package-manager-ci.ts'
+
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) throw new Error(msg)
+}
+
+Deno.test('blocks npm ci', () => {
+  const r = noPackageManagerCi.check('npm ci')
+  assert(r !== null, 'expected violation')
+  assert(r.rule === 'no-package-manager-ci', `wrong rule: ${r.rule}`)
+})
+
+Deno.test('blocks pnpm ci', () => {
+  assert(noPackageManagerCi.check('pnpm ci') !== null, 'expected violation')
+})
+
+Deno.test('blocks yarn ci', () => {
+  assert(noPackageManagerCi.check('yarn ci') !== null, 'expected violation')
+})
+
+Deno.test('blocks bun ci', () => {
+  assert(noPackageManagerCi.check('bun ci') !== null, 'expected violation')
+})
+
+Deno.test('blocks vp ci', () => {
+  assert(noPackageManagerCi.check('vp ci') !== null, 'expected violation')
+})
+
+Deno.test('blocks npm ci with extra args', () => {
+  assert(noPackageManagerCi.check('npm ci --legacy-peer-deps') !== null, 'expected violation')
+})
+
+Deno.test('blocks npm ci behind env prefix', () => {
+  assert(noPackageManagerCi.check('FOO=bar npm ci') !== null, 'expected violation')
+})
+
+Deno.test('blocks npm ci behind export prefix', () => {
+  assert(noPackageManagerCi.check('export FOO=1 && npm ci') !== null, 'expected violation')
+})
+
+Deno.test('blocks npm ci in second segment', () => {
+  assert(noPackageManagerCi.check('cd foo && npm ci') !== null, 'expected violation')
+})
+
+Deno.test('blocks npm ci piped', () => {
+  assert(noPackageManagerCi.check('echo a | npm ci') !== null, 'expected violation')
+})
+
+Deno.test('allows npm install', () => {
+  assert(noPackageManagerCi.check('npm install') === null, 'unexpected violation')
+})
+
+Deno.test('allows pnpm install --frozen-lockfile', () => {
+  assert(noPackageManagerCi.check('pnpm install --frozen-lockfile') === null, 'unexpected violation')
+})
+
+Deno.test('allows npm citgen (different word, would not tokenize as ci)', () => {
+  assert(noPackageManagerCi.check('npm citgen') === null, 'unexpected violation')
+})
+
+Deno.test('allows non-package-manager ci command', () => {
+  assert(noPackageManagerCi.check('mycli ci') === null, 'unexpected violation')
+})
+
+Deno.test('resolution mentions install', () => {
+  const r = noPackageManagerCi.check('npm ci')
+  assert(r !== null, 'expected violation')
+  assert(/install/i.test(r.resolution), 'resolution should suggest install')
+})

--- a/plugins/totto2727/hooks/script/bash-guard/rules/no-package-manager-ci.ts
+++ b/plugins/totto2727/hooks/script/bash-guard/rules/no-package-manager-ci.ts
@@ -1,0 +1,33 @@
+import { skipEnvPrefix, splitCommands, tokenize } from '../lib/shell.ts'
+import type { Rule, RuleViolation } from './types.ts'
+
+const PACKAGE_MANAGERS = new Set(['npm', 'pnpm', 'yarn', 'bun', 'vp'])
+
+const RESOLUTION: Record<string, string> = {
+  npm: 'Use `npm install` instead. `npm ci` removes node_modules and reinstalls from the lockfile — appropriate only for CI runners.',
+  pnpm:
+    'Use `pnpm install` (or `pnpm install --frozen-lockfile` if you need a CI-style lockfile check) instead.',
+  yarn: 'Use `yarn install` (Yarn does not have a `ci` subcommand).',
+  bun: 'Use `bun install --frozen-lockfile` if you need a lockfile-strict install (Bun does not have a `ci` subcommand).',
+  vp: 'Use `vp install` (or whichever non-`ci` workflow your task needs). `vp ci` is reserved for CI environments.',
+}
+
+export const noPackageManagerCi: Rule = {
+  name: 'no-package-manager-ci',
+  check(command) {
+    for (const cmd of splitCommands(tokenize(command))) {
+      const start = skipEnvPrefix(cmd)
+      const exec = cmd[start]
+      const sub = cmd[start + 1]
+      if (exec === undefined || sub !== 'ci') continue
+      if (!PACKAGE_MANAGERS.has(exec)) continue
+      const violation: RuleViolation = {
+        rule: 'no-package-manager-ci',
+        message: `\`${exec} ci\` is forbidden. CI-style installs should only run inside the CI pipeline.`,
+        resolution: RESOLUTION[exec] ?? 'Use the package manager\'s regular install command.',
+      }
+      return violation
+    }
+    return null
+  },
+}

--- a/plugins/totto2727/hooks/script/bash-guard/rules/types.ts
+++ b/plugins/totto2727/hooks/script/bash-guard/rules/types.ts
@@ -1,0 +1,24 @@
+/**
+ * A single violation produced by a rule.
+ *
+ * - `rule` identifies the rule that fired.
+ * - `message` is shown verbatim to the user/Claude when blocking.
+ * - `resolution` describes how to comply with the rule.
+ */
+export type RuleViolation = {
+  readonly rule: string
+  readonly message: string
+  readonly resolution: string
+}
+
+/**
+ * A bash-command rule. Each rule inspects the raw command string and returns
+ * a violation when it should be blocked, or `null` otherwise.
+ *
+ * Rules are independent: they own their own parsing strategy (regex, shell
+ * tokenization, flag walking) and do not rely on each other.
+ */
+export type Rule = {
+  readonly name: string
+  readonly check: (command: string) => RuleViolation | null
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     experimentalSortPackageJson: true,
     extends: [core, react, remix],
+    ignorePatterns: ['**/__fixtures__/**', '**/.script/**', '**/skills/**', '**/hooks/script/**'],
     jsxSingleQuote: true,
     printWidth: 120,
     quoteProps: 'as-needed',
@@ -27,7 +28,7 @@ export default defineConfig({
   },
   lint: {
     extends: [core, react, remix],
-    ignorePatterns: ['**/__fixtures__/**', '**/.script/**', '**/skills/**'],
+    ignorePatterns: ['**/__fixtures__/**', '**/.script/**', '**/skills/**', '**/hooks/script/**'],
     jsPlugins: ['./js/package/oxlint-plugin/src/index.ts'],
     options: {
       typeAware: true,


### PR DESCRIPTION
## Summary

- New `PreToolUse(Bash)` hook in `plugins/totto2727` that blocks forbidden commands at hook time, implemented as a zero-dependency Deno script under `plugins/totto2727/hooks/script/bash-guard/`.
- Initial rules: **no-ci-env** (`CI=true` etc.), **no-package-manager-ci** (`npm/pnpm/yarn/bun/vp ci`), **no-git-c** (`git -C` regardless of option order).
- ADR `doc/adr/2026-04-25-bash-command-guard-hook.md` records the design (runtime choice, plugin layout, rule contract, hook I/O). Marked `confirmed: false` pending review.

## Layout

```
plugins/totto2727/hooks/
├── hooks.json                       # PreToolUse(Bash) registration
└── script/
    └── bash-guard/                  # one directory per hook
        ├── deno.json
        ├── main.ts                  # stdin JSON → rules → permissionDecision
        ├── lib/{shell,shell.test}.ts
        └── rules/
            ├── types.ts / index.ts
            ├── no-ci-env.{ts,test.ts}
            ├── no-package-manager-ci.{ts,test.ts}
            └── no-git-c.{ts,test.ts}
```

Each rule is a `(command: string) => RuleViolation | null` function. Violations are aggregated and surfaced together via `permissionDecision: deny`.

## Toolchain

- Verified with `deno lint` / `deno check` / `deno test` (58/58 passing).
- `vite.config.ts` ignore patterns extended (`**/hooks/script/**`) for both `lint` and `fmt`, so `vp check` skips Deno sources.

## Test plan

- [x] `deno lint` clean (11 files)
- [x] `deno check` clean (10 files)
- [x] `deno test`: 58 passed / 0 failed
- [x] `vp check`: 230 fmt + 112 lint pass, hook scripts excluded
- [x] E2E: `CI=true npm test`, `git -C /foo status`, `pnpm ci`, and combined cases all return `permissionDecision: deny` with appropriate `Resolution:` text; `npm install` passes through.
- [ ] Manual sanity-check by reloading the plugin in Claude Code and triggering one denied command end-to-end.