### PR TITLE
fix(c-plugin,bw): add node shebang to bin entry

### DIFF
--- a/js/app/bw/package.json
+++ b/js/app/bw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totto2727/bw",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/js/app/bw/src/bin.ts
+++ b/js/app/bw/src/bin.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { NodeRuntime, NodeServices } from '@effect/platform-node'
 import { Effect, Layer } from 'effect'
 import { Command } from 'effect/unstable/cli'

--- a/js/app/c-plugin/package.json
+++ b/js/app/c-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totto2727/c-plugin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/js/app/c-plugin/src/bin.ts
+++ b/js/app/c-plugin/src/bin.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { NodeServices } from '@effect/platform-node'
 import { Effect } from 'effect'
 import { Command } from 'effect/unstable/cli'


### PR DESCRIPTION
## Summary
- Add `#!/usr/bin/env node` shebang to `c-plugin` and `bw` `bin.ts`. Without it, the published `dist/bin.mjs` lacked an interpreter directive and could not be executed through `npx` / `pnpm exec`.
- Bump versions: `@totto2727/c-plugin` `0.1.2` → `0.1.3`, `@totto2727/bw` `0.1.1` → `0.1.2`.

## Test plan
- [x] `vp run --filter @totto2727/c-plugin --filter @totto2727/bw build` succeeds and `dist/bin.mjs` starts with `#!/usr/bin/env node`.
- [x] `vp run --cache --filter @totto2727/c-plugin --filter @totto2727/bw check` passes.
- [ ] After publish, verify `npx -y @totto2727/c-plugin --help` and `npx -y @totto2727/bw --help` run without "command not found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)