### PR TITLE
fix(mbt/geo): migrate derive(Show) → derive(Debug) per MoonBit deprecation

### DIFF
--- a/mbt/package/geo/src/geojson/bbox.mbt
+++ b/mbt/package/geo/src/geojson/bbox.mbt
@@ -7,7 +7,7 @@ pub(open) trait BBoxTrait {
 pub(all) enum BBox {
   BBox2D(Double, Double, Double, Double)
   BBox3D(Double, Double, Double, Double, Double, Double)
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub impl ToJson for BBox with to_json(self) {

--- a/mbt/package/geo/src/geojson/bbox.mbt.md
+++ b/mbt/package/geo/src/geojson/bbox.mbt.md
@@ -23,7 +23,7 @@
 ///|
 test "BBox new_2d - non sorting" {
   let bbox = BBox::new_2d(10.0, 20.0, 0.0, 5.0)
-  inspect(bbox, content="BBox2D(0, 5, 10, 20)")
+  debug_inspect(bbox, content="BBox2D(0, 5, 10, 20)")
 }
 ```
 
@@ -33,7 +33,7 @@ test "BBox new_2d - non sorting" {
 ///|
 test "BBox new_2d - sorting" {
   let bbox = BBox::new_2d(0.0, 5.0, 10.0, 20.0)
-  inspect(bbox, content="BBox2D(0, 5, 10, 20)")
+  debug_inspect(bbox, content="BBox2D(0, 5, 10, 20)")
 }
 ```
 
@@ -45,7 +45,7 @@ test "BBox new_2d - sorting" {
 ///|
 test "BBox new_3d - sorting" {
   let bbox = BBox::new_3d(10.0, 20.0, 30.0, 0.0, 5.0, 10.0)
-  inspect(bbox, content="BBox3D(0, 5, 10, 10, 20, 30)")
+  debug_inspect(bbox, content="BBox3D(0, 5, 10, 10, 20, 30)")
 }
 ```
 
@@ -55,7 +55,7 @@ test "BBox new_3d - sorting" {
 ///|
 test "BBox new_3d - non sorting" {
   let bbox = BBox::new_3d(0.0, 5.0, 10.0, 20.0, 30.0, 10.0)
-  inspect(bbox, content="BBox3D(0, 5, 10, 20, 30, 10)")
+  debug_inspect(bbox, content="BBox3D(0, 5, 10, 20, 30, 10)")
 }
 ```
 
@@ -71,7 +71,7 @@ test "BBox from_coordinate_array - 2d" {
     Coordinates::XY(10.0, 10.0),
     Coordinates::XY(5.0, 5.0),
   ]
-  inspect(coords, content="[XY(0, 0), XY(10, 10), XY(5, 5)]")
+  debug_inspect(coords, content="[XY(0, 0), XY(10, 10), XY(5, 5)]")
 }
 ```
 
@@ -85,7 +85,7 @@ test "BBox from_coordinate_array - 3d" {
     Coordinates::XYZ_OR_XYM(10.0, 10.0, 10.0),
     Coordinates::XYZ_OR_XYM(5.0, 5.0, 5.0),
   ]
-  inspect(
+  debug_inspect(
     coords,
     content="[XYZ_OR_XYM(0, 0, 0), XYZ_OR_XYM(10, 10, 10), XYZ_OR_XYM(5, 5, 5)]",
   )
@@ -144,7 +144,7 @@ test "BBox ToJson::to_json - bbox3d" {
 ///|
 test "BBox FromJson::from_json - bbox2d" {
   let bbox : BBox = @json.from_json([0.0, 1.0, 2.0, 3.0])
-  inspect(bbox, content="BBox2D(0, 1, 2, 3)")
+  debug_inspect(bbox, content="BBox2D(0, 1, 2, 3)")
 }
 ```
 
@@ -154,7 +154,7 @@ test "BBox FromJson::from_json - bbox2d" {
 ///|
 test "BBox FromJson::from_json - bbox3d" {
   let bbox : BBox = @json.from_json([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
-  inspect(bbox, content="BBox3D(0, 1, 2, 3, 4, 5)")
+  debug_inspect(bbox, content="BBox3D(0, 1, 2, 3, 4, 5)")
 }
 ```
 

--- a/mbt/package/geo/src/geojson/coordinates.mbt
+++ b/mbt/package/geo/src/geojson/coordinates.mbt
@@ -3,7 +3,7 @@ pub(all) enum Coordinates {
   XY(Double, Double)
   XYZ_OR_XYM(Double, Double, Double)
   XYZM(Double, Double, Double, Double)
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub impl ToJson for Coordinates with to_json(self) {

--- a/mbt/package/geo/src/geojson/coordinates.mbt.md
+++ b/mbt/package/geo/src/geojson/coordinates.mbt.md
@@ -20,7 +20,7 @@
 ///|
 test "Coordinates x" {
   let coord = Coordinates::XY(1, 2)
-  inspect(coord.x(), content="1")
+  debug_inspect(coord.x(), content="1")
 }
 ```
 
@@ -30,7 +30,7 @@ test "Coordinates x" {
 ///|
 test "Coordinates y" {
   let coord = Coordinates::XY(1, 2)
-  inspect(coord.y(), content="2")
+  debug_inspect(coord.y(), content="2")
 }
 ```
 
@@ -42,7 +42,7 @@ test "Coordinates y" {
 ///|
 test "Coordinates z - non panic" {
   let coord = Coordinates::XYZ_OR_XYM(1, 2, 3)
-  inspect(coord.z(), content="3")
+  debug_inspect(coord.z(), content="3")
 }
 ```
 
@@ -61,9 +61,9 @@ test "panic_Coordinates z - on XY" {
 ```mbt check
 ///|
 test "Coordinates dimension" {
-  inspect(Coordinates::XY(1.0, 2.0).dimension(), content="2")
-  inspect(Coordinates::XYZ_OR_XYM(1.0, 2.0, 3.0).dimension(), content="3")
-  inspect(Coordinates::XYZM(1.0, 2.0, 3.0, 4.0).dimension(), content="4")
+  debug_inspect(Coordinates::XY(1.0, 2.0).dimension(), content="2")
+  debug_inspect(Coordinates::XYZ_OR_XYM(1.0, 2.0, 3.0).dimension(), content="3")
+  debug_inspect(Coordinates::XYZM(1.0, 2.0, 3.0, 4.0).dimension(), content="4")
 }
 ```
 
@@ -104,7 +104,7 @@ test "Coordinates ToJson::to_json - XYZM" {
 ///|
 test "Coordinates FromJson::from_json - XY" {
   let coordinates : Coordinates = @json.from_json([1.0, 2.0])
-  inspect(coordinates, content="XY(1, 2)")
+  debug_inspect(coordinates, content="XY(1, 2)")
 }
 ```
 
@@ -114,7 +114,7 @@ test "Coordinates FromJson::from_json - XY" {
 ///|
 test "Coordinates FromJson::from_json - XYZ_OR_XYM" {
   let coordinates : Coordinates = @json.from_json([1.0, 2.0, 3.0])
-  inspect(coordinates, content="XYZ_OR_XYM(1, 2, 3)")
+  debug_inspect(coordinates, content="XYZ_OR_XYM(1, 2, 3)")
 }
 ```
 
@@ -124,7 +124,7 @@ test "Coordinates FromJson::from_json - XYZ_OR_XYM" {
 ///|
 test "Coordinates FromJson::from_json - XYZM" {
   let coordinates : Coordinates = @json.from_json([1.0, 2.0, 3.0, 4.0])
-  inspect(coordinates, content="XYZM(1, 2, 3, 4)")
+  debug_inspect(coordinates, content="XYZM(1, 2, 3, 4)")
 }
 ```
 

--- a/mbt/package/geo/src/geojson/feature.mbt
+++ b/mbt/package/geo/src/geojson/feature.mbt
@@ -3,7 +3,7 @@ pub struct Feature {
   geometry : Geometry?
   properties : Map[String, Json]?
   id : ID?
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn Feature::new(

--- a/mbt/package/geo/src/geojson/feature.mbt.md
+++ b/mbt/package/geo/src/geojson/feature.mbt.md
@@ -23,9 +23,15 @@ test "Feature new" {
   let feature = Feature::new(
     geometry=Some(Geometry::Point(Point::new(Coordinates::XY(1.0, 2.0)))),
   )
-  inspect(
+  debug_inspect(
     feature,
-    content="{geometry: Some(Point({coordinates: XY(1, 2)})), properties: None, id: None}",
+    content=(
+      #|{
+      #|  geometry: Some(Point({ coordinates: XY(1, 2) })),
+      #|  properties: None,
+      #|  id: None,
+      #|}
+    ),
   )
 }
 ```
@@ -40,7 +46,7 @@ test "Feature BBoxTrait::bbox" {
   let feature = Feature::new(
     geometry=Some(Geometry::Point(Point::new(Coordinates::XY(1.0, 2.0)))),
   )
-  inspect(feature.bbox(), content="BBox2D(1, 2, 1, 2)")
+  debug_inspect(feature.bbox(), content="BBox2D(1, 2, 1, 2)")
 }
 ```
 
@@ -102,10 +108,15 @@ test "Feature FromJson::from_json - With Geometry and Properties" {
     "geometry": { "type": "Point", "coordinates": [1.0, 2.0] },
     "properties": { "name": "test" },
   })
-  inspect(
+  debug_inspect(
     feature,
     content=(
-      #|{geometry: Some(Point({coordinates: XY(1, 2)})), properties: Some({"name": String("test")}), id: None}
+      #|{
+      #|  geometry: Some(Point({ coordinates: XY(1, 2) })),
+      #|  properties: Some({ "name": String("test") }),
+      #|  id: None,
+      #|}
+
     ),
   )
 }
@@ -121,7 +132,9 @@ test "Feature FromJson::from_json - Without Geometry and Properties" {
     "geometry": null,
     "properties": null,
   })
-  inspect(feature, content="{geometry: None, properties: None, id: None}")
+  debug_inspect(feature, content=(
+    #|{ geometry: None, properties: None, id: None }
+  ))
 }
 ```
 
@@ -136,9 +149,11 @@ test "Feature FromJson::from_json - With ID" {
     "properties": null,
     "id": "abc",
   })
-  inspect(
+  debug_inspect(
     feature,
-    content="{geometry: None, properties: None, id: Some(String(\"abc\"))}",
+    content=(
+      #|{ geometry: None, properties: None, id: Some(String("abc")) }
+    ),
   )
 }
 ```

--- a/mbt/package/geo/src/geojson/feature_collection.mbt
+++ b/mbt/package/geo/src/geojson/feature_collection.mbt
@@ -1,7 +1,7 @@
 ///|
 pub struct FeatureCollection {
   features : Array[Feature]
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn FeatureCollection::new(features : Array[Feature]) -> FeatureCollection {

--- a/mbt/package/geo/src/geojson/feature_collection.mbt.md
+++ b/mbt/package/geo/src/geojson/feature_collection.mbt.md
@@ -21,7 +21,9 @@
 ///|
 test "FeatureCollection new" {
   let fc = FeatureCollection::new([])
-  inspect(fc, content="{features: []}")
+  debug_inspect(fc, content=(
+    #|{ features: [] }
+  ))
 }
 ```
 
@@ -40,7 +42,7 @@ test "FeatureCollection BBoxTrait::bbox" {
       geometry=Some(Geometry::Point(Point::new(Coordinates::XY(10.0, 10.0)))),
     ),
   ])
-  inspect(fc.bbox(), content="BBox2D(0, 0, 10, 10)")
+  debug_inspect(fc.bbox(), content="BBox2D(0, 0, 10, 10)")
 }
 ```
 
@@ -93,9 +95,11 @@ test "FeatureCollection FromJson::from_json - With Features" {
     "type": "FeatureCollection",
     "features": [{ "type": "Feature", "geometry": null, "properties": null }],
   })
-  inspect(
+  debug_inspect(
     fc,
-    content="{features: [{geometry: None, properties: None, id: None}]}",
+    content=(
+      #|{ features: [{ geometry: None, properties: None, id: None }] }
+    ),
   )
 }
 ```
@@ -109,6 +113,8 @@ test "FeatureCollection FromJson::from_json - Empty" {
     "type": "FeatureCollection",
     "features": [],
   })
-  inspect(fc, content="{features: []}")
+  debug_inspect(fc, content=(
+    #|{ features: [] }
+  ))
 }
 ```

--- a/mbt/package/geo/src/geojson/geojson.mbt
+++ b/mbt/package/geo/src/geojson/geojson.mbt
@@ -13,7 +13,7 @@ pub(all) enum GeoJSON {
   FeatureCollection(FeatureCollection)
   Feature(Feature)
   Geometry(Geometry)
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub(open) trait GeoJSONTrait: FromJson + ToJson {

--- a/mbt/package/geo/src/geojson/geojson.mbt.md
+++ b/mbt/package/geo/src/geojson/geojson.mbt.md
@@ -31,7 +31,7 @@ test "GeoJSON BBoxTrait::bbox" {
     "type": "Point",
     "coordinates": [1.0, 2.0],
   })
-  inspect(geojson.bbox(), content="BBox2D(1, 2, 1, 2)")
+  debug_inspect(geojson.bbox(), content="BBox2D(1, 2, 1, 2)")
 }
 ```
 
@@ -152,7 +152,9 @@ test "GeoJSON FromJson::from_json - FeatureCollection" {
     "type": "FeatureCollection",
     "features": [],
   })
-  inspect(geojson, content="FeatureCollection({features: []})")
+  debug_inspect(geojson, content=(
+    #|FeatureCollection({ features: [] })
+  ))
 }
 ```
 
@@ -166,9 +168,11 @@ test "GeoJSON FromJson::from_json - Feature" {
     "geometry": null,
     "properties": null,
   })
-  inspect(
+  debug_inspect(
     geojson,
-    content="Feature({geometry: None, properties: None, id: None})",
+    content=(
+      #|Feature({ geometry: None, properties: None, id: None })
+    ),
   )
 }
 ```
@@ -182,7 +186,9 @@ test "GeoJSON FromJson::from_json - Geometry" {
     "type": "Point",
     "coordinates": [1.0, 2.0],
   })
-  inspect(geojson, content="Geometry(Point({coordinates: XY(1, 2)}))")
+  debug_inspect(geojson, content=(
+    #|Geometry(Point({ coordinates: XY(1, 2) }))
+  ))
 }
 ```
 

--- a/mbt/package/geo/src/geojson/geojson_type.mbt
+++ b/mbt/package/geo/src/geojson/geojson_type.mbt
@@ -3,7 +3,7 @@ pub(all) enum GeoJSONType {
   FeatureCollection
   Feature
   Geometry(GeometryType)
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn GeoJSONType::from_raw_geojson(

--- a/mbt/package/geo/src/geojson/geojson_type.mbt.md
+++ b/mbt/package/geo/src/geojson/geojson_type.mbt.md
@@ -52,7 +52,7 @@ test "GeoJSONType ToJson::to_json - Geometry" {
 ///|
 test "GeoJSONType FromJson::from_json - Feature" {
   let t : GeoJSONType = @json.from_json("Feature")
-  inspect(t, content="Feature")
+  debug_inspect(t, content="Feature")
 }
 ```
 
