### PR TITLE
chore(sandbox): split image into base / dev / monorepo layers

### DIFF
--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -13,13 +13,15 @@ env:
 
 jobs:
   deploy:
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -35,6 +37,7 @@ jobs:
           context: ./sandbox
           file: ./sandbox/sandbox-base.Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.IMAGE_PREFIX }}/sandbox-base:latest
 
       - name: Build and push sandbox-dev
@@ -43,6 +46,7 @@ jobs:
           context: ./sandbox
           file: ./sandbox/sandbox-dev.Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.IMAGE_PREFIX }}/sandbox-dev:latest
 
       - name: Build and push sandbox-monorepo
@@ -51,4 +55,5 @@ jobs:
           context: ./sandbox
           file: ./sandbox/sandbox-monorepo.Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.IMAGE_PREFIX }}/sandbox-monorepo:latest

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -1,0 +1,54 @@
+name: Deploy sandbox images
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/totto2727-org/monorepo
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push sandbox-base
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./sandbox
+          file: ./sandbox/sandbox-base.Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}/sandbox-base:latest
+
+      - name: Build and push sandbox-dev
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./sandbox
+          file: ./sandbox/sandbox-dev.Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}/sandbox-dev:latest
+
+      - name: Build and push sandbox-monorepo
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./sandbox
+          file: ./sandbox/sandbox-monorepo.Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}/sandbox-monorepo:latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,24 +7,32 @@ tasks:
       - list
     cmd: task --list-all
 
-  docker:build:sandbox:
+  docker:build:sandbox-base:
+    cmds:
+      - docker build --progress=plain -t ghcr.io/totto2727-org/monorepo/sandbox-base:latest -f ./sandbox/sandbox-base.Dockerfile ./sandbox
+
+  docker:build:sandbox-dev:
     deps:
       - docker:build:sandbox-base
     cmds:
-      - docker build --progress=plain -t ghcr.io/totto2727-org/monorepo/sandbox:latest -f ./sandbox/Dockerfile ./sandbox
+      - docker build --progress=plain -t ghcr.io/totto2727-org/monorepo/sandbox-dev:latest -f ./sandbox/sandbox-dev.Dockerfile ./sandbox
 
-  docker:build:sandbox-base:
+  docker:build:sandbox-monorepo:
+    deps:
+      - docker:build:sandbox-dev
     cmds:
-      - docker build --progress=plain -t ghcr.io/totto2727-org/monorepo/sandbox-base:latest -f ./docker/sandbox-base.Dockerfile ./docker
+      - docker build --progress=plain -t ghcr.io/totto2727-org/monorepo/sandbox-monorepo:latest -f ./sandbox/sandbox-monorepo.Dockerfile ./sandbox
 
   docker:push:
     deps:
-      - docker:build:sandbox
       - docker:build:sandbox-base
+      - docker:build:sandbox-dev
+      - docker:build:sandbox-monorepo
     cmds:
-      - docker push ghcr.io/totto2727-org/monorepo/sandbox:latest
       - docker push ghcr.io/totto2727-org/monorepo/sandbox-base:latest
+      - docker push ghcr.io/totto2727-org/monorepo/sandbox-dev:latest
+      - docker push ghcr.io/totto2727-org/monorepo/sandbox-monorepo:latest
 
   sandbox:create:
     cmds:
-      - uvx openshell sandbox create --from ghcr.io/totto2727-org/monorepo/sandbox:latest --policy sandbox/policy.yaml
+      - uvx openshell sandbox create --from ghcr.io/totto2727-org/monorepo/sandbox-monorepo:latest --policy sandbox/policy.yaml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,16 +23,6 @@ tasks:
     cmds:
       - docker build --progress=plain -t ghcr.io/totto2727-org/monorepo/sandbox-monorepo:latest -f ./sandbox/sandbox-monorepo.Dockerfile ./sandbox
 
-  docker:push:
-    deps:
-      - docker:build:sandbox-base
-      - docker:build:sandbox-dev
-      - docker:build:sandbox-monorepo
-    cmds:
-      - docker push ghcr.io/totto2727-org/monorepo/sandbox-base:latest
-      - docker push ghcr.io/totto2727-org/monorepo/sandbox-dev:latest
-      - docker push ghcr.io/totto2727-org/monorepo/sandbox-monorepo:latest
-
   sandbox:create:
     cmds:
       - uvx openshell sandbox create --from ghcr.io/totto2727-org/monorepo/sandbox-monorepo:latest --policy sandbox/policy.yaml

--- a/nix/macos-work/flake.lock
+++ b/nix/macos-work/flake.lock
@@ -59,12 +59,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1773930107,
-        "narHash": "sha256-iNpmFcq7345jkVvguIbo6DoukNBy4aSZ09i5qHj4UEk=",
-        "rev": "b7ee59ae8a38807095f4174d185dc8d6d862ae2a",
-        "revCount": 10,
+        "lastModified": 1778055827,
+        "narHash": "sha256-0TYOBQU/ZE0leb3j46IgZXKjhhyZC8hqbg1OpUKJupY=",
+        "rev": "d9b62e8ca4b8a536a43e97a2e7f16f28f78d6422",
+        "revCount": 11,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/totto2727-dotfiles/npm-packages/0.1.10%2Brev-b7ee59ae8a38807095f4174d185dc8d6d862ae2a/019d067a-eae5-793a-9361-6bbd3e7b81cd/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/totto2727-dotfiles/npm-packages/0.1.11%2Brev-d9b62e8ca4b8a536a43e97a2e7f16f28f78d6422/019dfc64-84eb-7033-ab47-aa04b7987a6b/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/macos-work/flake.nix
+++ b/nix/macos-work/flake.nix
@@ -81,6 +81,7 @@
 
                   home.packages =
                     (import ../share/packages.nix { inherit pkgs npm; })
