### PR TITLE
chore(ci): extract shared publish/setup composite actions

### DIFF
--- a/.github/actions/publish-jsr/action.yaml
+++ b/.github/actions/publish-jsr/action.yaml
@@ -12,4 +12,6 @@ runs:
     - name: Publish JSR package
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: vpx jsr publish
+      run: |
+        eval "$(devbox shellenv)"
+        vpx jsr publish

--- a/.github/actions/publish-jsr/action.yaml
+++ b/.github/actions/publish-jsr/action.yaml
@@ -1,0 +1,15 @@
+name: Publish to JSR
+description: Publish the package in working-directory to JSR via `vpx jsr publish`.
+
+inputs:
+  working-directory:
+    description: Directory containing the JSR package to publish.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Publish JSR package
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: vpx jsr publish

--- a/.github/actions/publish-npm/action.yaml
+++ b/.github/actions/publish-npm/action.yaml
@@ -19,6 +19,7 @@ runs:
       env:
         NPM_REGISTRY: ${{ inputs.registry }}
       run: |
+        eval "$(devbox shellenv)"
         ENCODED_NAME=$(node -p "encodeURIComponent(require('./package.json').name)")
         LOCAL_VERSION=$(node -p "require('./package.json').version")
         HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${NPM_REGISTRY}/${ENCODED_NAME}/${LOCAL_VERSION}")

--- a/.github/actions/publish-npm/action.yaml
+++ b/.github/actions/publish-npm/action.yaml
@@ -1,0 +1,30 @@
+name: Publish to npm
+description: Publish the package in working-directory to npm via pnpm, skipping if the version is already published.
+
+inputs:
+  working-directory:
+    description: Directory containing the package.json to publish.
+    required: true
+  registry:
+    description: npm registry URL.
+    required: false
+    default: https://registry.npmjs.org
+
+runs:
+  using: composite
+  steps:
+    - name: Publish npm package
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        NPM_REGISTRY: ${{ inputs.registry }}
+      run: |
+        ENCODED_NAME=$(node -p "encodeURIComponent(require('./package.json').name)")
+        LOCAL_VERSION=$(node -p "require('./package.json').version")
+        HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${NPM_REGISTRY}/${ENCODED_NAME}/${LOCAL_VERSION}")
+
+        if [ "$HTTP_STATUS" = "200" ]; then
+          echo "v${LOCAL_VERSION} already published. Skipping."
+        else
+          pnpm publish --registry "${NPM_REGISTRY}"
+        fi

--- a/.github/actions/setup-devbox/action.yaml
+++ b/.github/actions/setup-devbox/action.yaml
@@ -1,0 +1,10 @@
+name: Setup devbox
+description: Install devbox with cache enabled. Subsequent steps can activate the devbox environment via `eval "$(devbox shellenv)"` and then run the provided tools directly.
+
+runs:
+  using: composite
+  steps:
+    - name: Install devbox
+      uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+      with:
+        enable-cache: true

--- a/.github/actions/setup-typescript/action.yaml
+++ b/.github/actions/setup-typescript/action.yaml
@@ -1,5 +1,5 @@
 name: Setup TypeScript
-description: Install devbox (for pnpm and related dev tools), set up Vite+ (vp), and run vp install.
+description: Set up Vite+ (vp) and run `vp install`. Devbox must be installed beforehand via the setup-devbox action.
 
 inputs:
   node-version-file:
@@ -10,15 +10,16 @@ inputs:
     description: Enable setup-vp cache.
     required: false
     default: 'true'
+  install-args:
+    description: |
+      Extra arguments appended to `vp install`. Useful for narrowing the install graph
+      to a single workspace and its dependencies, e.g. `--filter @totto2727/bw...`.
+    required: false
+    default: ''
 
 runs:
   using: composite
   steps:
-    - name: Install devbox
-      uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
-      with:
-        enable-cache: true
-
     - name: Setup vp
       uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
       with:
@@ -27,4 +28,6 @@ runs:
 
     - name: Install packages
       shell: bash