@@ -62,7 +62,7 @@ test "GeoJSONType FromJson::from_json - Feature" {
 ///|
 test "GeoJSONType FromJson::from_json - FeatureCollection" {
   let t : GeoJSONType = @json.from_json("FeatureCollection")
-  inspect(t, content="FeatureCollection")
+  debug_inspect(t, content="FeatureCollection")
 }
 ```
 
@@ -72,6 +72,6 @@ test "GeoJSONType FromJson::from_json - FeatureCollection" {
 ///|
 test "GeoJSONType FromJson::from_json - Geometry" {
   let t : GeoJSONType = @json.from_json("Point")
-  inspect(t, content="Geometry(Point)")
+  debug_inspect(t, content="Geometry(Point)")
 }
 ```

--- a/mbt/package/geo/src/geojson/geometry.mbt
+++ b/mbt/package/geo/src/geojson/geometry.mbt
@@ -7,7 +7,7 @@ pub(all) enum Geometry {
   MultiLineString(MultiLineString)
   MultiPolygon(MultiPolygon)
   GeometryCollection(GeometryCollection)
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub impl GeoJSONTrait for Geometry with to_json(self, with_bbox? = false) {

--- a/mbt/package/geo/src/geojson/geometry.mbt.md
+++ b/mbt/package/geo/src/geojson/geometry.mbt.md
@@ -25,7 +25,7 @@ test "Geometry BBoxTrait::bbox" {
     "type": "Point",
     "coordinates": [1.0, 2.0],
   })
-  inspect(geom.bbox(), content="BBox2D(1, 2, 1, 2)")
+  debug_inspect(geom.bbox(), content="BBox2D(1, 2, 1, 2)")
 }
 ```
 
@@ -297,7 +297,9 @@ test "Geometry FromJson::from_json - Point" {
     "type": "Point",
     "coordinates": [1.0, 2.0],
   })
-  inspect(geom, content="Point({coordinates: XY(1, 2)})")
+  debug_inspect(geom, content=(
+    #|Point({ coordinates: XY(1, 2) })
+  ))
 }
 ```
 
@@ -310,7 +312,9 @@ test "Geometry FromJson::from_json - LineString" {
     "type": "LineString",
     "coordinates": [[0.0, 0.0], [1.0, 1.0]],
   })
-  inspect(geom, content="LineString({coordinates: [XY(0, 0), XY(1, 1)]})")
+  debug_inspect(geom, content=(
+    #|LineString({ coordinates: [XY(0, 0), XY(1, 1)] })
+  ))
 }
 ```
 
@@ -325,9 +329,11 @@ test "Geometry FromJson::from_json - Polygon" {
   })
   match geom {
     Polygon(p) =>
-      inspect(
+      debug_inspect(
         p,
-        content="{coordinates: [[XY(0, 0), XY(1, 0), XY(1, 1), XY(0, 0)]]}",
+        content=(
+          #|{ coordinates: [[XY(0, 0), XY(1, 0), XY(1, 1), XY(0, 0)]] }
+        ),
       )
     _ => fail("Expected Polygon")
   }
@@ -343,7 +349,9 @@ test "Geometry FromJson::from_json - MultiPoint" {
     "type": "MultiPoint",
     "coordinates": [[0.0, 0.0], [1.0, 1.0]],
   })
-  inspect(geom, content="MultiPoint({coordinates: [XY(0, 0), XY(1, 1)]})")
+  debug_inspect(geom, content=(
+    #|MultiPoint({ coordinates: [XY(0, 0), XY(1, 1)] })
+  ))
 }
 ```
 
@@ -356,9 +364,11 @@ test "Geometry FromJson::from_json - MultiLineString" {
     "type": "MultiLineString",
     "coordinates": [[[0.0, 0.0], [1.0, 1.0]]],
   })
-  inspect(
+  debug_inspect(
     geom,
-    content="MultiLineString({coordinates: [[XY(0, 0), XY(1, 1)]]})",
+    content=(
+      #|MultiLineString({ coordinates: [[XY(0, 0), XY(1, 1)]] })
+    ),
   )
 }
 ```
@@ -372,9 +382,11 @@ test "Geometry FromJson::from_json - MultiPolygon" {
     "type": "MultiPolygon",
     "coordinates": [[[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]]],
   })
-  inspect(
+  debug_inspect(
     geom,
-    content="MultiPolygon({coordinates: [[[XY(0, 0), XY(1, 0), XY(1, 1), XY(0, 0)]]]})",
+    content=(
+      #|MultiPolygon({ coordinates: [[[XY(0, 0), XY(1, 0), XY(1, 1), XY(0, 0)]]] })
+    ),
   )
 }
 ```
@@ -388,9 +400,11 @@ test "Geometry FromJson::from_json - GeometryCollection" {
     "type": "GeometryCollection",
     "geometries": [{ "type": "Point", "coordinates": [0.0, 0.0] }],
   })
-  inspect(
+  debug_inspect(
     geom,
-    content="GeometryCollection({geometries: [Point({coordinates: XY(0, 0)})]})",
+    content=(
+      #|GeometryCollection({ geometries: [Point({ coordinates: XY(0, 0) })] })
+    ),
   )
 }
 ```

--- a/mbt/package/geo/src/geojson/geometry_collection.mbt
+++ b/mbt/package/geo/src/geojson/geometry_collection.mbt
@@ -1,7 +1,7 @@
 ///|
 pub struct GeometryCollection {
   geometries : Array[Geometry]
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn GeometryCollection::new(

--- a/mbt/package/geo/src/geojson/geometry_collection.mbt.md
+++ b/mbt/package/geo/src/geojson/geometry_collection.mbt.md
@@ -21,7 +21,9 @@
 ///|
 test "GeometryCollection new" {
   let gc = GeometryCollection::new([])
-  inspect(gc, content="{geometries: []}")
+  debug_inspect(gc, content=(
+    #|{ geometries: [] }
+  ))
 }
 ```
 
@@ -36,7 +38,7 @@ test "GeometryCollection BBoxTrait::bbox" {
     Geometry::Point(Point::new(Coordinates::XY(0.0, 0.0))),
     Geometry::Point(Point::new(Coordinates::XY(10.0, 10.0))),
   ])
-  inspect(gc.bbox(), content="BBox2D(0, 0, 10, 10)")
+  debug_inspect(gc.bbox(), content="BBox2D(0, 0, 10, 10)")
 }
 ```
 
@@ -89,7 +91,9 @@ test "GeometryCollection FromJson::from_json - Valid" {
     "type": "GeometryCollection",
     "geometries": [{ "type": "Point", "coordinates": [0.0, 0.0] }],
   })
-  inspect(gc, content="{geometries: [Point({coordinates: XY(0, 0)})]}")
+  debug_inspect(gc, content=(
+    #|{ geometries: [Point({ coordinates: XY(0, 0) })] }
+  ))
 }
 ```
 
@@ -102,6 +106,8 @@ test "GeometryCollection FromJson::from_json - Empty" {
     "type": "GeometryCollection",
     "geometries": [],
   })
-  inspect(gc, content="{geometries: []}")
+  debug_inspect(gc, content=(
+    #|{ geometries: [] }
+  ))
 }
 ```

--- a/mbt/package/geo/src/geojson/geometry_type.mbt
+++ b/mbt/package/geo/src/geojson/geometry_type.mbt
@@ -7,7 +7,7 @@ pub(all) enum GeometryType {
   MultiLineString
   MultiPolygon
   GeometryCollection
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn GeometryType::from_raw_geojson(

--- a/mbt/package/geo/src/geojson/geometry_type.mbt.md
+++ b/mbt/package/geo/src/geojson/geometry_type.mbt.md
@@ -84,7 +84,7 @@ test "GeometryType ToJson::to_json - geometry collection" {
 ///|
 test "GeometryType FromJson::from_json - point" {
   let t : GeometryType = @json.from_json("Point")
-  inspect(t, content="Point")
+  debug_inspect(t, content="Point")
 }
 ```
 
@@ -94,7 +94,7 @@ test "GeometryType FromJson::from_json - point" {
 ///|
 test "GeometryType FromJson::from_json - line string" {
   let t : GeometryType = @json.from_json("LineString")
-  inspect(t, content="LineString")
+  debug_inspect(t, content="LineString")
 }
 ```
 
@@ -104,7 +104,7 @@ test "GeometryType FromJson::from_json - line string" {
 ///|
 test "GeometryType FromJson::from_json - polygon" {
   let t : GeometryType = @json.from_json("Polygon")
-  inspect(t, content="Polygon")
+  debug_inspect(t, content="Polygon")
 }
 ```
 
@@ -114,7 +114,7 @@ test "GeometryType FromJson::from_json - polygon" {
 ///|
 test "GeometryType FromJson::from_json - multi point" {
   let t : GeometryType = @json.from_json("MultiPoint")
-  inspect(t, content="MultiPoint")
+  debug_inspect(t, content="MultiPoint")
 }
 ```
 
@@ -124,7 +124,7 @@ test "GeometryType FromJson::from_json - multi point" {
 ///|
 test "GeometryType FromJson::from_json - multi line string" {
   let t : GeometryType = @json.from_json("MultiLineString")
-  inspect(t, content="MultiLineString")
+  debug_inspect(t, content="MultiLineString")
 }
 ```
 
@@ -134,7 +134,7 @@ test "GeometryType FromJson::from_json - multi line string" {
 ///|
 test "GeometryType FromJson::from_json - multi polygon" {
   let t : GeometryType = @json.from_json("MultiPolygon")
-  inspect(t, content="MultiPolygon")
+  debug_inspect(t, content="MultiPolygon")
 }
 ```
 
@@ -144,7 +144,7 @@ test "GeometryType FromJson::from_json - multi polygon" {
 ///|
 test "GeometryType FromJson::from_json - geometry collection" {
   let t : GeometryType = @json.from_json("GeometryCollection")
-  inspect(t, content="GeometryCollection")
+  debug_inspect(t, content="GeometryCollection")
 }
 ```
 

--- a/mbt/package/geo/src/geojson/id.mbt
+++ b/mbt/package/geo/src/geojson/id.mbt
@@ -2,7 +2,7 @@
 pub(all) enum ID {
   String(String)
   Number(Double)
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub impl ToJson for ID with to_json(self) {

--- a/mbt/package/geo/src/geojson/id.mbt.md
+++ b/mbt/package/geo/src/geojson/id.mbt.md
@@ -38,7 +38,7 @@ test "ID ToJson::to_json - number" {
 ///|
 test "ID FromJson::from_json - string" {
   let id : ID = @json.from_json("test")
-  inspect(id, content="String(\"test\")")
+  debug_inspect(id, content="String(\"test\")")
 }
 ```
 
@@ -48,7 +48,7 @@ test "ID FromJson::from_json - string" {
 ///|
 test "ID FromJson::from_json - number" {
   let id : ID = @json.from_json(123.0)
-  inspect(id, content="Number(123)")
+  debug_inspect(id, content="Number(123)")
 }
 ```
 

--- a/mbt/package/geo/src/geojson/line_string.mbt
+++ b/mbt/package/geo/src/geojson/line_string.mbt
@@ -1,7 +1,7 @@
 ///|
 pub struct LineString {
   coordinates : Array[Coordinates]
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn LineString::new(

--- a/mbt/package/geo/src/geojson/line_string.mbt.md
+++ b/mbt/package/geo/src/geojson/line_string.mbt.md
@@ -24,7 +24,9 @@ test "LineString new" {
     Coordinates::XY(0.0, 0.0),
     Coordinates::XY(1.0, 1.0),
   ])
-  inspect(ls, content="{coordinates: [XY(0, 0), XY(1, 1)]}")
+  debug_inspect(ls, content=(
+    #|{ coordinates: [XY(0, 0), XY(1, 1)] }
+  ))
 }
 ```
 
@@ -39,7 +41,7 @@ test "LineString BBoxTrait::bbox" {
     Coordinates::XY(0.0, 0.0),
     Coordinates::XY(1.0, 1.0),
   ])
-  inspect(ls.bbox(), content="BBox2D(0, 0, 1, 1)")
+  debug_inspect(ls.bbox(), content="BBox2D(0, 0, 1, 1)")
 }
 ```
 
@@ -90,7 +92,9 @@ test "LineString FromJson::from_json - valid" {
     "type": "LineString",
     "coordinates": [[0.0, 0.0], [1.0, 1.0]],
   })
-  inspect(ls, content="{coordinates: [XY(0, 0), XY(1, 1)]}")
+  debug_inspect(ls, content=(
+    #|{ coordinates: [XY(0, 0), XY(1, 1)] }
+  ))
 }
 ```
 

--- a/mbt/package/geo/src/geojson/multi_line_string.mbt
+++ b/mbt/package/geo/src/geojson/multi_line_string.mbt
@@ -1,7 +1,7 @@
 ///|
 pub struct MultiLineString {
   coordinates : Array[Array[Coordinates]]
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn MultiLineString::new(

--- a/mbt/package/geo/src/geojson/multi_line_string.mbt.md
+++ b/mbt/package/geo/src/geojson/multi_line_string.mbt.md
@@ -23,7 +23,9 @@ test "MultiLineString new" {
   let mls = MultiLineString::new([
     [Coordinates::XY(0.0, 0.0), Coordinates::XY(1.0, 1.0)],
   ])
-  inspect(mls, content="{coordinates: [[XY(0, 0), XY(1, 1)]]}")
+  debug_inspect(mls, content=(
+    #|{ coordinates: [[XY(0, 0), XY(1, 1)]] }
+  ))
 }
 ```
 
@@ -37,7 +39,7 @@ test "MultiLineString BBoxTrait::bbox" {
   let mls = MultiLineString::new([
     [Coordinates::XY(0.0, 0.0), Coordinates::XY(1.0, 1.0)],
   ])
-  inspect(mls.bbox(), content="BBox2D(0, 0, 1, 1)")
+  debug_inspect(mls.bbox(), content="BBox2D(0, 0, 1, 1)")
 }
 ```
 
@@ -88,7 +90,9 @@ test "MultiLineString FromJson::from_json - valid" {
     "type": "MultiLineString",
     "coordinates": [[[0.0, 0.0], [1.0, 1.0]]],
   })
-  inspect(mls, content="{coordinates: [[XY(0, 0), XY(1, 1)]]}")
+  debug_inspect(mls, content=(
+    #|{ coordinates: [[XY(0, 0), XY(1, 1)]] }
+  ))
 }
 ```
 
@@ -101,6 +105,8 @@ test "MultiLineString FromJson::from_json - empty" {
     "type": "MultiLineString",
     "coordinates": [],
   })
-  inspect(mls, content="{coordinates: []}")
+  debug_inspect(mls, content=(
+    #|{ coordinates: [] }
+  ))
 }
 ```

--- a/mbt/package/geo/src/geojson/multi_point.mbt
+++ b/mbt/package/geo/src/geojson/multi_point.mbt
@@ -1,7 +1,7 @@
 ///|
 pub struct MultiPoint {
   coordinates : Array[Coordinates]
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn MultiPoint::new(coordinates : Array[Coordinates]) -> MultiPoint {

--- a/mbt/package/geo/src/geojson/multi_point.mbt.md
+++ b/mbt/package/geo/src/geojson/multi_point.mbt.md
@@ -24,7 +24,9 @@ test "MultiPoint new" {
     Coordinates::XY(0.0, 0.0),
     Coordinates::XY(1.0, 1.0),
   ])
-  inspect(mp, content="{coordinates: [XY(0, 0), XY(1, 1)]}")
+  debug_inspect(mp, content=(
+    #|{ coordinates: [XY(0, 0), XY(1, 1)] }
+  ))
 }
 ```
 
@@ -39,7 +41,7 @@ test "MultiPoint BBoxTrait::bbox" {
     Coordinates::XY(0.0, 0.0),
     Coordinates::XY(1.0, 1.0),
   ])
-  inspect(mp.bbox(), content="BBox2D(0, 0, 1, 1)")
+  debug_inspect(mp.bbox(), content="BBox2D(0, 0, 1, 1)")
 }
 ```
 
@@ -90,7 +92,9 @@ test "MultiPoint FromJson::from_json - valid" {
     "type": "MultiPoint",
     "coordinates": [[0.0, 0.0]],
   })
-  inspect(mp, content="{coordinates: [XY(0, 0)]}")
+  debug_inspect(mp, content=(
+    #|{ coordinates: [XY(0, 0)] }
+  ))
 }
 ```
 