+                    ++ (import ../share/packages-dev.nix { inherit pkgs; })
                     ++ (import ../share/packages-macos.nix { inherit pkgs; })
                     ++ (with pkgs; [
                       docker

--- a/nix/macos/flake.lock
+++ b/nix/macos/flake.lock
@@ -7,12 +7,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1775077333,
-        "narHash": "sha256-OXcxobt7lBkh1B8AjwreU+24myhtKpqeLfAeIyNLFY8=",
-        "rev": "49ca96b2714c5931e17401eff87f3edd42d2b0f2",
-        "revCount": 5877,
+        "lastModified": 1777851538,
+        "narHash": "sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8=",
+        "rev": "cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5",
+        "revCount": 5883,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.2511.5877%2Brev-49ca96b2714c5931e17401eff87f3edd42d2b0f2/019d4adb-bc83-7299-8dd4-8f298ac59af2/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.2511.5883%2Brev-cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5/019df1ad-8c7a-7e60-93a7-5e7f1a5d3c72/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -40,12 +40,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775002709,
-        "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
-        "rev": "bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e",
-        "revCount": 910305,
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "revCount": 912297,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.910305%2Brev-bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e/019d4a2b-10e7-79a8-b5ae-0c9d5245e157/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.912297%2Brev-0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5/019dfbf4-87c2-7d91-9a98-ccf8f9b548eb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/macos/flake.lock
+++ b/nix/macos/flake.lock
@@ -59,12 +59,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1773930107,
-        "narHash": "sha256-iNpmFcq7345jkVvguIbo6DoukNBy4aSZ09i5qHj4UEk=",
-        "rev": "b7ee59ae8a38807095f4174d185dc8d6d862ae2a",
-        "revCount": 10,
+        "lastModified": 1778055827,
+        "narHash": "sha256-0TYOBQU/ZE0leb3j46IgZXKjhhyZC8hqbg1OpUKJupY=",
+        "rev": "d9b62e8ca4b8a536a43e97a2e7f16f28f78d6422",
+        "revCount": 11,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/totto2727-dotfiles/npm-packages/0.1.10%2Brev-b7ee59ae8a38807095f4174d185dc8d6d862ae2a/019d067a-eae5-793a-9361-6bbd3e7b81cd/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/totto2727-dotfiles/npm-packages/0.1.11%2Brev-d9b62e8ca4b8a536a43e97a2e7f16f28f78d6422/019dfc64-84eb-7033-ab47-aa04b7987a6b/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/macos/flake.nix
+++ b/nix/macos/flake.nix
@@ -62,6 +62,7 @@
                   # Coding
                   "zed"
                   "orbstack"
+                  "warp"
                   # Game
                   "heroic"
                   # Utility

--- a/nix/macos/flake.nix
+++ b/nix/macos/flake.nix
@@ -93,6 +93,7 @@
 
                   home.packages =
                     (import ../share/packages.nix { inherit pkgs npm; })
+                    ++ (import ../share/packages-dev.nix { inherit pkgs; })
                     ++ (import ../share/packages-macos.nix { inherit pkgs; })
                     ++ (with pkgs; [
                       gopls

--- a/nix/nixos-server/Taskfile.yml
+++ b/nix/nixos-server/Taskfile.yml
@@ -26,3 +26,7 @@ tasks:
     cmds:
       - sudo nix flake update
       - sudo nixos-rebuild switch --flake .#nixos
+
+  tailscale:
+    cmds:
+      - sudo tailscale up --ssh --advertise-routes 172.32.0.0/12

--- a/nix/nixos-server/flake.lock
+++ b/nix/nixos-server/flake.lock
@@ -241,12 +241,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1773930107,
-        "narHash": "sha256-iNpmFcq7345jkVvguIbo6DoukNBy4aSZ09i5qHj4UEk=",
-        "rev": "b7ee59ae8a38807095f4174d185dc8d6d862ae2a",
-        "revCount": 10,
+        "lastModified": 1778055827,
+        "narHash": "sha256-0TYOBQU/ZE0leb3j46IgZXKjhhyZC8hqbg1OpUKJupY=",
+        "rev": "d9b62e8ca4b8a536a43e97a2e7f16f28f78d6422",
+        "revCount": 11,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/totto2727-dotfiles/npm-packages/0.1.10%2Brev-b7ee59ae8a38807095f4174d185dc8d6d862ae2a/019d067a-eae5-793a-9361-6bbd3e7b81cd/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/totto2727-dotfiles/npm-packages/0.1.11%2Brev-d9b62e8ca4b8a536a43e97a2e7f16f28f78d6422/019dfc64-84eb-7033-ab47-aa04b7987a6b/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/nixos-server/flake.nix
+++ b/nix/nixos-server/flake.nix
@@ -134,6 +134,7 @@
 
                 home.packages =
                   (import ../share/packages.nix { inherit pkgs npm; })
+                  ++ (import ../share/packages-dev.nix { inherit pkgs; })
                   ++ (with pkgs; [
                     docker
                   ]);

--- a/nix/nixos-server/flake.nix
+++ b/nix/nixos-server/flake.nix
@@ -51,6 +51,10 @@
 
               networking.hostName = "nixos";
               networking.networkmanager.enable = true;
+              boot.kernel.sysctl = {
+                "net.ipv4.ip_forward" = 1;
+                "net.ipv6.conf.all.forwarding" = 1;
+              };
 
               time.timeZone = "Asia/Tokyo";
 
@@ -93,6 +97,18 @@
               ];
               services.tailscale.enable = true;
 
+              virtualisation.docker = {
+                # Consider disabling the system wide Docker daemon
+                enable = false;
+                rootless = {
+                  enable = true;
+                  setSocketVariable = true;
+                  daemon.settings = {
+                    registry-mirrors = [ "https://mirror.gcr.io" ];
+                  };
+                };
+              };
+
               users.users.totto2727 = {
                 isNormalUser = true;
                 description = "totto2727";
@@ -108,36 +124,35 @@
               users.defaultUserShell = pkgs.zsh;
 
               programs.zsh.enable = true;
-              programs.firefox.enable = true;
               programs.ssh.enableAskPassword = false;
             }
             home-manager.nixosModules.home-manager
-            (
-              (import ../share/home-manager.nix { inherit username homedir; })
-              // {
-                home-manager.users.totto2727 = {
-                  home.stateVersion = stateVersion;
+            (import ../share/home-manager.nix { inherit username homedir stateVersion; })
+            {
+              home-manager.users.totto2727 = {
+                home.shell.enableZshIntegration = true;
 
-                  home.shell.enableZshIntegration = true;
+                home.packages =
+                  (import ../share/packages.nix { inherit pkgs npm; })
+                  ++ (with pkgs; [
+                    docker
+                  ]);
 
-                  home.packages = import ../share/packages.nix { inherit pkgs npm; };
+                programs = (import ../share/programs.nix) // {
+                  home-manager.enable = true;
+                  zsh = (import ../share/zsh.nix { inherit pkgs; }) // {
+                    initContent = ''
+                              eval "$(devbox global shellenv --init-hook)"
+                      	      '';
 
-                  programs = (import ../share/programs.nix) // {
-                    home-manager.enable = true;
-                    zsh = (import ../share/zsh.nix { inherit pkgs; }) // {
-                      initContent = ''
-                                eval "$(devbox global shellenv --init-hook)"
-                        	      '';
-
-                      shellAliases = (import ../share/shell-aliases.nix);
-                    };
+                    shellAliases = (import ../share/shell-aliases.nix);
                   };
-
-                  home.sessionVariables = import ../share/session-variables.nix;
-                  home.sessionPath = import ../share/session-path.nix;
                 };
-              }
-            )
+
+                home.sessionVariables = import ../share/session-variables.nix;
+                home.sessionPath = import ../share/session-path.nix;
+              };
+            }
           ];
         };
       };

