### PR TITLE
refactor(oxlint-plugin): extract default rules into reusable preset

### DIFF
--- a/js/package/oxlint-plugin/package.json
+++ b/js/package/oxlint-plugin/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./preset": "./src/preset.ts"
   },
   "dependencies": {
     "@oxlint/plugins": "^1.59.0",

--- a/js/package/oxlint-plugin/src/preset.ts
+++ b/js/package/oxlint-plugin/src/preset.ts
@@ -1,0 +1,40 @@
+import { fileURLToPath } from 'node:url'
+
+type Severity = 'allow' | 'deny' | 'error' | 'off' | 'warn'
+type RuleEntry = Severity | [Severity, ...unknown[]]
+type RuleMap = Record<string, RuleEntry>
+
+interface Preset {
+  jsPlugins: string[]
+  overrides: { files: string[]; rules: RuleMap }[]
+  rules: RuleMap
+}
+
+const pluginPath = fileURLToPath(new URL('index.ts', import.meta.url))
+
+const preset: Preset = {
+  jsPlugins: [pluginPath],
+  overrides: [
+    {
+      files: ['**/*.test.ts', '**/*.spec.ts'],
+      rules: {
+        'rules/no-let': 'allow',
+        'rules/no-sync-decode': 'allow',
+        'rules/prefer-is-nullish': 'allow',
+        'rules/prefer-non-unknown-decode': 'allow',
+      },
+    },
+  ],
+  rules: {
+    'rules/force-predicate': 'error',
+    'rules/force-ts-extension': 'error',
+    'rules/no-eslint-disable-comments': 'error',
+    'rules/no-let': 'error',
+    'rules/no-option-tag-comparison': 'error',
+    'rules/no-sync-decode': 'error',
+    'rules/prefer-is-nullish': 'warn',
+    'rules/prefer-non-unknown-decode': 'warn',
+  },
+}
+
+export default preset

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import react from 'ultracite/oxlint/react'
 import remix from 'ultracite/oxlint/remix'
 import { defineConfig } from 'vite-plus'
 
+import oxlintPluginPreset from './js/package/oxlint-plugin/src/preset.ts'
+
 export default defineConfig({
   fmt: {
     arrowParens: 'always',
@@ -26,38 +28,18 @@ export default defineConfig({
     useTabs: false,
   },
   lint: {
-    extends: [core, react, remix],
+    extends: [core, react, remix, oxlintPluginPreset],
     ignorePatterns: ['**/__fixtures__/**', '**/.script/**', '**/skills/**'],
-    jsPlugins: ['./js/package/oxlint-plugin/src/index.ts'],
     options: {
       typeAware: true,
       typeCheck: true,
     },
-    overrides: [
-      {
-        files: ['**/*.test.ts', '**/*.spec.ts'],
-        rules: {
-          'rules/no-let': 'allow',
-          'rules/no-sync-decode': 'allow',
-          'rules/prefer-is-nullish': 'allow',
-          'rules/prefer-non-unknown-decode': 'allow',
-        },
-      },
-    ],
     rules: {
       'func-names': ['error', 'always', { generators: 'never' }],
       'import/extensions': ['error', 'always', { checkTypeImports: true, ignorePackages: true }],
       'jsx-no-new-function-as-prop': 'allow',
       'no-nodejs-modules': 'allow',
       'number-literal-case': 'allow',
-      'rules/force-predicate': 'error',
-      'rules/force-ts-extension': 'error',
-      'rules/no-eslint-disable-comments': 'error',
-      'rules/no-let': 'error',
-      'rules/no-option-tag-comparison': 'error',
-      'rules/no-sync-decode': 'error',
-      'rules/prefer-is-nullish': 'warn',
-      'rules/prefer-non-unknown-decode': 'warn',
       'typescript/promise-function-async': 'allow',
     },
   },


### PR DESCRIPTION
## Summary
- Add `@package/oxlint-plugin/preset` exporting an `OxlintConfig`-compatible preset that bundles the plugin's `jsPlugins` registration, default rule severities, and the `*.test.ts` / `*.spec.ts` override block.
- Wire it into `vite.config.ts` via `lint.extends`, the same shape ultracite uses for its `core` / `react` / `remix` presets.
- Plugin path is resolved through `import.meta.url`, so consumers don't have to mind the relative path from their own config file.

## Why
The root `vite.config.ts` was accumulating per-plugin rule entries and override blocks. Treating the local plugin like ultracite's presets keeps the root small and lets future rule additions land in the plugin without touching the root config.

## Test plan
- [x] `vp check` passes (no lint or type errors).
- [x] Verified `rules/no-let` still fires on `let foo = 1` in a regular `.ts` file.
- [x] Verified the `*.test.ts` override still suppresses `rules/no-let` (only the built-in `prefer-const` fires).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)