@@ -103,6 +107,8 @@ test "MultiPoint FromJson::from_json - empty" {
     "type": "MultiPoint",
     "coordinates": [],
   })
-  inspect(mp, content="{coordinates: []}")
+  debug_inspect(mp, content=(
+    #|{ coordinates: [] }
+  ))
 }
 ```

--- a/mbt/package/geo/src/geojson/multi_polygon.mbt
+++ b/mbt/package/geo/src/geojson/multi_polygon.mbt
@@ -1,7 +1,7 @@
 ///|
 pub struct MultiPolygon {
   coordinates : Array[Array[Array[Coordinates]]]
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn MultiPolygon::new(

--- a/mbt/package/geo/src/geojson/multi_polygon.mbt.md
+++ b/mbt/package/geo/src/geojson/multi_polygon.mbt.md
@@ -29,7 +29,9 @@ test "MultiPolygon new" {
       ],
     ],
   ])
-  inspect(mp, content="{coordinates: [[[XY(0, 0), XY(1, 1), XY(0, 0)]]]}")
+  debug_inspect(mp, content=(
+    #|{ coordinates: [[[XY(0, 0), XY(1, 1), XY(0, 0)]]] }
+  ))
 }
 ```
 
@@ -49,7 +51,7 @@ test "MultiPolygon BBoxTrait::bbox" {
       ],
     ],
   ])
-  inspect(mp.bbox(), content="BBox2D(0, 0, 1, 1)")
+  debug_inspect(mp.bbox(), content="BBox2D(0, 0, 1, 1)")
 }
 ```
 
@@ -100,9 +102,11 @@ test "MultiPolygon FromJson::from_json - valid" {
     "type": "MultiPolygon",
     "coordinates": [[[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]]],
   })
-  inspect(
+  debug_inspect(
     multi_polyfill,
-    content="{coordinates: [[[XY(0, 0), XY(1, 0), XY(1, 1), XY(0, 0)]]]}",
+    content=(
+      #|{ coordinates: [[[XY(0, 0), XY(1, 0), XY(1, 1), XY(0, 0)]]] }
+    ),
   )
 }
 ```
@@ -116,6 +120,8 @@ test "MultiPolygon FromJson::from_json - empty" {
     "type": "MultiPolygon",
     "coordinates": [],
   })
-  inspect(multi_polyfill, content="{coordinates: []}")
+  debug_inspect(multi_polyfill, content=(
+    #|{ coordinates: [] }
+  ))
 }
 ```

--- a/mbt/package/geo/src/geojson/pkg.generated.mbti
+++ b/mbt/package/geo/src/geojson/pkg.generated.mbti
@@ -1,0 +1,194 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "totto2727/geo/geojson"
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+pub suberror InvalidGeoJSONError {
+  InvalidGeoJSONError(String)
+}
+pub fn InvalidGeoJSONError::new(String) -> Self
+
+// Types and methods
+pub(all) enum BBox {
+  BBox2D(Double, Double, Double, Double)
+  BBox3D(Double, Double, Double, Double, Double, Double)
+} derive(Eq, @debug.Debug)
+pub fn BBox::from_coordinate_array(Array[Coordinates]) -> Self raise InvalidGeoJSONError
+pub fn BBox::new_2d(Double, Double, Double, Double) -> Self
+pub fn BBox::new_3d(Double, Double, Double, Double, Double, Double) -> Self
+pub impl ToJson for BBox
+pub impl @json.FromJson for BBox
+
+pub(all) enum Coordinates {
+  XY(Double, Double)
+  XYZ_OR_XYM(Double, Double, Double)
+  XYZM(Double, Double, Double, Double)
+} derive(Eq, @debug.Debug)
+pub fn Coordinates::dimension(Self) -> Int
+pub fn Coordinates::x(Self) -> Double
+pub fn Coordinates::y(Self) -> Double
+pub fn Coordinates::z(Self) -> Double raise InvalidGeoJSONError
+pub impl ToJson for Coordinates
+pub impl @json.FromJson for Coordinates
+
+pub struct Feature {
+  geometry : Geometry?
+  properties : Map[String, Json]?
+  id : ID?
+} derive(Eq, @debug.Debug)
+pub fn Feature::new(geometry? : Geometry?, properties? : Map[String, Json]?, id? : ID?) -> Self
+pub impl ToJson for Feature
+pub impl @json.FromJson for Feature
+pub impl BBoxTrait for Feature
+pub impl GeoJSONTrait for Feature
+
+pub struct FeatureCollection {
+  features : Array[Feature]
+} derive(Eq, @debug.Debug)
+pub fn FeatureCollection::new(Array[Feature]) -> Self
+pub impl ToJson for FeatureCollection
+pub impl @json.FromJson for FeatureCollection
+pub impl BBoxTrait for FeatureCollection
+pub impl GeoJSONTrait for FeatureCollection
+
+pub(all) enum GeoJSON {
+  FeatureCollection(FeatureCollection)
+  Feature(Feature)
+  Geometry(Geometry)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for GeoJSON
+pub impl @json.FromJson for GeoJSON
+pub impl BBoxTrait for GeoJSON
+pub impl GeoJSONTrait for GeoJSON
+
+pub(all) enum GeoJSONType {
+  FeatureCollection
+  Feature
+  Geometry(GeometryType)
+} derive(Eq, @debug.Debug)
+pub fn GeoJSONType::from_raw_geojson(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub impl ToJson for GeoJSONType
+pub impl @json.FromJson for GeoJSONType
+
+pub(all) enum Geometry {
+  Point(Point)
+  LineString(LineString)
+  Polygon(Polygon)
+  MultiPoint(MultiPoint)
+  MultiLineString(MultiLineString)
+  MultiPolygon(MultiPolygon)
+  GeometryCollection(GeometryCollection)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for Geometry
+pub impl @json.FromJson for Geometry
+pub impl BBoxTrait for Geometry
+pub impl GeoJSONTrait for Geometry
+
+pub struct GeometryCollection {
+  geometries : Array[Geometry]
+} derive(Eq, @debug.Debug)
+pub fn GeometryCollection::new(Array[Geometry]) -> Self
+pub impl ToJson for GeometryCollection
+pub impl @json.FromJson for GeometryCollection
+pub impl BBoxTrait for GeometryCollection
+pub impl GeoJSONTrait for GeometryCollection
+
+pub(all) enum GeometryType {
+  Point
+  LineString
+  Polygon
+  MultiPoint
+  MultiLineString
+  MultiPolygon
+  GeometryCollection
+} derive(Eq, @debug.Debug)
+pub fn GeometryType::from_raw_geojson(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub impl ToJson for GeometryType
+pub impl @json.FromJson for GeometryType
+
+pub(all) enum ID {
+  String(String)
+  Number(Double)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for ID
+pub impl @json.FromJson for ID
+
+pub struct LineString {
+  coordinates : Array[Coordinates]
+} derive(Eq, @debug.Debug)
+pub fn LineString::new(Array[Coordinates]) -> Self raise InvalidGeoJSONError
+pub impl ToJson for LineString
+pub impl @json.FromJson for LineString
+pub impl BBoxTrait for LineString
+pub impl GeoJSONTrait for LineString
+
+pub struct MultiLineString {
+  coordinates : Array[Array[Coordinates]]
+} derive(Eq, @debug.Debug)
+pub fn MultiLineString::new(Array[Array[Coordinates]]) -> Self
+pub impl ToJson for MultiLineString
+pub impl @json.FromJson for MultiLineString
+pub impl BBoxTrait for MultiLineString
+pub impl GeoJSONTrait for MultiLineString
+
+pub struct MultiPoint {
+  coordinates : Array[Coordinates]
+} derive(Eq, @debug.Debug)
+pub fn MultiPoint::new(Array[Coordinates]) -> Self
+pub impl ToJson for MultiPoint
+pub impl @json.FromJson for MultiPoint
+pub impl BBoxTrait for MultiPoint
+pub impl GeoJSONTrait for MultiPoint
+
+pub struct MultiPolygon {
+  coordinates : Array[Array[Array[Coordinates]]]
+} derive(Eq, @debug.Debug)
+pub fn MultiPolygon::new(Array[Array[Array[Coordinates]]]) -> Self
+pub impl ToJson for MultiPolygon
+pub impl @json.FromJson for MultiPolygon
+pub impl BBoxTrait for MultiPolygon
+pub impl GeoJSONTrait for MultiPolygon
+
+pub struct Point {
+  coordinates : Coordinates
+} derive(Eq, @debug.Debug)
+pub fn Point::new(Coordinates) -> Self
+pub impl ToJson for Point
+pub impl @json.FromJson for Point
+pub impl BBoxTrait for Point
+pub impl GeoJSONTrait for Point
+
+pub struct Polygon {
+  coordinates : Array[Array[Coordinates]]
+} derive(Eq, @debug.Debug)
+pub fn Polygon::new(Array[Array[Coordinates]]) -> Self raise InvalidGeoJSONError
+pub impl ToJson for Polygon
+pub impl @json.FromJson for Polygon
+pub impl BBoxTrait for Polygon
+pub impl GeoJSONTrait for Polygon
+
+// Type aliases
+
+// Traits
+pub(open) trait BBoxTrait {
+  bbox(Self) -> BBox raise InvalidGeoJSONError
+}
+
+pub(open) trait FromGeoJSON {
+  from_geojson_geometry(Geometry) -> Self raise InvalidGeoJSONError
+}
+
+pub(open) trait GeoJSONTrait : @json.FromJson + ToJson {
+  to_json(Self, with_bbox? : Bool) -> Json
+}
+
+pub(open) trait ToGeoJSON {
+  to_geojson(Self, with_bbox? : Bool) -> GeoJSON
+}
+

--- a/mbt/package/geo/src/geojson/point.mbt
+++ b/mbt/package/geo/src/geojson/point.mbt
@@ -1,7 +1,7 @@
 ///|
 pub struct Point {
   coordinates : Coordinates
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn Point::new(coordinates : Coordinates) -> Point {

--- a/mbt/package/geo/src/geojson/point.mbt.md
+++ b/mbt/package/geo/src/geojson/point.mbt.md
@@ -21,7 +21,9 @@
 ///|
 test "Point new" {
   let p = Point::new(Coordinates::XY(1.0, 2.0))
-  inspect(p, content="{coordinates: XY(1, 2)}")
+  debug_inspect(p, content=(
+    #|{ coordinates: XY(1, 2) }
+  ))
 }
 ```
 
@@ -33,7 +35,7 @@ test "Point new" {
 ///|
 test "Point BBoxTrait::bbox" {
   let p = Point::new(Coordinates::XY(1.0, 2.0))
-  inspect(p.bbox(), content="BBox2D(1, 2, 1, 2)")
+  debug_inspect(p.bbox(), content="BBox2D(1, 2, 1, 2)")
 }
 ```
 
@@ -72,7 +74,9 @@ test "Point ToJson::to_json" {
 ///|
 test "Point FromJson::from_json - valid" {
   let p : Point = @json.from_json({ "type": "Point", "coordinates": [1.0, 2.0] })
-  inspect(p, content="{coordinates: XY(1, 2)}")
+  debug_inspect(p, content=(
+    #|{ coordinates: XY(1, 2) }
+  ))
 }
 ```
 

--- a/mbt/package/geo/src/geojson/polygon.mbt
+++ b/mbt/package/geo/src/geojson/polygon.mbt
@@ -1,7 +1,7 @@
 ///|
 pub struct Polygon {
   coordinates : Array[Array[Coordinates]]
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn Polygon::new(

--- a/mbt/package/geo/src/geojson/polygon.mbt.md
+++ b/mbt/package/geo/src/geojson/polygon.mbt.md
@@ -28,9 +28,11 @@ test "Polygon new" {
       Coordinates::XY(0.0, 0.0),
     ],
   ])
-  inspect(
+  debug_inspect(
     p,
-    content="{coordinates: [[XY(0, 0), XY(1, 0), XY(1, 1), XY(0, 0)]]}",
+    content=(
+      #|{ coordinates: [[XY(0, 0), XY(1, 0), XY(1, 1), XY(0, 0)]] }
+    ),
   )
 }
 ```
@@ -50,7 +52,7 @@ test "Polygon BBoxTrait::bbox" {
       Coordinates::XY(0.0, 0.0),
     ],
   ])
-  inspect(p.bbox(), content="BBox2D(0, 0, 1, 1)")
+  debug_inspect(p.bbox(), content="BBox2D(0, 0, 1, 1)")
 }
 ```
 
@@ -101,9 +103,11 @@ test "Polygon FromJson::from_json - valid" {
     "type": "Polygon",
     "coordinates": [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]],
   })