--- a/nix/sandbox/flake.lock
+++ b/nix/sandbox/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "home-manager": {
       "inputs": {
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1773963144,
@@ -17,64 +19,33 @@
         "url": "https://flakehub.com/f/nix-community/home-manager/%2A"
       }
     },
-    "nix-darwin": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1773000227,
-        "narHash": "sha256-zm3ftUQw0MPumYi91HovoGhgyZBlM4o3Zy0LhPNwzXE=",
-        "owner": "nix-darwin",
-        "repo": "nix-darwin",
-        "rev": "da529ac9e46f25ed5616fd634079a5f3c579135f",
-        "type": "github"
-      },
-      "original": {
-        "id": "nix-darwin",
-        "type": "indirect"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765934234,
-        "narHash": "sha256-pJjWUzNnjbIAMIc5gRFUuKCDQ9S1cuh3b2hKgA7Mc4A=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "af84f9d270d404c17699522fab95bbf928a2d92f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1773964973,
-        "narHash": "sha256-NV/J+tTER0P5iJhUDL/8HO5MDjDceLQPRUYgdmy5wXw=",
-        "rev": "812b3986fd1568f7a858f97fcf425ad996ba7d25",
-        "revCount": 909676,
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "revCount": 912297,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.909676%2Brev-812b3986fd1568f7a858f97fcf425ad996ba7d25/019d117d-aaf2-7594-b15e-42a645b5cfe0/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.912297%2Brev-0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5/019dfbf4-87c2-7d91-9a98-ccf8f9b548eb/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2511"
       }
     },
     "npmpkgs": {
       "inputs": {
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1773930107,
-        "narHash": "sha256-iNpmFcq7345jkVvguIbo6DoukNBy4aSZ09i5qHj4UEk=",
-        "rev": "b7ee59ae8a38807095f4174d185dc8d6d862ae2a",
-        "revCount": 10,
+        "lastModified": 1778055827,
+        "narHash": "sha256-0TYOBQU/ZE0leb3j46IgZXKjhhyZC8hqbg1OpUKJupY=",
+        "rev": "d9b62e8ca4b8a536a43e97a2e7f16f28f78d6422",
+        "revCount": 11,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/totto2727-dotfiles/npm-packages/0.1.10%2Brev-b7ee59ae8a38807095f4174d185dc8d6d862ae2a/019d067a-eae5-793a-9361-6bbd3e7b81cd/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/totto2727-dotfiles/npm-packages/0.1.11%2Brev-d9b62e8ca4b8a536a43e97a2e7f16f28f78d6422/019dfc64-84eb-7033-ab47-aa04b7987a6b/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -84,8 +55,7 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
-        "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "npmpkgs": "npmpkgs"
       }
     }

--- a/nix/sandbox/flake.nix
+++ b/nix/sandbox/flake.nix
@@ -24,42 +24,54 @@
       username = "sandbox";
       homedir = "/sandbox";
       stateVersion = "25.11";