-      run: vp install
+      env:
+        VP_INSTALL_ARGS: ${{ inputs.install-args }}
+      run: vp install $VP_INSTALL_ARGS

--- a/.github/actions/setup-typescript/action.yaml
+++ b/.github/actions/setup-typescript/action.yaml
@@ -30,4 +30,6 @@ runs:
       shell: bash
       env:
         VP_INSTALL_ARGS: ${{ inputs.install-args }}
-      run: vp install $VP_INSTALL_ARGS
+      run: |
+        eval "$(devbox shellenv)"
+        vp install $VP_INSTALL_ARGS

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/setup-devbox
+
       - uses: ./.github/actions/setup-moonbit
 
       - uses: ./.github/actions/setup-typescript
 
       - name: Run check, build, and test
-        run: devbox run -- 'vp run -r prebuild && vp run -r check && vp run -r test && vp run -r build'
+        shell: bash
+        run: |
+          eval "$(devbox shellenv)"
+          vp run -r prebuild
+          vp run -r check
+          vp run -r test
+          vp run -r build

--- a/.github/workflows/deploy-bw.yaml
+++ b/.github/workflows/deploy-bw.yaml
@@ -15,20 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/setup-devbox
+
       - uses: ./.github/actions/setup-typescript
+        with:
+          install-args: --filter @totto2727/bw...
 
       - name: Build @totto2727/bw
         run: vp run --filter @totto2727/bw build
 
       - name: Publish npm:@totto2727/bw
-        working-directory: js/app/bw
-        run: |
-          ENCODED_NAME=$(node -p "encodeURIComponent(require('./package.json').name)")
-          LOCAL_VERSION=$(node -p "require('./package.json').version")
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/${ENCODED_NAME}/${LOCAL_VERSION}")
-
-          if [ "$HTTP_STATUS" = "200" ]; then
-            echo "v${LOCAL_VERSION} already published. Skipping."
-          else
-            pnpm publish --registry https://registry.npmjs.org
-          fi
+        uses: ./.github/actions/publish-npm
+        with:
+          working-directory: js/app/bw

--- a/.github/workflows/deploy-bw.yaml
+++ b/.github/workflows/deploy-bw.yaml
@@ -22,7 +22,10 @@ jobs:
           install-args: --filter @totto2727/bw...
 
       - name: Build @totto2727/bw
-        run: vp run -t @totto2727/bw#build
+        shell: bash
+        run: |
+          eval "$(devbox shellenv)"
+          vp run -t @totto2727/bw#build
 
       - name: Publish npm:@totto2727/bw
         uses: ./.github/actions/publish-npm

--- a/.github/workflows/deploy-bw.yaml
+++ b/.github/workflows/deploy-bw.yaml
@@ -22,7 +22,7 @@ jobs:
           install-args: --filter @totto2727/bw...
 
       - name: Build @totto2727/bw
-        run: vp run --filter @totto2727/bw build
+        run: vp run -t @totto2727/bw#build
 
       - name: Publish npm:@totto2727/bw
         uses: ./.github/actions/publish-npm

--- a/.github/workflows/deploy-c-plugin.yaml
+++ b/.github/workflows/deploy-c-plugin.yaml
@@ -22,7 +22,7 @@ jobs:
           install-args: --filter @totto2727/c-plugin...
 
       - name: Build @totto2727/c-plugin
-        run: vp run --filter @totto2727/c-plugin build
+        run: vp run -t @totto2727/c-plugin#build
 
       - name: Publish npm:@totto2727/c-plugin
         uses: ./.github/actions/publish-npm

--- a/.github/workflows/deploy-c-plugin.yaml
+++ b/.github/workflows/deploy-c-plugin.yaml
@@ -15,20 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/setup-devbox
+
       - uses: ./.github/actions/setup-typescript
+        with:
+          install-args: --filter @totto2727/c-plugin...
 
       - name: Build @totto2727/c-plugin
         run: vp run --filter @totto2727/c-plugin build
 
       - name: Publish npm:@totto2727/c-plugin