-  inspect(
+  debug_inspect(
     poly,
-    content="{coordinates: [[XY(0, 0), XY(1, 0), XY(1, 1), XY(0, 0)]]}",
+    content=(
+      #|{ coordinates: [[XY(0, 0), XY(1, 0), XY(1, 1), XY(0, 0)]] }
+    ),
   )
 }
 ```

--- a/mbt/package/geo/src/json_helper/from_json.mbt.md
+++ b/mbt/package/geo/src/json_helper/from_json.mbt.md
@@ -25,7 +25,7 @@ Helper functions for extracting values from JSON objects.
 ///|
 struct TestStruct {
   key : String?
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl FromJson for TestStruct with from_json(json, path) {
@@ -36,10 +36,11 @@ impl FromJson for TestStruct with from_json(json, path) {
 test {
   let json : Json = { "key": "value" }
   let result : TestStruct = @json.from_json(json)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|{key: Some("value")}
+      #|{ key: Some("value") }
+
     ),
   )
 }
@@ -52,7 +53,9 @@ test {
 test {
   let json : Json = {}
   let result : TestStruct = @json.from_json(json)
-  inspect(result, content="{key: None}")
+  debug_inspect(result, content=(
+    #|{ key: None }
+  ))
 }
 ```
 
@@ -63,7 +66,9 @@ test {
 test {
   let json : Json = { "key": Json::null() }
   let result : TestStruct = @json.from_json(json)
-  inspect(result, content="{key: None}")
+  debug_inspect(result, content=(
+    #|{ key: None }
+  ))
 }
 ```
 
@@ -93,7 +98,7 @@ test "panic_from_json_property - on non-object JSON" {
 ///|
 struct TestStruct2 {
   key : String
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl FromJson for TestStruct2 with from_json(json, path) {
@@ -106,10 +111,11 @@ impl FromJson for TestStruct2 with from_json(json, path) {
 test {
   let json : Json = { "key": "value" }
   let result : TestStruct2 = @json.from_json(json)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|{key: "value"}
+      #|{ key: "value" }
+
     ),
   )
 }
@@ -122,10 +128,11 @@ test {
 test {
   let json : Json = {}
   let result : TestStruct2 = @json.from_json(json)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|{key: "default"}
+      #|{ key: "default" }
+
     ),
   )
 }
@@ -138,10 +145,11 @@ test {
 test {
   let json : Json = { "key": Json::null() }
   let result : TestStruct2 = @json.from_json(json)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|{key: "default"}
+      #|{ key: "default" }
+
     ),
   )
 }
@@ -172,7 +180,7 @@ test "panic_from_json_property_or_default - on non-object JSON" {
 ///|
 struct TestStruct3 {
   key : Array[String]
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl FromJson for TestStruct3 with from_json(json, path) {
@@ -183,10 +191,11 @@ impl FromJson for TestStruct3 with from_json(json, path) {
 test {
   let json : Json = { "key": ["value"] }
   let result : TestStruct3 = @json.from_json(json)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|{key: ["value"]}
+      #|{ key: ["value"] }
+
     ),
   )
 }
@@ -199,7 +208,9 @@ test {
 test {
   let json : Json = {}
   let result : TestStruct3 = @json.from_json(json)
-  inspect(result, content="{key: []}")
+  debug_inspect(result, content=(
+    #|{ key: [] }
+  ))
 }
 ```
 
@@ -210,6 +221,8 @@ test {
 test {
   let json : Json = { "key": Json::null() }
   let result : TestStruct3 = @json.from_json(json)
-  inspect(result, content="{key: []}")
+  debug_inspect(result, content=(
+    #|{ key: [] }
+  ))
 }
 ```

--- a/mbt/package/geo/src/json_helper/pkg.generated.mbti
+++ b/mbt/package/geo/src/json_helper/pkg.generated.mbti
@@ -1,0 +1,30 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "totto2727/geo/json_helper"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+pub fn[T : @json.FromJson] from_json_property(String, Json, @json.JsonPath) -> T? raise @json.JsonDecodeError
+
+pub fn[T : @json.FromJson] from_json_property_or_array_or_empty(String, Json, @json.JsonPath) -> Array[T] raise @json.JsonDecodeError
+
+pub fn[T : @json.FromJson] from_json_property_or_default(String, () -> T, Json, @json.JsonPath) -> T raise @json.JsonDecodeError
+
+pub fn[T : @json.FromJson] from_json_property_or_throw(String, Json, @json.JsonPath) -> T raise @json.JsonDecodeError
+
+pub fn[T : ToJson, U : ToJson] to_json_or_default(Map[String, Json], String, T?, () -> U) -> Unit
+
+pub fn[T : ToJson] to_nullable_json(Map[String, Json], String, T?) -> Unit
+
+pub fn[T : ToJson] to_optional_json(Map[String, Json], String, T?) -> Unit
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/mbt/package/geo/src/turf/boolean_point_in_polygon.mbt
+++ b/mbt/package/geo/src/turf/boolean_point_in_polygon.mbt
@@ -17,7 +17,7 @@ pub fn[Point : @type.PointTrait, Polygon : @type.PolygonTrait] boolean_point_in_
 ) -> Bool raise {
   let coord = point.coord()
   let bbox = polygon.bbox()
-  if not(in_bbox(coord, bbox)) {
+  if !in_bbox(coord, bbox) {
     return false
   }
   match @point_in_ring.point_in_ring(coord, polygon.exterior()) {

--- a/mbt/package/geo/src/turf/boolean_point_in_polygon.mbt.md
+++ b/mbt/package/geo/src/turf/boolean_point_in_polygon.mbt.md
@@ -25,7 +25,7 @@ test {
     ]),
   )
   let point = @type.Point::new(@type.XY::new(50.0, 50.0))
-  inspect(@turf.boolean_point_in_polygon(point, polygon), content="true")
+  debug_inspect(@turf.boolean_point_in_polygon(point, polygon), content="true")
 }
 ```
 
@@ -44,7 +44,7 @@ test {
     ]),
   )
   let point = @type.Point::new(@type.XY::new(140.0, 150.0))
-  inspect(@turf.boolean_point_in_polygon(point, polygon), content="false")
+  debug_inspect(@turf.boolean_point_in_polygon(point, polygon), content="false")
 }
 ```
 
@@ -64,7 +64,7 @@ test {
       @type.XY::new(0.0, 0.0),
     ]),
   )
-  inspect(@turf.boolean_point_in_polygon(point, polygon), content="true")
+  debug_inspect(@turf.boolean_point_in_polygon(point, polygon), content="true")
 }
 ```
 
@@ -84,7 +84,7 @@ test {
       @type.XY::new(0.0, 0.0),
     ]),
   )
-  inspect(@turf.boolean_point_in_polygon(point, polygon), content="false")
+  debug_inspect(@turf.boolean_point_in_polygon(point, polygon), content="false")
 }
 ```
 
@@ -103,7 +103,7 @@ test {
       @type.XY::new(10.0, 10.0),
     ]),
   )
-  inspect(@turf.boolean_point_in_polygon(point, polygon), content="true")
+  debug_inspect(@turf.boolean_point_in_polygon(point, polygon), content="true")
 }
 ```
 
@@ -122,7 +122,7 @@ test {
       @type.XY::new(10.0, 10.0),
     ]),
   )
-  inspect(
+  debug_inspect(
     @turf.boolean_point_in_polygon(point, polygon, ignore_boundary=true),
     content="false",
   )
@@ -153,7 +153,7 @@ test {
     ],
   )
   let point = @type.Point::new(@type.XY::new(10.0, 10.0))
-  inspect(@turf.boolean_point_in_polygon(point, polygon), content="true")
+  debug_inspect(@turf.boolean_point_in_polygon(point, polygon), content="true")
 }
 ```
 
@@ -181,7 +181,7 @@ test {
     ],
   )
   let point = @type.Point::new(@type.XY::new(50.0, 50.0))
-  inspect(@turf.boolean_point_in_polygon(point, polygon), content="false")
+  debug_inspect(@turf.boolean_point_in_polygon(point, polygon), content="false")
 }
 ```
 
@@ -200,7 +200,7 @@ test {
     ]),
   )
   let point = @type.Point::new(@type.XY::new(-9.9964077, 53.8040989))
-  inspect(@turf.boolean_point_in_polygon(point, polygon), content="true")
+  debug_inspect(@turf.boolean_point_in_polygon(point, polygon), content="true")
 }
 ```
 
@@ -338,15 +338,15 @@ test {
   let pt_outside_poly = @type.Point::new(
     @type.XY::new(-86.75079345703125, 36.18527313913089),
   )
-  inspect(
+  debug_inspect(
     @turf.boolean_point_in_polygon(pt_in_hole, @fixture.poly_with_hole),
     content="false",
   )
-  inspect(
+  debug_inspect(
     @turf.boolean_point_in_polygon(pt_in_poly, @fixture.poly_with_hole),
     content="true",
   )
-  inspect(
+  debug_inspect(
     @turf.boolean_point_in_polygon(pt_outside_poly, @fixture.poly_with_hole),
     content="false",
   )

--- a/mbt/package/geo/src/turf/internal/fixture/pkg.generated.mbti
+++ b/mbt/package/geo/src/turf/internal/fixture/pkg.generated.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "totto2727/geo/turf/internal/fixture"
+
+import {
+  "totto2727/geo/type",
+}
+
+// Values
+pub let multipoly_with_hole : @type.MultiPolygon[@type.XY]
+
+pub let poly_with_hole : @type.Polygon[@type.XY]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/mbt/package/geo/src/turf/pkg.generated.mbti
+++ b/mbt/package/geo/src/turf/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "totto2727/geo/turf"
+
+import {
+  "moonbitlang/core/debug",
+  "totto2727/geo/type",
+}
+
+// Values
+pub fn[Point : @type.PointTrait, Polygon : @type.PolygonTrait] boolean_point_in_polygon(Point, Polygon, ignore_boundary? : Bool) -> Bool raise
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/mbt/package/geo/src/type/coord.mbt
+++ b/mbt/package/geo/src/type/coord.mbt
@@ -1,5 +1,5 @@
 ///|
-pub(open) trait CoordTrait: Add + Sub + Neg + Show {
+pub(open) trait CoordTrait: Add + Sub + Neg + Debug {
   /// Due to Moonbit's current specification, implementing multiplication and division across different types is impossible.
   /// Therefore, we will not use the Mul trait or Div trait, but instead define our own functions.
   mul(Self, Double) -> Self

--- a/mbt/package/geo/src/type/coord.mbt.md
+++ b/mbt/package/geo/src/type/coord.mbt.md
@@ -19,7 +19,9 @@ Provides basic coordinate operations including accessors, arithmetic (negation, 
 ///|
 test {
   let c = XY::new(1.0, 2.0)
-  inspect(c.xy(), content="{x: 1, y: 2}")
+  debug_inspect(c.xy(), content=(
+    #|{ x: 1, y: 2 }
+  ))
 }
 ```
 