-      pkgs = import nixpkgs {
-        system = "arm64-linux";
-      };
-      npm = npmpkgs.lib.${pkgs.system}.npmPackage;
-    in
-    {
-      nixpkgs.config.allowUnfree = true;
-      homeConfigurations.${username} = home-manager.lib.homeManagerConfiguration {
-        inherit pkgs;
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
 
-        modules = [
-          ({
-            home.stateVersion = stateVersion;
-            home.username = username;
-            home.homeDirectory = homedir;
+      mkHomeConfiguration =
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+          };
+          npm = npmpkgs.lib.${system}.npmPackage;
+        in
+        home-manager.lib.homeManagerConfiguration {
+          inherit pkgs;
 
-            home.packages = import ../share/packages.nix { inherit pkgs npm; };
+          modules = [
+            ({
+              home.stateVersion = stateVersion;
+              home.username = username;
+              home.homeDirectory = homedir;
 
-            programs = (import ../share/programs.nix) // {
-              home-manager.enable = true;
-              zsh = (import ../share/zsh.nix { inherit pkgs; }) // {
-                initContent = ''
-                          eval "$(devbox global shellenv --init-hook)"
-                          [ -f "$HOME/.vite-plus/env" ] && . "$HOME/.vite-plus/env"
-                  	      '';
+              home.packages = import ../share/packages.nix { inherit pkgs npm; };
 
-                shellAliases = (import ../share/shell-aliases.nix) // {
-                  home-manager = "home-manager --flake ~/nix/sandbox#sandbox";
+              programs = (import ../share/programs.nix) // {
+                home-manager.enable = true;
+                zsh = (import ../share/zsh.nix { inherit pkgs; }) // {
+                  initContent = ''
+                            eval "$(devbox global shellenv --init-hook)"
+                            [ -f "$HOME/.vite-plus/env" ] && . "$HOME/.vite-plus/env"
+                    	      '';
+
+                  shellAliases = (import ../share/shell-aliases.nix) // {
+                    home-manager = "home-manager --flake ~/nix/sandbox#${username}-${system}";
+                  };
                 };
               };
-            };
 
-            home.sessionVariables = import ../share/session-variables.nix;
-            home.sessionPath = import ../share/session-path.nix;
-          })
-        ];
-      };
+              home.sessionVariables = import ../share/session-variables.nix;
+              home.sessionPath = import ../share/session-path.nix;
+            })
+          ];
+        };
+    in
+    {
+      homeConfigurations = nixpkgs.lib.genAttrs (map (s: "${username}-${s}") systems) (
+        name: mkHomeConfiguration (nixpkgs.lib.removePrefix "${username}-" name)
+      );
     };
 }

--- a/nix/share/packages-dev.nix
+++ b/nix/share/packages-dev.nix
@@ -1,0 +1,21 @@
+{ pkgs }:
+with pkgs;
+[
+  # Coding
+  lefthook
+  go-task
+  nixfmt-rfc-style
+  duckdb
+  # Runtime
+  nodejs
+  bun
+  deno
+  pnpm
+  typescript
+  typescript-language-server
+  python3
+  pyright
+  uv
+  go
+  rustup
+]

--- a/nix/share/packages.nix
+++ b/nix/share/packages.nix
@@ -17,38 +17,21 @@ with pkgs;
   # Coding
   devbox
   chezmoi
-  lefthook
-  go-task
-  nixfmt-rfc-style
-  duckdb
-  # Runtime
-  nodejs
-  bun
-  deno
-  pnpm
-  typescript
-  typescript-language-server
-  python3
-  pyright
-  uv
-  go
-  rustup
   # npm
   (npm {
-    name = "srt";
+    binName = "srt";
     packageName = "@anthropic-ai/sandbox-runtime";
-    additionalArgs = "";
   })
   (npm {
-    name = "skills";
+    binName = "skills";
     packageName = "skills";
   })
   (npm {
-    name = "pi";
+    binName = "pi";
     packageName = "@mariozechner/pi-coding-agent";
   })
   (npm {
-    name = "ctx7";
+    binName = "ctx7";
     packageName = "ctx7";
   })
 ]

--- a/nix/share/packages.nix
+++ b/nix/share/packages.nix
@@ -30,8 +30,4 @@ with pkgs;
     binName = "ctx7";
     packageName = "ctx7";
   })
-  (npm {
-    binName = "nono";
-    packageName = "nono";
-  })
 ]

--- a/nix/share/packages.nix
+++ b/nix/share/packages.nix
@@ -19,10 +19,6 @@ with pkgs;
   chezmoi
   # npm
   (npm {
-    binName = "srt";
-    packageName = "@anthropic-ai/sandbox-runtime";
-  })
-  (npm {
     binName = "skills";
     packageName = "skills";
   })
@@ -33,5 +29,9 @@ with pkgs;
   (npm {
     binName = "ctx7";
     packageName = "ctx7";
+  })
+  (npm {
+    binName = "nono";
+    packageName = "nono";
   })
 ]

--- a/nix/share/packages.nix
+++ b/nix/share/packages.nix
@@ -19,15 +19,19 @@ with pkgs;
   chezmoi
   # npm
   (npm {
-    binName = "skills";
-    packageName = "skills";
-  })
-  (npm {
     binName = "pi";
     packageName = "@mariozechner/pi-coding-agent";
   })
   (npm {
     binName = "ctx7";
     packageName = "ctx7";
+  })
+  (npm {
+    binName = "c-plugin";
+    packageName = "@totto2727/c-plugin";
+  })
+  (npm {
+    binName = "bw";
+    packageName = "@totto2727/bw";
   })
 ]

--- a/sandbox/sandbox-base.Dockerfile
+++ b/sandbox/sandbox-base.Dockerfile
@@ -58,7 +58,7 @@ EOF
 USER sandbox
 WORKDIR /sandbox
 ENV USER=sandbox
-ENV PATH="/sandbox/.nix-profile/bin:/sandbox/.moon/bin:$PATH"
+ENV PATH="/sandbox/.nix-profile/bin:/sandbox/.moon/bin:/sandbox/.vite-plus/bin:/sandbox/.local/bin:$PATH"
 
 ## Install the sandbox-user toolchain (nix + home-manager + moonbit + vp + claude).
 ## MoonBit's installer needs a node runtime and a rustup-managed Rust toolchain,