-        working-directory: js/app/c-plugin
-        run: |
-          ENCODED_NAME=$(node -p "encodeURIComponent(require('./package.json').name)")
-          LOCAL_VERSION=$(node -p "require('./package.json').version")
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/${ENCODED_NAME}/${LOCAL_VERSION}")
-
-          if [ "$HTTP_STATUS" = "200" ]; then
-            echo "v${LOCAL_VERSION} already published. Skipping."
-          else
-            pnpm publish --registry https://registry.npmjs.org
-          fi
+        uses: ./.github/actions/publish-npm
+        with:
+          working-directory: js/app/c-plugin

--- a/.github/workflows/deploy-c-plugin.yaml
+++ b/.github/workflows/deploy-c-plugin.yaml
@@ -22,7 +22,10 @@ jobs:
           install-args: --filter @totto2727/c-plugin...
 
       - name: Build @totto2727/c-plugin
-        run: vp run -t @totto2727/c-plugin#build
+        shell: bash
+        run: |
+          eval "$(devbox shellenv)"
+          vp run -t @totto2727/c-plugin#build
 
       - name: Publish npm:@totto2727/c-plugin
         uses: ./.github/actions/publish-npm

--- a/.github/workflows/deploy-totto2727-fp.yaml
+++ b/.github/workflows/deploy-totto2727-fp.yaml
@@ -15,22 +15,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/setup-devbox
+
       - uses: ./.github/actions/setup-typescript
+        with:
+          install-args: --filter @totto2727/fp...
 
       - name: Publish jsr:@totto2727/fp
-        working-directory: js/package/fp
-        run: |
-          vpx jsr publish
+        uses: ./.github/actions/publish-jsr
+        with:
+          working-directory: js/package/fp
 
       - name: Publish npm:@totto2727/fp
-        working-directory: js/package/fp
-        run: |
-          ENCODED_NAME=$(node -p "encodeURIComponent(require('./package.json').name)")
-          LOCAL_VERSION=$(node -p "require('./package.json').version")
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/${ENCODED_NAME}/${LOCAL_VERSION}")
-
-          if [ "$HTTP_STATUS" = "200" ]; then
-            echo "v${LOCAL_VERSION} already published. Skipping."
-          else
-            pnpm publish --registry https://registry.npmjs.org
-          fi
+        uses: ./.github/actions/publish-npm
+        with:
+          working-directory: js/package/fp


### PR DESCRIPTION
## Summary

Refactor the GitHub Actions setup so the three publish workflows share their non-trivial steps and so devbox activation is opt-in per step instead of being forced via `devbox run`.

- New composite actions:
  - `.github/actions/publish-npm` — `pnpm publish` with skip-if-already-published behaviour, parameterised by `working-directory` and an optional `registry` (passed via env to avoid shell injection).
  - `.github/actions/publish-jsr` — thin wrapper around `vpx jsr publish`, parameterised by `working-directory`.
  - `.github/actions/setup-devbox` — split out of `setup-typescript`. Consumers run `eval "$(devbox shellenv)"` per step when they need devbox-provided binaries.
- `setup-typescript`:
  - Drop the inline devbox install (now done by `setup-devbox`).
  - Add `install-args` input so callers can do `--filter <pkg>...` and only install a target workspace plus its transitive workspace dependencies.
- `ci.yaml`: replace `devbox run -- '...'` with a multi-line step that starts with `eval "$(devbox shellenv)"`. This keeps `working-directory` honoured for any future per-step customisation.
- `deploy-bw.yaml` / `deploy-c-plugin.yaml` / `deploy-totto2727-fp.yaml`:
  - Use the new composite actions.
  - Pass `--filter <pkg>...` to `setup-typescript` to shrink the install graph during release.

## Test plan

- [ ] CI workflow `check` job passes on this branch.
- [ ] `deploy-*.yaml` workflows are not triggered on this PR (push-to-main only); rely on syntactic review and a follow-up post-merge run on `main` to confirm publishing still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)