@@ -31,6 +33,8 @@ test {
 ///|
 test {
   let c = XYZ::new(1.0, 2.0, 3.0)
-  inspect(c.xyz(), content="{x: 1, y: 2, z: 3}")
+  debug_inspect(c.xyz(), content=(
+    #|{ x: 1, y: 2, z: 3 }
+  ))
 }
 ```

--- a/mbt/package/geo/src/type/geometry.mbt
+++ b/mbt/package/geo/src/type/geometry.mbt
@@ -2,7 +2,7 @@
 pub suberror NonExistCoordError
 
 ///|
-pub trait GeometryTrait: Show {
+pub trait GeometryTrait: Debug {
   coord_array(Self) -> Array[XY]
   point_array(Self) -> Array[Point[XY]] = _
   bbox(Self) -> BBox[XY] raise NonExistCoordError = _

--- a/mbt/package/geo/src/type/geometry.mbt.md
+++ b/mbt/package/geo/src/type/geometry.mbt.md
@@ -22,9 +22,11 @@ Defines the core behavior for all geometry types, including bounding box calcula
 ///|
 test {
   let ls = LineString::new([XY::new(1.0, 1.0), XY::new(2.0, 2.0)])
-  inspect(
+  debug_inspect(
     ls.point_array(),
-    content="[Point({x: 1, y: 1}), Point({x: 2, y: 2})]",
+    content=(
+      #|[Point({ x: 1, y: 1 }), Point({ x: 2, y: 2 })]
+    ),
   )
 }
 ```
@@ -42,7 +44,9 @@ test {
 ///|
 test {
   let ls = LineString::new([XY::new(1.0, 1.0), XY::new(2.0, 2.0)])
-  inspect(ls.bbox(), content="{min: {x: 1, y: 1}, max: {x: 2, y: 2}}")
+  debug_inspect(ls.bbox(), content=(
+    #|{ min: { x: 1, y: 1 }, max: { x: 2, y: 2 } }
+  ))
 }
 ```
 

--- a/mbt/package/geo/src/type/geometry_collection.mbt
+++ b/mbt/package/geo/src/type/geometry_collection.mbt
@@ -1,5 +1,5 @@
 ///|
-pub struct GeometryCollection(Array[&GeometryTrait]) derive(Show)
+pub struct GeometryCollection(Array[&GeometryTrait]) derive(Debug)
 
 ///|
 #warnings("-unused_trait_bound")

--- a/mbt/package/geo/src/type/geometry_collection.mbt.md
+++ b/mbt/package/geo/src/type/geometry_collection.mbt.md
@@ -20,7 +20,12 @@ Represents a heterogeneous collection of geometries.
 test {
   let point = Point::new(XY::new(1.0, 1.0))
   let geometry_collection = GeometryCollection::new([point])
-  inspect(geometry_collection.geometry_array(), content="[Point({x: 1, y: 1})]")
+  debug_inspect(
+    geometry_collection.geometry_array(),
+    content=(
+      #|[Point({ x: 1, y: 1 })]
+    ),
+  )
 }
 ```
 
@@ -34,9 +39,11 @@ test {
   let point = Point::new(XY::new(1.0, 1.0))
   let line_string = LineString::new([XY::new(2.0, 2.0), XY::new(3.0, 3.0)])
   let geometry_collection = GeometryCollection::new([point, line_string])
-  inspect(
+  debug_inspect(
     geometry_collection.coord_array(),
-    content="[{x: 1, y: 1}, {x: 2, y: 2}, {x: 3, y: 3}]",
+    content=(
+      #|[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]
+    ),
   )
 }
 ```
@@ -51,9 +58,11 @@ test {
   let point = Point::new(XY::new(1.0, 1.0))
   let line_string = LineString::new([XY::new(2.0, 2.0), XY::new(3.0, 3.0)])
   let geometry_collection = GeometryCollection::new([point, line_string])
-  inspect(
+  debug_inspect(
     geometry_collection.geometry_array(),
-    content="[Point({x: 1, y: 1}), LineString([{x: 2, y: 2}, {x: 3, y: 3}])]",
+    content=(
+      #|[Point({ x: 1, y: 1 }), LineString([{ x: 2, y: 2 }, { x: 3, y: 3 }])]
+    ),
   )
 }
 ```
@@ -73,9 +82,11 @@ test {
   let point = Point::new(XY::new(1.0, 1.0))
   let line_string = LineString::new([XY::new(2.0, 2.0), XY::new(3.0, 3.0)])
   let geometry_collection = GeometryCollection::new([point, line_string])
-  inspect(
+  debug_inspect(
     geometry_collection.bbox(),
-    content="{min: {x: 1, y: 1}, max: {x: 3, y: 3}}",
+    content=(
+      #|{ min: { x: 1, y: 1 }, max: { x: 3, y: 3 } }
+    ),
   )
 }
 ```

--- a/mbt/package/geo/src/type/line.mbt
+++ b/mbt/package/geo/src/type/line.mbt
@@ -14,7 +14,7 @@ impl LineTrait with line(self) {
 pub struct Line[Coord] {
   start : Coord
   end : Coord
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 ///|
 #warnings("-unused_trait_bound")

--- a/mbt/package/geo/src/type/line.mbt.md
+++ b/mbt/package/geo/src/type/line.mbt.md
@@ -22,7 +22,9 @@ test {
   let start = XY::new(0.0, 0.0)
   let end = XY::new(10.0, 5.0)
   let line = Line::new(start, end)
-  inspect(line, content="{start: {x: 0, y: 0}, end: {x: 10, y: 5}}")
+  debug_inspect(line, content=(
+    #|{ start: { x: 0, y: 0 }, end: { x: 10, y: 5 } }
+  ))
 }
 ```
 
@@ -36,7 +38,9 @@ test {
   let start = XY::new(1.0, 2.0)
   let end = XY::new(3.0, 4.0)
   let line = Line::new(start, end)
-  inspect(line.start(), content="{x: 1, y: 2}")
+  debug_inspect(line.start(), content=(
+    #|{ x: 1, y: 2 }
+  ))
 }
 ```
 
@@ -50,7 +54,9 @@ test {
   let start = XY::new(1.0, 2.0)
   let end = XY::new(3.0, 4.0)
   let line = Line::new(start, end)
-  inspect(line.end(), content="{x: 3, y: 4}")
+  debug_inspect(line.end(), content=(
+    #|{ x: 3, y: 4 }
+  ))
 }
 ```
 
@@ -64,7 +70,9 @@ test {
   let start = XY::new(0.0, 0.0)
   let end = XY::new(10.0, 10.0)
   let line = Line::new(start, end)
-  inspect(line.coord_array(), content="[{x: 0, y: 0}, {x: 10, y: 10}]")
+  debug_inspect(line.coord_array(), content=(
+    #|[{ x: 0, y: 0 }, { x: 10, y: 10 }]
+  ))
 }
 ```
 
@@ -78,6 +86,8 @@ test {
   let start = XY::new(1.0, 5.0)
   let end = XY::new(4.0, 2.0)
   let line = Line::new(start, end)
-  inspect(line.bbox(), content="{min: {x: 1, y: 2}, max: {x: 4, y: 5}}")
+  debug_inspect(line.bbox(), content=(
+    #|{ min: { x: 1, y: 2 }, max: { x: 4, y: 5 } }
+  ))
 }
 ```

--- a/mbt/package/geo/src/type/line_string.mbt
+++ b/mbt/package/geo/src/type/line_string.mbt
@@ -7,12 +7,12 @@ pub trait LineStringTrait: GeometryTrait {
 ///|
 impl LineStringTrait with line_array(self) {
   let coord_array = self.coord_array()
-  let zipped_coord_array = Array::zip(coord_array, coord_array[1:].to_array())
+  let zipped_coord_array = Array::zip(coord_array, coord_array[1:].to_owned())
   zipped_coord_array.map(coord_tuple => Line::new(coord_tuple.0, coord_tuple.1))
 }
 
 ///|
-pub struct LineString[Coord](Array[Coord]) derive(Show, Eq)
+pub struct LineString[Coord](Array[Coord]) derive(Debug, Eq)
 
 ///|
 #warnings("-unused_trait_bound")

--- a/mbt/package/geo/src/type/line_string.mbt.md
+++ b/mbt/package/geo/src/type/line_string.mbt.md
@@ -21,7 +21,9 @@ test {
   let point1 = XY::new(0.0, 0.0)
   let point2 = XY::new(1.0, 1.0)
   let line_string = LineString::new([point1, point2])
-  inspect(line_string, content="LineString([{x: 0, y: 0}, {x: 1, y: 1}])")
+  debug_inspect(line_string, content=(
+    #|LineString([{ x: 0, y: 0 }, { x: 1, y: 1 }])
+  ))
 }
 ```
 
@@ -35,7 +37,12 @@ test {
   let point1 = XY::new(0.0, 0.0)
   let point2 = XY::new(10.0, 10.0)
   let line_string = LineString::new([point1, point2])
-  inspect(line_string.coord_array(), content="[{x: 0, y: 0}, {x: 10, y: 10}]")
+  debug_inspect(
+    line_string.coord_array(),
+    content=(
+      #|[{ x: 0, y: 0 }, { x: 10, y: 10 }]
+    ),
+  )
 }
 ```
 
@@ -50,9 +57,14 @@ test {
   let point2 = XY::new(10.0, 10.0)
   let point3 = XY::new(20.0, 0.0)
   let line_string = LineString::new([point1, point2, point3])
-  inspect(
+  debug_inspect(
     line_string.line_array(),
-    content="[{start: {x: 0, y: 0}, end: {x: 10, y: 10}}, {start: {x: 10, y: 10}, end: {x: 20, y: 0}}]",
+    content=(
+      #|[
+      #|  { start: { x: 0, y: 0 }, end: { x: 10, y: 10 } },
+      #|  { start: { x: 10, y: 10 }, end: { x: 20, y: 0 } },
+      #|]
+    ),
   )
 }
 ```
@@ -73,9 +85,11 @@ test {
   let point2 = XY::new(10.0, 10.0)
   let point3 = XY::new(20.0, 0.0)
   let line_string = LineString::new([point1, point2, point3])
-  inspect(
+  debug_inspect(
     line_string.bbox(),
-    content="{min: {x: 0, y: 0}, max: {x: 20, y: 10}}",
+    content=(
+      #|{ min: { x: 0, y: 0 }, max: { x: 20, y: 10 } }
+    ),
   )
 }
 ```

--- a/mbt/package/geo/src/type/multi_geometry.mbt.md
+++ b/mbt/package/geo/src/type/multi_geometry.mbt.md
@@ -5,7 +5,7 @@ Provides functionality for collections of geometries, including efficient flatte
 ## Public API
 
 - `coord_array` (default implementation via `&MultiGeometryTrait`)
-- `Show` (default implementation for `&MultiGeometryTrait`)
+- `Debug` (default implementation for `&MultiGeometryTrait`)
 
 ## Test
 
@@ -25,25 +25,29 @@ test {
     Point::new(XY::new(2.0, 2.0)),
   ])
   // MultiPoint uses &MultiGeometryTrait::coordArray implicitly
-  inspect(mp.coord_array(), content="[{x: 1, y: 1}, {x: 2, y: 2}]")
+  debug_inspect(mp.coord_array(), content=(
+    #|[{ x: 1, y: 1 }, { x: 2, y: 2 }]
+  ))
 }
 ```
 
-### `Show`
+### `Debug`
 
-#### `output`
+#### `to_repr`
 
 | Variable | State   | Note |  1  |
 | :------- | :------ | :--- | :-: |
 | `self`   | `Valid` |      |  ✓  |
 
-- Default implementation delegates to geometry_array show
+- Default implementation delegates to geometry_array debug
 
 ```mbt check
 ///|
 test {
   let mp = MultiPoint::new([Point::new(XY::new(1.0, 1.0))])
   let boxed : &MultiGeometryTrait = mp
-  inspect(boxed, content="MultiPoint([Point({x: 1, y: 1})])")
+  debug_inspect(boxed, content=(
+    #|MultiPoint([Point({ x: 1, y: 1 })])
+  ))
 }
 ```

--- a/mbt/package/geo/src/type/multi_line_string.mbt
+++ b/mbt/package/geo/src/type/multi_line_string.mbt
@@ -1,5 +1,5 @@
 ///|
-pub struct MultiLineString[Coord](Array[LineString[Coord]]) derive(Show, Eq)
+pub struct MultiLineString[Coord](Array[LineString[Coord]]) derive(Debug, Eq)
 
 ///|
 #warnings("-unused_trait_bound")

--- a/mbt/package/geo/src/type/multi_line_string.mbt.md
+++ b/mbt/package/geo/src/type/multi_line_string.mbt.md
@@ -20,9 +20,11 @@ Represents a collection of line strings.
 test {
   let line_string1 = LineString::new([XY::new(0.0, 0.0), XY::new(1.0, 1.0)])
   let multi_line_string = MultiLineString::new([line_string1])
-  inspect(
+  debug_inspect(
     multi_line_string,
-    content="MultiLineString([LineString([{x: 0, y: 0}, {x: 1, y: 1}])])",
+    content=(
+      #|MultiLineString([LineString([{ x: 0, y: 0 }, { x: 1, y: 1 }])])
+    ),
   )
 }
 ```
@@ -37,9 +39,11 @@ test {
   let line_string1 = LineString::new([XY::new(0.0, 0.0), XY::new(1.0, 1.0)])
   let line_string2 = LineString::new([XY::new(2.0, 2.0), XY::new(3.0, 3.0)])
   let multi_line_string = MultiLineString::new([line_string1, line_string2])
-  inspect(
+  debug_inspect(
     multi_line_string.coord_array(),
-    content="[{x: 0, y: 0}, {x: 1, y: 1}, {x: 2, y: 2}, {x: 3, y: 3}]",
+    content=(
+      #|[{ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]
+    ),
   )
 }
 ```
@@ -53,9 +57,11 @@ test {
 test {
   let line_string1 = LineString::new([XY::new(0.0, 0.0), XY::new(1.0, 1.0)])
   let multi_line_string = MultiLineString::new([line_string1])
-  inspect(
+  debug_inspect(
     multi_line_string.geometry_array(),
-    content="[LineString([{x: 0, y: 0}, {x: 1, y: 1}])]",
+    content=(
+      #|[LineString([{ x: 0, y: 0 }, { x: 1, y: 1 }])]
+    ),
   )
 }
 ```
@@ -75,9 +81,11 @@ test {
   let line_string1 = LineString::new([XY::new(0.0, 0.0), XY::new(1.0, 1.0)])
   let line_string2 = LineString::new([XY::new(2.0, 2.0), XY::new(3.0, 3.0)])
   let multi_line_string = MultiLineString::new([line_string1, line_string2])
-  inspect(
+  debug_inspect(
     multi_line_string.bbox(),
-    content="{min: {x: 0, y: 0}, max: {x: 3, y: 3}}",
+    content=(
+      #|{ min: { x: 0, y: 0 }, max: { x: 3, y: 3 } }
+    ),
   )
 }
 ```

--- a/mbt/package/geo/src/type/multi_point.mbt
+++ b/mbt/package/geo/src/type/multi_point.mbt
@@ -1,5 +1,5 @@
 ///|
-pub struct MultiPoint[Coord](Array[Point[Coord]]) derive(Show, Eq)
+pub struct MultiPoint[Coord](Array[Point[Coord]]) derive(Debug, Eq)
 
 ///|
 #warnings("-unused_trait_bound")

--- a/mbt/package/geo/src/type/multi_point.mbt.md
+++ b/mbt/package/geo/src/type/multi_point.mbt.md
@@ -20,7 +20,9 @@ Represents a collection of points.
 test {
   let point1 = Point::new(XY::new(1.0, 1.0))
   let multi_point = MultiPoint::new([point1])
-  inspect(multi_point, content="MultiPoint([Point({x: 1, y: 1})])")
+  debug_inspect(multi_point, content=(
+    #|MultiPoint([Point({ x: 1, y: 1 })])
+  ))
 }
 ```
 
@@ -34,7 +36,12 @@ test {
   let point1 = Point::new(XY::new(1.0, 1.0))
   let point2 = Point::new(XY::new(2.0, 2.0))
   let multi_point = MultiPoint::new([point1, point2])
-  inspect(multi_point.coord_array(), content="[{x: 1, y: 1}, {x: 2, y: 2}]")
+  debug_inspect(
+    multi_point.coord_array(),
+    content=(
+      #|[{ x: 1, y: 1 }, { x: 2, y: 2 }]
+    ),
+  )
 }
 ```
 
@@ -47,7 +54,9 @@ test {
 test {
   let point1 = Point::new(XY::new(1.0, 1.0))
   let multi_point = MultiPoint::new([point1])
-  inspect(multi_point.geometry_array(), content="[Point({x: 1, y: 1})]")
+  debug_inspect(multi_point.geometry_array(), content=(
+    #|[Point({ x: 1, y: 1 })]
+  ))
 }
 ```
 
@@ -66,7 +75,12 @@ test {
   let point1 = Point::new(XY::new(1.0, 1.0))
   let point2 = Point::new(XY::new(2.0, 2.0))
   let multi_point = MultiPoint::new([point1, point2])
-  inspect(multi_point.bbox(), content="{min: {x: 1, y: 1}, max: {x: 2, y: 2}}")
+  debug_inspect(
+    multi_point.bbox(),
+    content=(
+      #|{ min: { x: 1, y: 1 }, max: { x: 2, y: 2 } }
+    ),
+  )
 }
 ```
 

--- a/mbt/package/geo/src/type/multi_polygon.mbt
+++ b/mbt/package/geo/src/type/multi_polygon.mbt
@@ -1,5 +1,5 @@
 ///|
-pub struct MultiPolygon[Coord](Array[Polygon[Coord]]) derive(Show, Eq)
+pub struct MultiPolygon[Coord](Array[Polygon[Coord]]) derive(Debug, Eq)
 
 ///|
 #warnings("-unused_trait_bound")

--- a/mbt/package/geo/src/type/multi_polygon.mbt.md
+++ b/mbt/package/geo/src/type/multi_polygon.mbt.md
@@ -26,9 +26,18 @@ test {
   ])
   let polygon1 = Polygon::new(exterior)
   let multi_polygon = MultiPolygon::new([polygon1])
-  inspect(
+  debug_inspect(
     multi_polygon,
-    content="MultiPolygon([{exterior: Ring([{x: 0, y: 0}, {x: 10, y: 0}, {x: 0, y: 10}, {x: 0, y: 0}]), interior_array: []}])",
+    content=(
+      #|MultiPolygon(
+      #|  [
+      #|    {
+      #|      exterior: Ring([{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 0, y: 10 }, { x: 0, y: 0 }]),
+      #|      interior_array: [],
+      #|    },
+      #|  ],
+      #|)
+    ),
   )
 }
 ```
@@ -48,9 +57,11 @@ test {
   ])
   let polygon1 = Polygon::new(exterior)
   let multi_polygon = MultiPolygon::new([polygon1])
-  inspect(
+  debug_inspect(
     multi_polygon.coord_array(),
-    content="[{x: 0, y: 0}, {x: 10, y: 0}, {x: 0, y: 10}, {x: 0, y: 0}]",
+    content=(
+      #|[{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 0, y: 10 }, { x: 0, y: 0 }]
+    ),
   )
 }
 ```
@@ -70,9 +81,16 @@ test {
   ])
   let polygon1 = Polygon::new(exterior)
   let multi_polygon = MultiPolygon::new([polygon1])
-  inspect(
+  debug_inspect(
     multi_polygon.geometry_array(),
-    content="[{exterior: Ring([{x: 0, y: 0}, {x: 10, y: 0}, {x: 0, y: 10}, {x: 0, y: 0}]), interior_array: []}]",
+    content=(
+      #|[
+      #|  {
+      #|    exterior: Ring([{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 0, y: 10 }, { x: 0, y: 0 }]),
+      #|    interior_array: [],
+      #|  },
+      #|]
+    ),
   )
 }
 ```
@@ -97,9 +115,11 @@ test {
   ])
   let polygon1 = Polygon::new(exterior)
   let multi_polygon = MultiPolygon::new([polygon1])
-  inspect(
+  debug_inspect(
     multi_polygon.bbox(),
-    content="{min: {x: 0, y: 0}, max: {x: 10, y: 10}}",
+    content=(
+      #|{ min: { x: 0, y: 0 }, max: { x: 10, y: 10 } }
+    ),
   )
 }
 ```

--- a/mbt/package/geo/src/type/pkg.generated.mbti
+++ b/mbt/package/geo/src/type/pkg.generated.mbti
@@ -1,0 +1,173 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "totto2727/geo/type"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+pub suberror NonExistCoordError
+
+// Types and methods
+pub struct GeometryCollection(Array[&GeometryTrait]) derive(@debug.Debug)
+pub fn GeometryCollection::new(Array[&GeometryTrait]) -> Self
+pub impl GeometryTrait for GeometryCollection
+pub impl MultiGeometryTrait for GeometryCollection
+
+pub struct Line[Coord] {
+  start : Coord
+  end : Coord
+} derive(Eq, @debug.Debug)
+pub fn[Coord : Coord2DTrait] Line::new(Coord, Coord) -> Self[Coord]
+pub impl[Coord : Coord2DTrait] GeometryTrait for Line[Coord]
+pub impl[Coord : Coord2DTrait] LineTrait for Line[Coord]
+
+pub struct LineString[Coord](Array[Coord]) derive(Eq, @debug.Debug)
+pub fn[Coord : Coord2DTrait] LineString::new(Array[Coord]) -> Self[Coord]
+pub impl[Coord : Coord2DTrait] GeometryTrait for LineString[Coord]
+pub impl[Coord : Coord2DTrait] LineStringTrait for LineString[Coord]
+
+pub struct MultiLineString[Coord](Array[LineString[Coord]]) derive(Eq, @debug.Debug)
+pub fn[Coord : Coord2DTrait] MultiLineString::new(Array[LineString[Coord]]) -> Self[Coord]
+pub impl[Coord : Coord2DTrait] GeometryTrait for MultiLineString[Coord]
+pub impl[Coord : Coord2DTrait] MultiGeometryTrait for MultiLineString[Coord]
+
+pub struct MultiPoint[Coord](Array[Point[Coord]]) derive(Eq, @debug.Debug)
+pub fn[Coord : Coord2DTrait] MultiPoint::new(Array[Point[Coord]]) -> Self[Coord]
+pub impl[Coord : Coord2DTrait] GeometryTrait for MultiPoint[Coord]
+pub impl[Coord : Coord2DTrait] MultiGeometryTrait for MultiPoint[Coord]
+
+pub struct MultiPolygon[Coord](Array[Polygon[Coord]]) derive(Eq, @debug.Debug)
+pub fn[Coord : Coord2DTrait] MultiPolygon::new(Array[Polygon[Coord]]) -> Self[Coord]
+pub impl[Coord : Coord2DTrait] GeometryTrait for MultiPolygon[Coord]
+pub impl[Coord : Coord2DTrait] MultiGeometryTrait for MultiPolygon[Coord]
+
+pub struct Point[Coord](Coord) derive(Eq, @debug.Debug)
+pub fn[Coord : Coord2DTrait] Point::new(Coord) -> Self[Coord]
+pub impl[Coord : Coord2DTrait] GeometryTrait for Point[Coord]
+pub impl[Coord : Coord2DTrait] PointTrait for Point[Coord]
+
+pub struct Polygon[Coord] {
+  exterior : Ring[Coord]
+  interior_array : Array[Ring[Coord]]
+} derive(Eq, @debug.Debug)
+pub fn[Coord : Coord2DTrait] Polygon::new(Ring[Coord], interior_array? : Array[Ring[Coord]]) -> Self[Coord]
+pub impl[Coord : Coord2DTrait] GeometryTrait for Polygon[Coord]
+pub impl[Coord : Coord2DTrait] PolygonTrait for Polygon[Coord]
+
+#alias(BBox)
+pub struct Rect[Coord] {
+  min : Coord
+  max : Coord
+} derive(Eq, @debug.Debug)
+pub fn[Coord : Coord2DTrait] Rect::new(Coord, Coord) -> Self[Coord]
+pub impl[Coord : Coord2DTrait] GeometryTrait for Rect[Coord]
+pub impl[Coord : Coord2DTrait] PolygonTrait for Rect[Coord]
+
+pub struct Ring[Coord](Array[Coord]) derive(Eq, @debug.Debug)
+pub fn[Coord : Coord2DTrait] Ring::new(Array[Coord]) -> Self[Coord]
+pub impl[Coord : Coord2DTrait] GeometryTrait for Ring[Coord]
+pub impl[Coord : Coord2DTrait] LineStringTrait for Ring[Coord]
+pub impl[Coord : Coord2DTrait] RingTrait for Ring[Coord]
+
+pub struct Triangle[Coord] {
+  a : Coord
+  b : Coord
+  c : Coord
+} derive(Eq, @debug.Debug)
+pub fn[Coord : Coord2DTrait] Triangle::new(Coord, Coord, Coord) -> Self[Coord]
+pub impl[Coord : Coord2DTrait] GeometryTrait for Triangle[Coord]
+pub impl[Coord : Coord2DTrait] PolygonTrait for Triangle[Coord]
+
+pub struct XY {
+  x : Double
+  y : Double
+} derive(Eq, @debug.Debug)
+pub fn XY::new(Double, Double) -> Self
+pub impl Add for XY
+pub impl Neg for XY
+pub impl Sub for XY
+pub impl Coord2DTrait for XY
+pub impl CoordTrait for XY
+
+pub struct XYZ {
+  x : Double
+  y : Double
+  z : Double
+} derive(Eq, @debug.Debug)
+pub fn XYZ::new(Double, Double, Double) -> Self
+pub impl Add for XYZ
+pub impl Neg for XYZ
+pub impl Sub for XYZ
+pub impl Coord2DTrait for XYZ
+pub impl Coord3DTrait for XYZ
+pub impl CoordTrait for XYZ
+
+// Type aliases
+
+// Traits
+pub(open) trait Coord2DTrait : CoordTrait {
+  x(Self) -> Double
+  y(Self) -> Double
+  xy(Self) -> XY = _
+  set_x(Self, Double) -> Self
+  set_y(Self, Double) -> Self
+}
+
+pub(open) trait Coord3DTrait : Coord2DTrait {
+  z(Self) -> Double
+  xyz(Self) -> XYZ = _
+  set_z(Self, Double) -> Self
+}
+
+pub(open) trait CoordTrait : Add + Sub + Neg + @debug.Debug {
+  mul(Self, Double) -> Self
+  div(Self, Double) -> Self
+  dot(Self, Self) -> Double
+}
+
+pub trait GeometryTrait : @debug.Debug {
+  coord_array(Self) -> Array[XY]
+  point_array(Self) -> Array[Point[XY]]
+  bbox(Self) -> Rect[XY] raise NonExistCoordError
+}
+
+pub trait LineStringTrait : GeometryTrait {
+  line_string(Self) -> LineString[XY]
+  line_array(Self) -> Array[Line[XY]]
+}
+
+pub trait LineTrait : GeometryTrait {
+  line(Self) -> Line[XY]
+  start(Self) -> XY
+  end(Self) -> XY
+}
+
+pub trait LngLatTrait : Coord2DTrait {
+  to_degrees(Self) -> Self
+  to_radians(Self) -> Self
+}
+
+pub trait MultiGeometryTrait : GeometryTrait {
+  geometry_array(Self) -> Array[&GeometryTrait]
+}
+pub fn &MultiGeometryTrait::coord_array(Self) -> Array[XY]
+
+pub trait PointTrait : GeometryTrait {
+  coord(Self) -> XY
+}
+pub fn &PointTrait::bbox(Self) -> Rect[XY]
+pub fn &PointTrait::coordArray(Self) -> Array[XY]
+
+pub trait PolygonTrait : GeometryTrait {
+  exterior(Self) -> Ring[XY]
+  interior_array(Self) -> Array[Ring[XY]]
+}
+pub fn &PolygonTrait::coordArray(Self) -> Array[XY]
+
+pub trait RingTrait : LineStringTrait {
+  ring(Self) -> Ring[XY]
+}
+

--- a/mbt/package/geo/src/type/point.mbt
+++ b/mbt/package/geo/src/type/point.mbt
@@ -15,7 +15,7 @@ pub fn &PointTrait::bbox(self : &PointTrait) -> BBox[XY] {
 }
 
 ///|
-pub struct Point[Coord](Coord) derive(Show, Eq)
+pub struct Point[Coord](Coord) derive(Debug, Eq)
 
 ///|
 #warnings("-unused_trait_bound")

--- a/mbt/package/geo/src/type/point.mbt.md
+++ b/mbt/package/geo/src/type/point.mbt.md
@@ -18,7 +18,9 @@ Represents a single point in space.
 ```mbt check
 ///|
 test {
-  inspect(Point::new(XY::new(1.0, 2.0)), content="Point({x: 1, y: 2})")
+  debug_inspect(Point::new(XY::new(1.0, 2.0)), content=(
+    #|Point({ x: 1, y: 2 })
+  ))
 }
 ```
 
@@ -29,7 +31,9 @@ test {
 ```mbt check
 ///|
 test {
-  inspect(Point::new(XY::new(3.0, 4.0)).coord(), content="{x: 3, y: 4}")
+  debug_inspect(Point::new(XY::new(3.0, 4.0)).coord(), content=(
+    #|{ x: 3, y: 4 }
+  ))
 }
 ```
 
@@ -41,7 +45,12 @@ test {
 ///|
 test {
   // let _xy =
-  inspect(Point::new(XY::new(1.0, 2.0)).coord_array(), content="[{x: 1, y: 2}]")
+  debug_inspect(
+    Point::new(XY::new(1.0, 2.0)).coord_array(),
+    content=(
+      #|[{ x: 1, y: 2 }]
+    ),
+  )
 }
 ```
 
@@ -52,9 +61,11 @@ test {
 ```mbt check
 ///|
 test {
-  inspect(
+  debug_inspect(
     Point::new(XY::new(1.0, 2.0)).bbox(),
-    content="{min: {x: 1, y: 2}, max: {x: 1, y: 2}}",
+    content=(
+      #|{ min: { x: 1, y: 2 }, max: { x: 1, y: 2 } }
+    ),
   )
 }
 ```

--- a/mbt/package/geo/src/type/polygon.mbt
+++ b/mbt/package/geo/src/type/polygon.mbt
@@ -13,7 +13,7 @@ pub fn &PolygonTrait::coordArray(self : &PolygonTrait) -> Array[XY] {
 pub struct Polygon[Coord] {
   exterior : Ring[Coord]
   interior_array : Array[Ring[Coord]]
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 ///|
 /// TODO: Closeしていることの検証が必要

--- a/mbt/package/geo/src/type/polygon.mbt.md
+++ b/mbt/package/geo/src/type/polygon.mbt.md
@@ -32,9 +32,14 @@ test {
     XY::new(0.0, 0.0),
   ])
   let polygon = Polygon::new(exterior)
-  inspect(
+  debug_inspect(
     polygon,
-    content="{exterior: Ring([{x: 0, y: 0}, {x: 10, y: 0}, {x: 0, y: 10}, {x: 0, y: 0}]), interior_array: []}",
+    content=(
+      #|{
+      #|  exterior: Ring([{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 0, y: 10 }, { x: 0, y: 0 }]),
+      #|  interior_array: [],
+      #|}
+    ),
   )
 }
 ```
@@ -59,9 +64,32 @@ test {
     XY::new(2.0, 2.0),
   ])
   let polygon = Polygon::new(exterior, interior_array=[hole])
-  inspect(
+  debug_inspect(
     polygon,
-    content="{exterior: Ring([{x: 0, y: 0}, {x: 10, y: 0}, {x: 10, y: 10}, {x: 0, y: 10}, {x: 0, y: 0}]), interior_array: [Ring([{x: 2, y: 2}, {x: 8, y: 2}, {x: 8, y: 8}, {x: 2, y: 8}, {x: 2, y: 2}])]}",
+    content=(
+      #|{
+      #|  exterior: Ring(
+      #|    [
+      #|      { x: 0, y: 0 },
+      #|      { x: 10, y: 0 },
+      #|      { x: 10, y: 10 },
+      #|      { x: 0, y: 10 },
+      #|      { x: 0, y: 0 },
+      #|    ],
+      #|  ),
+      #|  interior_array: [
+      #|    Ring(
+      #|      [
+      #|        { x: 2, y: 2 },
+      #|        { x: 8, y: 2 },
+      #|        { x: 8, y: 8 },
+      #|        { x: 2, y: 8 },
+      #|        { x: 2, y: 2 },
+      #|      ],
+      #|    ),
+      #|  ],
+      #|}
+    ),
   )
 }
 ```
@@ -80,9 +108,11 @@ test {
     XY::new(0.0, 0.0),
   ])
   let polygon = Polygon::new(exterior)
-  inspect(
+  debug_inspect(
     polygon.exterior(),
-    content="Ring([{x: 0, y: 0}, {x: 10, y: 0}, {x: 0, y: 10}, {x: 0, y: 0}])",
+    content=(
+      #|Ring([{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 0, y: 10 }, { x: 0, y: 0 }])
+    ),
   )
 }
 ```
@@ -106,7 +136,7 @@ test {
     XY::new(0.0, 0.0),
   ])
   let polygon = Polygon::new(exterior)
-  inspect(polygon.interior_array(), content="[]")
+  debug_inspect(polygon.interior_array(), content="[]")
 }
 ```
 
@@ -130,9 +160,21 @@ test {
     XY::new(2.0, 2.0),
   ])
   let polygon = Polygon::new(exterior, interior_array=[hole])
-  inspect(
+  debug_inspect(
     polygon.interior_array(),
-    content="[Ring([{x: 2, y: 2}, {x: 8, y: 2}, {x: 8, y: 8}, {x: 2, y: 8}, {x: 2, y: 2}])]",
+    content=(
+      #|[
+      #|  Ring(
+      #|    [
+      #|      { x: 2, y: 2 },
+      #|      { x: 8, y: 2 },
+      #|      { x: 8, y: 8 },
+      #|      { x: 2, y: 8 },
+      #|      { x: 2, y: 2 },
+      #|    ],
+      #|  ),
+      #|]
+    ),
   )
 }
 ```
@@ -150,9 +192,11 @@ test {
     XY::new(0.0, 10.0),
   ])
   let polygon = Polygon::new(exterior)
-  inspect(
+  debug_inspect(
     polygon.coord_array(),
-    content="[{x: 0, y: 0}, {x: 10, y: 0}, {x: 0, y: 10}]",
+    content=(
+      #|[{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 0, y: 10 }]
+    ),
   )
 }
 ```
@@ -175,7 +219,12 @@ test {
     XY::new(0.0, 10.0),
   ])
   let polygon = Polygon::new(exterior)
-  inspect(polygon.bbox(), content="{min: {x: 0, y: 0}, max: {x: 10, y: 10}}")
+  debug_inspect(
+    polygon.bbox(),
+    content=(
+      #|{ min: { x: 0, y: 0 }, max: { x: 10, y: 10 } }
+    ),
+  )
 }
 ```
 

--- a/mbt/package/geo/src/type/rect.mbt
+++ b/mbt/package/geo/src/type/rect.mbt
@@ -3,7 +3,7 @@
 pub struct Rect[Coord] {
   min : Coord
   max : Coord
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 ///|
 #warnings("-unused_trait_bound")

--- a/mbt/package/geo/src/type/rect.mbt.md
+++ b/mbt/package/geo/src/type/rect.mbt.md
@@ -20,7 +20,9 @@ test {
   let min = XY::new(0.0, 0.0)
   let max = XY::new(10.0, 20.0)
   let rect = Rect::new(min, max)
-  inspect(rect, content="{min: {x: 0, y: 0}, max: {x: 10, y: 20}}")
+  debug_inspect(rect, content=(
+    #|{ min: { x: 0, y: 0 }, max: { x: 10, y: 20 } }
+  ))
 }
 ```
 
@@ -34,9 +36,17 @@ test {
   let min = XY::new(0.0, 0.0)
   let max = XY::new(10.0, 20.0)
   let rect = Rect::new(min, max)
-  inspect(
+  debug_inspect(
     rect.exterior().coord_array(),
-    content="[{x: 0, y: 0}, {x: 0, y: 20}, {x: 10, y: 20}, {x: 10, y: 0}, {x: 0, y: 0}]",
+    content=(
+      #|[
+      #|  { x: 0, y: 0 },
+      #|  { x: 0, y: 20 },
+      #|  { x: 10, y: 20 },
+      #|  { x: 10, y: 0 },
+      #|  { x: 0, y: 0 },
+      #|]
+    ),
   )
 }
 ```
@@ -51,6 +61,8 @@ test {
   let min = XY::new(1.0, 1.0)
   let max = XY::new(5.0, 5.0)
   let rect = Rect::new(min, max)
-  inspect(rect.bbox(), content="{min: {x: 1, y: 1}, max: {x: 5, y: 5}}")
+  debug_inspect(rect.bbox(), content=(
+    #|{ min: { x: 1, y: 1 }, max: { x: 5, y: 5 } }
+  ))
 }
 ```

--- a/mbt/package/geo/src/type/ring.mbt
+++ b/mbt/package/geo/src/type/ring.mbt
@@ -4,7 +4,7 @@ pub trait RingTrait: LineStringTrait {
 }
 
 ///|
-pub struct Ring[Coord](Array[Coord]) derive(Show, Eq)
+pub struct Ring[Coord](Array[Coord]) derive(Debug, Eq)
 
 ///|
 #warnings("-unused_trait_bound")

--- a/mbt/package/geo/src/type/ring.mbt.md
+++ b/mbt/package/geo/src/type/ring.mbt.md
@@ -23,9 +23,11 @@ test {
   let c3 = XY::new(1.0, 1.0)
   let c4 = XY::new(0.0, 0.0)
   let ring = Ring::new([c1, c2, c3, c4])
-  inspect(
+  debug_inspect(
     ring,
-    content="Ring([{x: 0, y: 0}, {x: 1, y: 0}, {x: 1, y: 1}, {x: 0, y: 0}])",
+    content=(
+      #|Ring([{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }, { x: 0, y: 0 }])
+    ),
   )
 }
 ```
@@ -45,9 +47,11 @@ test {
   let c4 = XY::new(0.0, 0.0)
   let ring = Ring::new([c1, c2, c3, c4])
   let ls = ring.line_string()
-  inspect(
+  debug_inspect(
     ls,
-    content="LineString([{x: 0, y: 0}, {x: 1, y: 0}, {x: 1, y: 1}, {x: 0, y: 0}])",
+    content=(
+      #|LineString([{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }, { x: 0, y: 0 }])
+    ),
   )
 }
 ```
@@ -66,9 +70,11 @@ test {
   let c3 = XY::new(1.0, 1.0)
   let c4 = XY::new(0.0, 0.0)
   let ring = Ring::new([c1, c2, c3, c4])
-  inspect(
+  debug_inspect(
     ring.coord_array(),
-    content="[{x: 0, y: 0}, {x: 1, y: 0}, {x: 1, y: 1}, {x: 0, y: 0}]",
+    content=(
+      #|[{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }, { x: 0, y: 0 }]
+    ),
   )
 }
 ```
@@ -87,9 +93,11 @@ test {
   let c3 = XY::new(1.0, 1.0)
   let c4 = XY::new(0.0, 0.0)
   let r = Ring::new([c1, c2, c3, c4])
-  inspect(
+  debug_inspect(
     r.ring(),
-    content="Ring([{x: 0, y: 0}, {x: 1, y: 0}, {x: 1, y: 1}, {x: 0, y: 0}])",
+    content=(
+      #|Ring([{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }, { x: 0, y: 0 }])
+    ),
   )
 }
 ```

--- a/mbt/package/geo/src/type/triangle.mbt
+++ b/mbt/package/geo/src/type/triangle.mbt
@@ -3,7 +3,7 @@ pub struct Triangle[Coord] {
   a : Coord
   b : Coord
   c : Coord
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 ///|
 #warnings("-unused_trait_bound")

--- a/mbt/package/geo/src/type/triangle.mbt.md
+++ b/mbt/package/geo/src/type/triangle.mbt.md
@@ -21,7 +21,12 @@ test {
   let b = XY::new(1.0, 0.0)
   let c = XY::new(0.0, 1.0)
   let tri = Triangle::new(a, b, c)
-  inspect(tri, content="{a: {x: 0, y: 0}, b: {x: 1, y: 0}, c: {x: 0, y: 1}}")
+  debug_inspect(
+    tri,
+    content=(
+      #|{ a: { x: 0, y: 0 }, b: { x: 1, y: 0 }, c: { x: 0, y: 1 } }
+    ),
+  )
 }
 ```
 
@@ -36,9 +41,11 @@ test {
   let b = XY::new(1.0, 0.0)
   let c = XY::new(0.0, 1.0)
   let tri = Triangle::new(a, b, c)
-  inspect(
+  debug_inspect(
     tri.exterior().coord_array(),
-    content="[{x: 0, y: 0}, {x: 1, y: 0}, {x: 0, y: 1}, {x: 0, y: 0}]",
+    content=(
+      #|[{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 0, y: 1 }, { x: 0, y: 0 }]
+    ),
   )
 }
 ```
@@ -54,6 +61,8 @@ test {
   let b = XY::new(2.0, 1.0)
   let c = XY::new(1.0, 3.0)
   let tri = Triangle::new(a, b, c)
-  inspect(tri.bbox(), content="{min: {x: 0, y: 0}, max: {x: 2, y: 3}}")
+  debug_inspect(tri.bbox(), content=(
+    #|{ min: { x: 0, y: 0 }, max: { x: 2, y: 3 } }
+  ))
 }
 ```

--- a/mbt/package/geo/src/type/xy.mbt
+++ b/mbt/package/geo/src/type/xy.mbt
@@ -2,7 +2,7 @@
 pub struct XY {
   x : Double
   y : Double
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 ///|
 pub fn XY::new(x : Double, y : Double) -> XY {

--- a/mbt/package/geo/src/type/xy.mbt.md
+++ b/mbt/package/geo/src/type/xy.mbt.md
@@ -26,7 +26,9 @@ A 2D coordinate structure used as the fundamental building block for geometries.
 ///|
 test {
   let xy = XY::new(1.0, 2.0)
-  inspect(xy, content="{x: 1, y: 2}")
+  debug_inspect(xy, content=(
+    #|{ x: 1, y: 2 }
+  ))
 }
 ```
 
@@ -41,7 +43,9 @@ test {
 test {
   let a = XY::new(1.0, 2.0)
   let b = XY::new(3.0, 4.0)
-  inspect(a + b, content="{x: 4, y: 6}")
+  debug_inspect(a + b, content=(
+    #|{ x: 4, y: 6 }
+  ))
 }
 ```
 
@@ -56,7 +60,9 @@ test {
 test {
   let a = XY::new(3.0, 5.0)
   let b = XY::new(1.0, 2.0)
-  inspect(a - b, content="{x: 2, y: 3}")
+  debug_inspect(a - b, content=(
+    #|{ x: 2, y: 3 }
+  ))
 }
 ```
 
@@ -70,7 +76,9 @@ test {
 ///|
 test {
   let a = XY::new(1.0, -2.0)
-  inspect(-a, content="{x: -1, y: 2}")
+  debug_inspect(-a, content=(
+    #|{ x: -1, y: 2 }
+  ))
 }
 ```
 
@@ -84,7 +92,9 @@ test {
 ///|
 test {
   let a = XY::new(2.0, 3.0)
-  inspect(a.mul(2.0), content="{x: 4, y: 6}")
+  debug_inspect(a.mul(2.0), content=(
+    #|{ x: 4, y: 6 }
+  ))
 }
 ```
 
@@ -96,7 +106,9 @@ test {
 ///|
 test {
   let b = XY::new(4.0, 6.0)
-  inspect(b.div(2.0), content="{x: 2, y: 3}")
+  debug_inspect(b.div(2.0), content=(
+    #|{ x: 2, y: 3 }
+  ))
 }
 ```
 
@@ -110,7 +122,7 @@ test {
   let a = XY::new(1.0, 2.0)
   let b = XY::new(3.0, 4.0)
   // 1*3 + 2*4 = 11
-  inspect(a.dot(b), content="11")
+  debug_inspect(a.dot(b), content="11")
 }
 ```
 
@@ -124,7 +136,7 @@ test {
 ///|
 test {
   let xy = XY::new(3.0, 4.0)
-  inspect(xy.x(), content="3")
+  debug_inspect(xy.x(), content="3")
 }
 ```
 
@@ -136,7 +148,7 @@ test {
 ///|
 test {
   let xy = XY::new(3.0, 4.0)
-  inspect(xy.y(), content="4")
+  debug_inspect(xy.y(), content="4")
 }
 ```
 
@@ -149,9 +161,13 @@ test {
 test {
   let xy = XY::new(1.0, 2.0)
   let updated_x = xy.set_x(5.0)
-  inspect(updated_x, content="{x: 5, y: 2}")
+  debug_inspect(updated_x, content=(
+    #|{ x: 5, y: 2 }
+  ))
   // Ensure original is unchanged
-  inspect(xy, content="{x: 1, y: 2}")
+  debug_inspect(xy, content=(
+    #|{ x: 1, y: 2 }
+  ))
 }
 ```
 
@@ -164,8 +180,12 @@ test {
 test {
   let xy = XY::new(1.0, 2.0)
   let updated_y = xy.set_y(6.0)
-  inspect(updated_y, content="{x: 1, y: 6}")
+  debug_inspect(updated_y, content=(
+    #|{ x: 1, y: 6 }
+  ))
   // Ensure original is unchanged
-  inspect(xy, content="{x: 1, y: 2}")
+  debug_inspect(xy, content=(
+    #|{ x: 1, y: 2 }
+  ))
 }
 ```

--- a/mbt/package/geo/src/type/xyz.mbt
+++ b/mbt/package/geo/src/type/xyz.mbt
@@ -3,7 +3,7 @@ pub struct XYZ {
   x : Double
   y : Double
   z : Double
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 ///|
 pub fn XYZ::new(x : Double, y : Double, z : Double) -> XYZ {

--- a/mbt/package/geo/src/type/xyz.mbt.md
+++ b/mbt/package/geo/src/type/xyz.mbt.md
@@ -20,7 +20,9 @@ Provides a 3D coordinate structure `XYZ` and implements associated traits for ar
 ///|
 test {
   let p = XYZ::new(1.0, 2.0, 3.0)
-  inspect(p, content="{x: 1, y: 2, z: 3}")
+  debug_inspect(p, content=(
+    #|{ x: 1, y: 2, z: 3 }
+  ))
 }
 ```
 
@@ -33,7 +35,9 @@ test {
 test {
   let p1 = XYZ::new(1.0, 2.0, 3.0)
   let p2 = XYZ::new(4.0, 5.0, 6.0)
-  inspect(p1 + p2, content="{x: 5, y: 7, z: 9}")
+  debug_inspect(p1 + p2, content=(
+    #|{ x: 5, y: 7, z: 9 }
+  ))
 }
 ```
 
@@ -46,7 +50,9 @@ test {
 test {
   let p1 = XYZ::new(4.0, 5.0, 6.0)
   let p2 = XYZ::new(1.0, 2.0, 3.0)
-  inspect(p1 - p2, content="{x: 3, y: 3, z: 3}")
+  debug_inspect(p1 - p2, content=(
+    #|{ x: 3, y: 3, z: 3 }
+  ))
 }
 ```
 
@@ -58,7 +64,9 @@ test {
 ///|
 test {
   let p = XYZ::new(1.0, -2.0, 3.0)
-  inspect(-p, content="{x: -1, y: 2, z: -3}")
+  debug_inspect(-p, content=(
+    #|{ x: -1, y: 2, z: -3 }
+  ))
 }
 ```
 
@@ -72,7 +80,9 @@ test {
 ///|
 test {
   let p = XYZ::new(2.0, 4.0, 6.0)
-  inspect(p.mul(2.0), content="{x: 4, y: 8, z: 12}")
+  debug_inspect(p.mul(2.0), content=(
+    #|{ x: 4, y: 8, z: 12 }
+  ))
 }
 ```
 
@@ -84,7 +94,9 @@ test {
 ///|
 test {
   let p = XYZ::new(2.0, 4.0, 6.0)
-  inspect(p.div(2.0), content="{x: 1, y: 2, z: 3}")
+  debug_inspect(p.div(2.0), content=(
+    #|{ x: 1, y: 2, z: 3 }
+  ))
 }
 ```
 
@@ -98,7 +110,7 @@ test {
   let p1 = XYZ::new(1.0, 2.0, 3.0)
   let p2 = XYZ::new(4.0, 5.0, 6.0)
   // 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
-  inspect(p1.dot(p2), content="32")
+  debug_inspect(p1.dot(p2), content="32")
 }
 ```
 
@@ -112,7 +124,7 @@ test {
 ///|
 test {
   let p = XYZ::new(1.0, 2.0, 3.0)
-  inspect(p.x(), content="1")
+  debug_inspect(p.x(), content="1")
 }
 ```
 
@@ -124,7 +136,7 @@ test {
 ///|
 test {
   let p = XYZ::new(1.0, 2.0, 3.0)
-  inspect(p.y(), content="2")
+  debug_inspect(p.y(), content="2")
 }
 ```
 
@@ -136,7 +148,9 @@ test {
 ///|
 test {
   let p = XYZ::new(1.0, 2.0, 3.0)
-  inspect(p.set_x(4.0), content="{x: 4, y: 2, z: 3}")
+  debug_inspect(p.set_x(4.0), content=(
+    #|{ x: 4, y: 2, z: 3 }
+  ))
 }
 ```
 
@@ -148,7 +162,9 @@ test {
 ///|
 test {
   let p = XYZ::new(1.0, 2.0, 3.0)
-  inspect(p.set_y(5.0), content="{x: 1, y: 5, z: 3}")
+  debug_inspect(p.set_y(5.0), content=(
+    #|{ x: 1, y: 5, z: 3 }
+  ))
 }
 ```
 
@@ -162,7 +178,7 @@ test {
 ///|
 test {
   let p = XYZ::new(1.0, 2.0, 3.0)
-  inspect(p.z(), content="3")
+  debug_inspect(p.z(), content="3")
 }
 ```
 
@@ -174,6 +190,8 @@ test {
 ///|
 test {
   let p = XYZ::new(1.0, 2.0, 3.0)
-  inspect(p.set_z(4.0), content="{x: 1, y: 2, z: 4}")
+  debug_inspect(p.set_z(4.0), content=(
+    #|{ x: 1, y: 2, z: 4 }
+  ))
 }
 ```

--- a/mbt/package/geo/src/util/point_in_ring/pkg.generated.mbti
+++ b/mbt/package/geo/src/util/point_in_ring/pkg.generated.mbti
@@ -1,0 +1,24 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "totto2727/geo/util/point_in_ring"
+
+import {
+  "moonbitlang/core/debug",
+  "totto2727/geo/type",
+}
+
+// Values
+pub fn[Coord : @type.Coord2DTrait, Ring : @type.RingTrait] point_in_ring(Coord, Ring) -> PointInRingResult
+
+// Errors
+
+// Types and methods
+pub enum PointInRingResult {
+  Inside
+  Outside
+  Boundary
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/mbt/package/geo/src/util/point_in_ring/point_in_polygon.mbt
+++ b/mbt/package/geo/src/util/point_in_ring/point_in_polygon.mbt
@@ -3,7 +3,7 @@ pub enum PointInRingResult {
   Inside
   Outside
   Boundary
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 ///|
 pub fn[Coord : @type.Coord2DTrait, Ring : @type.RingTrait] point_in_ring(

--- a/mbt/package/geo/src/util/point_in_ring/point_in_polygon_test.mbt
+++ b/mbt/package/geo/src/util/point_in_ring/point_in_polygon_test.mbt
@@ -8,7 +8,7 @@ test "point_in_ring - inside" {
     @type.XY::new(1.0, 1.0),
   ])
   let result = point_in_ring(@type.XY::new(1.5, 1.5), ring)
-  inspect(result, content="Inside")
+  debug_inspect(result, content="Inside")
 }
 
 ///|
@@ -21,7 +21,7 @@ test "point_in_ring - boundary" {
     @type.XY::new(1.0, 1.0),
   ])
   let result = point_in_ring(@type.XY::new(1.0, 1.5), ring)
-  inspect(result, content="Boundary")
+  debug_inspect(result, content="Boundary")
 }
 
 ///|
@@ -34,7 +34,7 @@ test "point_in_ring - outside" {
     @type.XY::new(1.0, 1.0),
   ])
   let result = point_in_ring(@type.XY::new(3.0, 3.0), ring)
-  inspect(result, content="Outside")
+  debug_inspect(result, content="Outside")
 }
 
 ///|
@@ -47,7 +47,7 @@ test "point_in_ring - integer coords boundary" {
     @type.XY::new(1.0, 1.0),
   ])
   let result = point_in_ring(@type.XY::new(1.0, 1.0), ring)
-  inspect(result, content="Boundary")
+  debug_inspect(result, content="Boundary")
 }
 
 ///|
@@ -60,7 +60,7 @@ test "point_in_ring - integer coords outside 1" {
     @type.XY::new(1.0, 1.0),
   ])
   let result = point_in_ring(@type.XY::new(1.0, 0.0), ring)
-  inspect(result, content="Outside")
+  debug_inspect(result, content="Outside")
 }
 
 ///|
@@ -73,7 +73,7 @@ test "point_in_ring - integer coords outside 2" {
     @type.XY::new(1.0, 1.0),
   ])
   let result = point_in_ring(@type.XY::new(0.0, 1.0), ring)
-  inspect(result, content="Outside")
+  debug_inspect(result, content="Outside")
 }
 
 ///|
@@ -86,7 +86,7 @@ test "point_in_ring - integer coords outside 3" {
     @type.XY::new(1.0, 1.0),
   ])
   let result = point_in_ring(@type.XY::new(-0.5, -0.5), ring)
-  inspect(result, content="Outside")
+  debug_inspect(result, content="Outside")
 }
 
 ///|
@@ -99,7 +99,7 @@ test "point_in_ring - integer coords outside 4" {
     @type.XY::new(1.0, 1.0),
   ])
   let result = point_in_ring(@type.XY::new(0.5, -0.5), ring)
-  inspect(result, content="Outside")
+  debug_inspect(result, content="Outside")
 }
 
 ///|
@@ -112,5 +112,5 @@ test "point_in_ring - wrapped around" {
     @type.XY::new(-180.0, -90.0),
   ])
   let result = point_in_ring(@type.XY::new(140.43, 70.43), ring)
-  inspect(result, content="Inside")
+  debug_inspect(result, content="Inside")
 }

--- a/mbt/package/geo/src/util/point_in_ring/test/biggeom_test.mbt
+++ b/mbt/package/geo/src/util/point_in_ring/test/biggeom_test.mbt
@@ -4,7 +4,7 @@ test "point_in_ring - Switzerland inside" {
     @type.XY::new(8.0, 46.5),
     @fixture.switzerland,
   )
-  inspect(result, content="Inside")
+  debug_inspect(result, content="Inside")
 }
 
 ///|
@@ -13,7 +13,7 @@ test "point_in_ring - Switzerland outside" {
     @type.XY::new(8.0, 44.0),
     @fixture.switzerland,
   )
-  inspect(result, content="Outside")
+  debug_inspect(result, content="Outside")
 }
 
 ///|
@@ -22,7 +22,7 @@ test "point_in_ring - kinked Switzerland inside" {
     @type.XY::new(8.0, 46.5),
     @fixture.switzerlandKinked,
   )
-  inspect(result, content="Inside")
+  debug_inspect(result, content="Inside")
 }
 
 ///|
@@ -31,5 +31,5 @@ test "point_in_ring - kinked Switzerland outside" {
     @type.XY::new(8.0, 44.0),
     @fixture.switzerlandKinked,
   )
-  inspect(result, content="Outside")
+  debug_inspect(result, content="Outside")
 }

--- a/mbt/package/geo/src/util/point_in_ring/test/floating_point_simpler_test.mbt
+++ b/mbt/package/geo/src/util/point_in_ring/test/floating_point_simpler_test.mbt
@@ -11,7 +11,7 @@ test "point_in_ring - floating simple bottom edge" {
     @type.XY::new(1.511111111111, 1.111111111111),
     ring,
   )
-  inspect(result, content="Boundary")
+  debug_inspect(result, content="Boundary")
 }
 
 ///|
@@ -27,7 +27,7 @@ test "point_in_ring - floating simple top edge" {
     @type.XY::new(1.511111111111, 2.111111111111),
     ring,
   )
-  inspect(result, content="Boundary")
+  debug_inspect(result, content="Boundary")
 }
 
 ///|
@@ -43,7 +43,7 @@ test "point_in_ring - floating simple left edge" {
     @type.XY::new(1.111111111111, 1.511111111111),
     ring,
   )
-  inspect(result, content="Boundary")
+  debug_inspect(result, content="Boundary")
 }
 
 ///|
@@ -59,7 +59,7 @@ test "point_in_ring - floating simple right edge" {
     @type.XY::new(2.111111111111, 1.511111111111),
     ring,
   )
-  inspect(result, content="Boundary")
+  debug_inspect(result, content="Boundary")
 }
 
 ///|
@@ -75,7 +75,7 @@ test "point_in_ring - floating simple just inside left" {
     @type.XY::new(1.1111111111111, 1.511111111111),
     ring,
   )
-  inspect(result, content="Inside")
+  debug_inspect(result, content="Inside")
 }
 
 ///|
@@ -91,5 +91,5 @@ test "point_in_ring - floating simple just outside left" {
     @type.XY::new(1.111111111110, 1.511111111111),
     ring,
   )
-  inspect(result, content="Outside")
+  debug_inspect(result, content="Outside")
 }

--- a/mbt/package/geo/src/util/point_in_ring/test/floating_point_test.mbt
+++ b/mbt/package/geo/src/util/point_in_ring/test/floating_point_test.mbt
@@ -11,7 +11,7 @@ test "point_in_ring - floating point on edge" {
     @type.XY::new(-115.1752799, 36.0874526),
     ring,
   )
-  inspect(result, content="Boundary")
+  debug_inspect(result, content="Boundary")
 }
 
 ///|
@@ -27,7 +27,7 @@ test "point_in_ring - floating point on other edge" {
     @type.XY::new(-115.1752799, 36.0873974),
     ring,
   )
-  inspect(result, content="Boundary")
+  debug_inspect(result, content="Boundary")
 }
 
 ///|
@@ -43,7 +43,7 @@ test "point_in_ring - floating point on tweaked edge" {
     @type.XY::new(-115.1752799, 36.0874528),
     ring,
   )
-  inspect(result, content="Boundary")
+  debug_inspect(result, content="Boundary")
 }
 
 ///|
@@ -59,7 +59,7 @@ test "point_in_ring - floating point on other tweaked edge" {
     @type.XY::new(-115.1752799, 36.0873974),
     ring,
   )
-  inspect(result, content="Boundary")
+  debug_inspect(result, content="Boundary")
 }
 
 ///|
@@ -71,7 +71,7 @@ test "point_in_ring - complex case 1" {
     @type.XY::new(0.9500000000001119, 0.9500000000001101),
   ])
   let result = @point_in_ring.point_in_ring(@type.XY::new(16.8, 16.8), ring)
-  inspect(result, content="Outside")
+  debug_inspect(result, content="Outside")
 }
 
 ///|
@@ -85,5 +85,5 @@ test "point_in_ring - complex case 2" {
   ])
   let point = @type.XY::new(51.6476999685446, 32.65383784687809)
   let result = @point_in_ring.point_in_ring(point, ring)
-  inspect(result, content="Outside")
+  debug_inspect(result, content="Outside")
 }

--- a/mbt/package/geo/src/util/point_in_ring/test/internal/fixture/pkg.generated.mbti
+++ b/mbt/package/geo/src/util/point_in_ring/test/internal/fixture/pkg.generated.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "totto2727/geo/util/point_in_ring/test/internal/fixture"
+
+import {
+  "totto2727/geo/type",
+}
+
+// Values
+pub let switzerland : @type.Ring[@type.XY]
+
+pub let switzerlandKinked : @type.Ring[@type.XY]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/mbt/package/geo/src/util/point_in_ring/test/pkg.generated.mbti
+++ b/mbt/package/geo/src/util/point_in_ring/test/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "totto2727/geo/util/point_in_ring/test"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/mbt/package/geo/src/util/robust/moon.pkg
+++ b/mbt/package/geo/src/util/robust/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "totto2727/geo/type",
-  "moonbitlang/core/strconv",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/string",
 }
 
 import {

--- a/mbt/package/geo/src/util/robust/pkg.generated.mbti
+++ b/mbt/package/geo/src/util/robust/pkg.generated.mbti
@@ -1,0 +1,25 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "totto2727/geo/util/robust"
+
+import {
+  "moonbitlang/core/debug",
+  "totto2727/geo/type",
+}
+
+// Values
+pub fn[C : @type.Coord2DTrait] incircle(C, C, C, C) -> Double
+
+pub fn[C : @type.Coord3DTrait] insphere(C, C, C, C, C) -> Double
+
+pub fn[C : @type.Coord2DTrait] orient2d(C, C, C) -> Double
+
+pub fn[Coord3D : @type.Coord3DTrait] orient3d(Coord3D, Coord3D, Coord3D, Coord3D) -> Double
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/mbt/package/geo/src/util/robust/util_test.mbt
+++ b/mbt/package/geo/src/util/robust/util_test.mbt
@@ -13,7 +13,7 @@ fn parse_fixture_lines(content : String) -> Array[Array[Double]] {
     }
     let values : Array[Double] = []
     for i = 1; i < parts.length(); i = i + 1 {
-      values.push(@strconv.parse_double(parts[i])) catch {
+      values.push(@string.parse_double(parts[i])) catch {
         _ => break
       }
     }


### PR DESCRIPTION
## Summary

- MoonBit `0.1.20260427` deprecated `derive(Show)` (and `Show` as a debugging trait bound). Migrate the `@totto2727/geo` package end-to-end:
  - All `derive(Show, X)` / `derive(X, Show)` → `derive(Debug, X)` / `derive(X, Debug)`
  - Trait bounds `CoordTrait: ... + Show` and `GeometryTrait: Show` → `... + Debug` / `: Debug`
  - All `inspect(...)` calls in `*.mbt.md` / `*_test.mbt` → `debug_inspect(...)` (snapshots regenerated via `moon test --update`)
- Fix related deprecations surfaced after the toolchain bump:
  - `Array::to_array` → `Array::to_owned` (`type/line_string.mbt`)
  - `not(expr)` → `!expr` (`turf/boolean_point_in_polygon.mbt`)
  - `@strconv.parse_double` → `@string.parse_double` (`util/robust/util_test.mbt`, with import updated in `moon.pkg`)
- Aligns with `plugins/moonbit/skills/moonbit-bestpractice/SKILL.md` §3.5: *"Always derive `Debug` instead of `Show`. `Debug` replaces `Show` as the standard trait for structural formatting."*
- `pkg.generated.mbti` interface files added per the `mbt/package/geo/CLAUDE.md` workflow ("After making changes, always run `moon info && moon fmt` … check `.mbti` diffs to verify expected API changes").

Re-cut from `origin/main` to replace closed PR #99.

## Test plan

- [x] `moon check --target all --deny-warn` → 0 warnings, 0 errors on `wasm`, `wasm-gc`, `js`, `native`
- [x] `moon test --target {wasm,wasm-gc,js,native}` → 290 / 290 passed on each target
- [x] `moon info && moon fmt` no further pending diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)