--- a/sandbox/sandbox-base.Dockerfile
+++ b/sandbox/sandbox-base.Dockerfile
@@ -4,7 +4,7 @@
 # https://github.com/jetify-com/devbox/blob/3ec20383af8deeb46c94972996d275b1593e63e2/internal/devbox/generate/tmpl/DevboxImageDockerfile
 # https://github.com/NVIDIA/OpenShell-Community/blob/6daeacdf199afdd49753ddd149a9c259921ab1a8/sandboxes/base/Dockerfile
 
-FROM ubuntu:26.04 AS base
+FROM ubuntu:26.04
 
 # Setup Nix
 ## Install dependencies
@@ -68,26 +68,3 @@ EOF
 ENV PATH="/sandbox/.nix-profile/bin:$PATH"
 
 ENTRYPOINT [ "/bin/bash" ]
-
-FROM base
-
-RUN <<EOF
-nix run home-manager/release-25.11 -- init --switch
-nix run nixpkgs#git clone https://github.com/totto2727-dotfiles/nix.git
-nix run nixpkgs#git clone https://github.com/totto2727-dotfiles/chezmoi.git
-home-manager switch --flake ~/nix/sandbox#sandbox
-EOF
-
-SHELL ["zsh", "-c"]
-
-RUN <<EOF
-rustup default stable
-curl -fsSL https://raw.githubusercontent.com/moonbitlang/moonbit-compiler/refs/heads/main/install.ts | node
-moon update
-curl -fsSL https://vite.plus | bash
-curl -fsSL https://claude.ai/install.sh | bash
-
-chezmoi apply --source ~/chezmoi
-EOF
-
-ENTRYPOINT [ "zsh" ]

--- a/sandbox/sandbox-base.Dockerfile
+++ b/sandbox/sandbox-base.Dockerfile
@@ -62,11 +62,13 @@ ENV PATH="/sandbox/.nix-profile/bin:/sandbox/.moon/bin:$PATH"
 
 ## Install the sandbox-user toolchain (nix + home-manager + moonbit + vp + claude).
 ## MoonBit's installer needs a node runtime and a rustup-managed Rust toolchain,
-## but `moon` itself ships as a self-contained native binary. We activate
-## rustup/nodejs ephemerally via `nix shell`, run the installer, drop the Rust
-## state, GC the temporary store paths, and only then run `moon update` /
-## `moon upgrade` — that doubles as a smoke test that moon is fully
-## bootstrap-capable without rust/node.
+## but `moon` itself is a self-bootstrapping native binary. We activate rustup
+## and nodejs ephemerally via `nix shell`, run the installer, then drop every
+## transient on-disk artifact (rustup/cargo/npm/XDG cache/tmp) and reclaim the
+## temporary nix-store paths via `nix-collect-garbage -d`. The trailing
+## `moon update` doubles as a smoke test that moon works without rust/node.
+## (`moon upgrade` is excluded — it's marked highly experimental and aborts
+## with "not a terminal" inside non-interactive Docker builds.)
 RUN <<EOF
 curl -fsSL https://nixos.org/nix/install | sh -s -- --no-daemon
 . ~/.nix-profile/etc/profile.d/nix.sh
@@ -77,15 +79,14 @@ nix shell nixpkgs#rustup nixpkgs#nodejs --command bash -c '
 rustup default stable
 curl -fsSL https://raw.githubusercontent.com/moonbitlang/moonbit-compiler/refs/heads/main/install.ts | node
 '
-rm -rf ~/.rustup ~/.cargo
 
 curl -fsSL https://vite.plus | bash
 curl -fsSL https://claude.ai/install.sh | bash
 
+rm -rf ~/.rustup ~/.cargo ~/.npm ~/.cache /tmp/*
 nix-collect-garbage -d
 
 moon update
-moon upgrade
 EOF
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/sandbox/sandbox-base.Dockerfile
+++ b/sandbox/sandbox-base.Dockerfile
@@ -72,4 +72,10 @@ RUN <<EOF
 nix run home-manager/release-25.11 -- init --switch
 EOF
 
+## Install vp / claude
+RUN <<EOF
+curl -fsSL https://vite.plus | bash
+curl -fsSL https://claude.ai/install.sh | bash
+EOF
+
 ENTRYPOINT [ "/bin/bash" ]

--- a/sandbox/sandbox-base.Dockerfile
+++ b/sandbox/sandbox-base.Dockerfile
@@ -58,17 +58,30 @@ EOF
 USER sandbox
 WORKDIR /sandbox
 ENV USER=sandbox
-ENV PATH="/sandbox/.nix-profile/bin:$PATH"
+ENV PATH="/sandbox/.nix-profile/bin:/sandbox/.moon/bin:$PATH"
 
-## Install Nix toolchain (nix + home-manager) and standalone CLIs (vp, claude)
+## Install the sandbox-user toolchain (nix + home-manager + moonbit + vp + claude).
+## MoonBit's installer requires a node runtime and a rustup-managed Rust toolchain,
+## but the resulting `moon` is a self-contained native binary, so we activate
+## rustup/nodejs ephemerally via `nix shell` and reclaim the temporary store
+## paths and Rust toolchain afterwards via `nix-collect-garbage -d`.
 RUN <<EOF
 curl -fsSL https://nixos.org/nix/install | sh -s -- --no-daemon
 . ~/.nix-profile/etc/profile.d/nix.sh
 
 nix run home-manager/release-25.11 -- init --switch
 
+nix shell nixpkgs#rustup nixpkgs#nodejs --command bash -c '
+rustup default stable
+curl -fsSL https://raw.githubusercontent.com/moonbitlang/moonbit-compiler/refs/heads/main/install.ts | node
+moon update
+'
+rm -rf ~/.rustup ~/.cargo
+
 curl -fsSL https://vite.plus | bash
 curl -fsSL https://claude.ai/install.sh | bash
+
+nix-collect-garbage -d
 EOF
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/sandbox/sandbox-base.Dockerfile
+++ b/sandbox/sandbox-base.Dockerfile
@@ -58,22 +58,15 @@ EOF
 USER sandbox
 WORKDIR /sandbox
 ENV USER=sandbox
+ENV PATH="/sandbox/.nix-profile/bin:$PATH"
 
-## Install Nix
+## Install Nix toolchain (nix + home-manager) and standalone CLIs (vp, claude)
 RUN <<EOF
 curl -fsSL https://nixos.org/nix/install | sh -s -- --no-daemon
 . ~/.nix-profile/etc/profile.d/nix.sh
-EOF
 
-ENV PATH="/sandbox/.nix-profile/bin:$PATH"
-
-## Install home-manager
-RUN <<EOF
 nix run home-manager/release-25.11 -- init --switch
-EOF
 
-## Install vp / claude
-RUN <<EOF
 curl -fsSL https://vite.plus | bash
 curl -fsSL https://claude.ai/install.sh | bash
 EOF

--- a/sandbox/sandbox-base.Dockerfile
+++ b/sandbox/sandbox-base.Dockerfile
@@ -67,4 +67,9 @@ EOF
 
 ENV PATH="/sandbox/.nix-profile/bin:$PATH"
 
+## Install home-manager
+RUN <<EOF
+nix run home-manager/release-25.11 -- init --switch
+EOF
+
 ENTRYPOINT [ "/bin/bash" ]

--- a/sandbox/sandbox-base.Dockerfile
+++ b/sandbox/sandbox-base.Dockerfile
@@ -61,10 +61,12 @@ ENV USER=sandbox
 ENV PATH="/sandbox/.nix-profile/bin:/sandbox/.moon/bin:$PATH"
 
 ## Install the sandbox-user toolchain (nix + home-manager + moonbit + vp + claude).
-## MoonBit's installer requires a node runtime and a rustup-managed Rust toolchain,
-## but the resulting `moon` is a self-contained native binary, so we activate
-## rustup/nodejs ephemerally via `nix shell` and reclaim the temporary store
-## paths and Rust toolchain afterwards via `nix-collect-garbage -d`.
+## MoonBit's installer needs a node runtime and a rustup-managed Rust toolchain,
+## but `moon` itself ships as a self-contained native binary. We activate
+## rustup/nodejs ephemerally via `nix shell`, run the installer, drop the Rust
+## state, GC the temporary store paths, and only then run `moon update` /
+## `moon upgrade` — that doubles as a smoke test that moon is fully
+## bootstrap-capable without rust/node.
 RUN <<EOF
 curl -fsSL https://nixos.org/nix/install | sh -s -- --no-daemon
 . ~/.nix-profile/etc/profile.d/nix.sh
@@ -74,7 +76,6 @@ nix run home-manager/release-25.11 -- init --switch
 nix shell nixpkgs#rustup nixpkgs#nodejs --command bash -c '
 rustup default stable
 curl -fsSL https://raw.githubusercontent.com/moonbitlang/moonbit-compiler/refs/heads/main/install.ts | node
-moon update
 '
 rm -rf ~/.rustup ~/.cargo
 
@@ -82,6 +83,9 @@ curl -fsSL https://vite.plus | bash
 curl -fsSL https://claude.ai/install.sh | bash
 
 nix-collect-garbage -d
+
+moon update
+moon upgrade
 EOF
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/sandbox/sandbox-base.Dockerfile
+++ b/sandbox/sandbox-base.Dockerfile
@@ -60,15 +60,6 @@ WORKDIR /sandbox
 ENV USER=sandbox
 ENV PATH="/sandbox/.nix-profile/bin:/sandbox/.moon/bin:/sandbox/.vite-plus/bin:/sandbox/.local/bin:$PATH"
 
-## Install the sandbox-user toolchain (nix + home-manager + moonbit + vp + claude).
-## MoonBit's installer needs a node runtime and a rustup-managed Rust toolchain,
-## but `moon` itself is a self-bootstrapping native binary. We activate rustup
-## and nodejs ephemerally via `nix shell`, run the installer, then drop every
-## transient on-disk artifact (rustup/cargo/npm/XDG cache/tmp) and reclaim the
-## temporary nix-store paths via `nix-collect-garbage -d`. The trailing
-## `moon update` doubles as a smoke test that moon works without rust/node.
-## (`moon upgrade` is excluded — it's marked highly experimental and aborts
-## with "not a terminal" inside non-interactive Docker builds.)
 RUN <<EOF
 curl -fsSL https://nixos.org/nix/install | sh -s -- --no-daemon
 . ~/.nix-profile/etc/profile.d/nix.sh
@@ -79,14 +70,13 @@ nix shell nixpkgs#rustup nixpkgs#nodejs --command bash -c '
 rustup default stable
 curl -fsSL https://raw.githubusercontent.com/moonbitlang/moonbit-compiler/refs/heads/main/install.ts | node
 '
+moon upgrade -f && moon update
 
 curl -fsSL https://vite.plus | bash
 curl -fsSL https://claude.ai/install.sh | bash
 
 rm -rf ~/.rustup ~/.cargo ~/.npm ~/.cache /tmp/*
 nix-collect-garbage -d
-
-moon update
 EOF
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/sandbox/sandbox-dev.Dockerfile
+++ b/sandbox/sandbox-dev.Dockerfile
@@ -4,15 +4,22 @@ FROM ghcr.io/totto2727-org/monorepo/sandbox-base:latest
 
 # Sparse-checkout `nix/share` + `nix/sandbox` from the monorepo (blobless partial
 # clone), then symlink ~/.local/share/sandbox-flake/nix to ~/nix so the flake alias
-# `~/nix/sandbox#sandbox` resolves.
+# `~/nix/sandbox#sandbox-<arch>` resolves.
+ARG TARGETARCH
 RUN <<EOF
+case "$TARGETARCH" in
+  amd64) NIX_SYSTEM=x86_64-linux ;;
+  arm64) NIX_SYSTEM=aarch64-linux ;;
+  *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;;
+esac
+
 git clone --filter=tree:0 --no-checkout https://github.com/totto2727-org/monorepo.git ~/.local/share/sandbox-flake
 cd ~/.local/share/sandbox-flake
 git sparse-checkout init --cone
 git sparse-checkout set nix/share nix/sandbox
 git checkout
 ln -s ~/.local/share/sandbox-flake/nix ~/nix
-home-manager switch --flake ~/nix/sandbox#sandbox
+home-manager switch --flake ~/nix/sandbox#sandbox-${NIX_SYSTEM}
 EOF
 
 RUN <<EOF

--- a/sandbox/sandbox-dev.Dockerfile
+++ b/sandbox/sandbox-dev.Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+FROM ghcr.io/totto2727-org/monorepo/sandbox-base:latest
+
+RUN <<EOF
+nix run home-manager/release-25.11 -- init --switch
+nix run nixpkgs#git clone https://github.com/totto2727-dotfiles/nix.git
+nix run nixpkgs#git clone https://github.com/totto2727-dotfiles/chezmoi.git
+home-manager switch --flake ~/nix/sandbox#sandbox
+EOF
+
+SHELL ["zsh", "-c"]
+
+RUN <<EOF
+rustup default stable
+curl -fsSL https://raw.githubusercontent.com/moonbitlang/moonbit-compiler/refs/heads/main/install.ts | node
+moon update
+curl -fsSL https://vite.plus | bash
+curl -fsSL https://claude.ai/install.sh | bash
+
+chezmoi apply --source ~/chezmoi
+EOF
+
+ENTRYPOINT [ "zsh" ]

--- a/sandbox/sandbox-dev.Dockerfile
+++ b/sandbox/sandbox-dev.Dockerfile
@@ -12,9 +12,6 @@ SHELL ["zsh", "-c"]
 
 RUN <<EOF
 rustup default stable
-curl -fsSL https://raw.githubusercontent.com/moonbitlang/moonbit-compiler/refs/heads/main/install.ts | node
-moon update
-
 chezmoi apply --source ~/chezmoi
 EOF
 

--- a/sandbox/sandbox-dev.Dockerfile
+++ b/sandbox/sandbox-dev.Dockerfile
@@ -3,15 +3,15 @@
 FROM ghcr.io/totto2727-org/monorepo/sandbox-base:latest
 
 # Sparse-checkout `nix/share` + `nix/sandbox` from the monorepo (blobless partial
-# clone), then symlink ~/monorepo/nix to ~/nix so the flake alias
+# clone), then symlink ~/.local/share/sandbox-flake/nix to ~/nix so the flake alias
 # `~/nix/sandbox#sandbox` resolves.
 RUN <<EOF
-git clone --filter=tree:0 --no-checkout https://github.com/totto2727-org/monorepo.git ~/monorepo
-cd ~/monorepo
+git clone --filter=tree:0 --no-checkout https://github.com/totto2727-org/monorepo.git ~/.local/share/sandbox-flake
+cd ~/.local/share/sandbox-flake
 git sparse-checkout init --cone
 git sparse-checkout set nix/share nix/sandbox
 git checkout
-ln -s ~/monorepo/nix ~/nix
+ln -s ~/.local/share/sandbox-flake/nix ~/nix
 home-manager switch --flake ~/nix/sandbox#sandbox
 EOF
 

--- a/sandbox/sandbox-dev.Dockerfile
+++ b/sandbox/sandbox-dev.Dockerfile
@@ -2,17 +2,23 @@
 
 FROM ghcr.io/totto2727-org/monorepo/sandbox-base:latest
 
+# Sparse-checkout `nix/share` + `nix/sandbox` from the monorepo (blobless partial
+# clone), then symlink ~/monorepo/nix to ~/nix so the flake alias
+# `~/nix/sandbox#sandbox` resolves.
 RUN <<EOF
-nix run nixpkgs#git clone https://github.com/totto2727-dotfiles/nix.git
-nix run nixpkgs#git clone https://github.com/totto2727-dotfiles/chezmoi.git
+git clone --filter=blob:none --no-checkout https://github.com/totto2727-org/monorepo.git ~/monorepo
+cd ~/monorepo
+git sparse-checkout init --cone
+git sparse-checkout set nix/share nix/sandbox
+git checkout
+ln -s ~/monorepo/nix ~/nix
 home-manager switch --flake ~/nix/sandbox#sandbox
 EOF
 
+RUN git clone https://github.com/totto2727-dotfiles/chezmoi.git ~/chezmoi
+
 SHELL ["zsh", "-c"]
 
-RUN <<EOF
-rustup default stable
-chezmoi apply --source ~/chezmoi
-EOF
+RUN chezmoi apply --source ~/chezmoi
 
 ENTRYPOINT [ "zsh" ]

--- a/sandbox/sandbox-dev.Dockerfile
+++ b/sandbox/sandbox-dev.Dockerfile
@@ -14,8 +14,6 @@ RUN <<EOF
 rustup default stable
 curl -fsSL https://raw.githubusercontent.com/moonbitlang/moonbit-compiler/refs/heads/main/install.ts | node
 moon update
-curl -fsSL https://vite.plus | bash
-curl -fsSL https://claude.ai/install.sh | bash
 
 chezmoi apply --source ~/chezmoi
 EOF

--- a/sandbox/sandbox-dev.Dockerfile
+++ b/sandbox/sandbox-dev.Dockerfile
@@ -6,7 +6,7 @@ FROM ghcr.io/totto2727-org/monorepo/sandbox-base:latest
 # clone), then symlink ~/monorepo/nix to ~/nix so the flake alias
 # `~/nix/sandbox#sandbox` resolves.
 RUN <<EOF
-git clone --filter=blob:none --no-checkout https://github.com/totto2727-org/monorepo.git ~/monorepo
+git clone --filter=tree:0 --no-checkout https://github.com/totto2727-org/monorepo.git ~/monorepo
 cd ~/monorepo
 git sparse-checkout init --cone
 git sparse-checkout set nix/share nix/sandbox
@@ -15,10 +15,11 @@ ln -s ~/monorepo/nix ~/nix
 home-manager switch --flake ~/nix/sandbox#sandbox
 EOF
 
-RUN git clone https://github.com/totto2727-dotfiles/chezmoi.git ~/chezmoi
+RUN <<EOF
+git clone https://github.com/totto2727-dotfiles/chezmoi.git ~/chezmoi
+chezmoi apply --source ~/chezmoi
+EOF
 
 SHELL ["zsh", "-c"]
-
-RUN chezmoi apply --source ~/chezmoi
 
 ENTRYPOINT [ "zsh" ]

--- a/sandbox/sandbox-dev.Dockerfile
+++ b/sandbox/sandbox-dev.Dockerfile
@@ -3,7 +3,6 @@
 FROM ghcr.io/totto2727-org/monorepo/sandbox-base:latest
 
 RUN <<EOF
-nix run home-manager/release-25.11 -- init --switch
 nix run nixpkgs#git clone https://github.com/totto2727-dotfiles/nix.git
 nix run nixpkgs#git clone https://github.com/totto2727-dotfiles/chezmoi.git
 home-manager switch --flake ~/nix/sandbox#sandbox

--- a/sandbox/sandbox-monorepo.Dockerfile
+++ b/sandbox/sandbox-monorepo.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/totto2727-org/monorepo/sandbox-base:latest
+FROM ghcr.io/totto2727-org/monorepo/sandbox-dev:latest
 
 SHELL ["zsh", "-c"]
 

--- a/sandbox/sandbox-monorepo.Dockerfile
+++ b/sandbox/sandbox-monorepo.Dockerfile
@@ -8,12 +8,12 @@ COPY policy.yaml /etc/openshell/policy.yaml
 
 RUN <<EOF
 export GIT_CONFIG_GLOBAL=/dev/null
-git clone https://github.com/totto2727-org/monorepo.git
-cd monorepo
+git clone https://github.com/totto2727-org/monorepo.git ~/monorepo
+cd ~/monorepo
 direnv allow
-devbox shell
-vp i
-vp run -r prebuild
+devbox install
+devbox run vp i
+devbox run vp run -r setup
 EOF
 
 WORKDIR /sandbox/monorepo

--- a/sandbox/sandbox-monorepo.Dockerfile
+++ b/sandbox/sandbox-monorepo.Dockerfile
@@ -10,10 +10,14 @@ RUN <<EOF
 export GIT_CONFIG_GLOBAL=/dev/null
 git clone https://github.com/totto2727-org/monorepo.git ~/monorepo
 cd ~/monorepo
+
 devbox install
+eval "$(devbox shellenv)"
 direnv allow
-devbox run vp i
-devbox run vp run workspace:setup
+
+vp config
+vp i
+vp run workspace:setup
 EOF
 
 WORKDIR /sandbox/monorepo

--- a/sandbox/sandbox-monorepo.Dockerfile
+++ b/sandbox/sandbox-monorepo.Dockerfile
@@ -10,10 +10,10 @@ RUN <<EOF
 export GIT_CONFIG_GLOBAL=/dev/null
 git clone https://github.com/totto2727-org/monorepo.git ~/monorepo
 cd ~/monorepo
-direnv allow
 devbox install
+direnv allow
 devbox run vp i
-devbox run vp run -r setup
+devbox run vp run workspace:setup
 EOF
 
 WORKDIR /sandbox/monorepo

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,15 +60,22 @@ export default defineConfig({
       },
       'workspace:build': {
         command: 'vp run -r build',
+        dependsOn: ['workspace:setup'],
       },
       'workspace:check': {
         command: 'vp run -r check',
+        dependsOn: ['workspace:setup'],
       },
       'workspace:fix': {
         command: 'vp run -r fix',
+        dependsOn: ['workspace:setup'],
+      },
+      'workspace:setup': {
+        command: 'vp run -r setup',
       },
       'workspace:test': {
         command: 'vp run -r test',
+        dependsOn: ['workspace:setup'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- Split the monolithic sandbox Dockerfile into three layered images so the base toolchain, developer config, and project bootstrap can be cached and rebuilt independently.
- Colocate everything under `sandbox/`: `sandbox-base.Dockerfile` moves out of `docker/`, and the old combined `sandbox/Dockerfile` is replaced by `sandbox-monorepo.Dockerfile`.
- Update `Taskfile.yml` to a 3-stage build/push chain; `sandbox:create` now boots from `sandbox-monorepo:latest`.

### New image layout
| Image | Dockerfile | Contents |
| --- | --- | --- |
| `sandbox-base` | `sandbox/sandbox-base.Dockerfile` | ubuntu + apt deps + sandbox/supervisor users + Nix install (no configs) |
| `sandbox-dev` | `sandbox/sandbox-dev.Dockerfile` | home-manager + dotfiles (nix/chezmoi) + rustup/moon/vp/claude + chezmoi apply |
| `sandbox-monorepo` | `sandbox/sandbox-monorepo.Dockerfile` | monorepo clone + devbox shell + `vp i` / `vp run -r prebuild` + `policy.yaml` |

## Test plan
- [ ] `task docker:build:sandbox-base`
- [ ] `task docker:build:sandbox-dev`
- [ ] `task docker:build:sandbox-monorepo`
- [ ] `task sandbox:create` boots a sandbox from `sandbox-monorepo:latest`