### PR TITLE
ci(actions): bump pinned actions to latest, drop Node 20 runtime

### DIFF
--- a/.github/actions/docker-build-by-digest/action.yml
+++ b/.github/actions/docker-build-by-digest/action.yml
@@ -47,7 +47,7 @@ runs:
         mkdir -p /tmp/digests
         touch "/tmp/digests/${DIGEST#sha256:}"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: /tmp/digests/*

--- a/.github/actions/docker-merge-manifests/action.yml
+++ b/.github/actions/docker-merge-manifests/action.yml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: /tmp/digests
         pattern: ${{ inputs.artifact-pattern }}

--- a/.github/actions/setup-devbox/action.yaml
+++ b/.github/actions/setup-devbox/action.yaml
@@ -5,6 +5,6 @@ runs:
   using: composite
   steps:
     - name: Install devbox
-      uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+      uses: jetify-com/devbox-install-action@8c6a66ed6273138b1915457069de78cb52fe3bd7 # v0.15.0
       with:
         enable-cache: true

--- a/.github/actions/setup-moonbit/action.yaml
+++ b/.github/actions/setup-moonbit/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install moonbit
-      uses: hustcer/setup-moonbit@e9b0a3082767ae669bf7588992ae3ba9eac09baa # v1.19
+      uses: hustcer/setup-moonbit@90ea2eec0b33fff99a2a1d2825d723deb31eb621 # v1.20
       env:
         GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/actions/setup-typescript/action.yaml
+++ b/.github/actions/setup-typescript/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Setup vp
-      uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
+      uses: voidzero-dev/setup-vp@4f5aa3e38c781f1b01e78fb9255527cee8a6efa6 # v1.8.0
       with:
         node-version-file: ${{ inputs.node-version-file }}
         cache: ${{ inputs.cache }}


### PR DESCRIPTION
## Summary
GitHub deprecates Node.js 20 actions on **June 2nd, 2026** (warning surfaced on the latest \`deploy-sandbox\` run). This PR bumps the affected artifact actions to their Node 24 major versions and pulls the rest of the external action pins forward to latest at the same time.

| action | before | after |
| --- | --- | --- |
| \`actions/upload-artifact\` | v4 | **v7.0.1** |
| \`actions/download-artifact\` | v4 | **v8.0.1** |
| \`hustcer/setup-moonbit\` | v1.19 | **v1.20** |
| \`jetify-com/devbox-install-action\` | v0.14.0 | **v0.15.0** |
| \`voidzero-dev/setup-vp\` | v1.6.0 | **v1.8.0** |

\`actions/checkout\`, \`docker/build-push-action\`, \`docker/login-action\`, \`docker/setup-buildx-action\` are already at latest.

All pins remain SHA-locked with a trailing \`# vX.Y.Z\` comment, matching the existing convention.

## Notes on potential breakage
- \`upload-artifact\` v5/v6/v7: Node 24 migration + new \`archive: false\` opt-in for direct uploads. Our usage (\`name\`, \`path\`, \`if-no-files-found\`, \`retention-days\`) is unchanged.
- \`download-artifact\` v5/v6/v7/v8: Node 24 migration + hash mismatch now errors by default. Our usage (\`pattern\`, \`merge-multiple\`) is unchanged; the hash check is intra-run so should never mismatch.
- \`setup-moonbit\`/\`devbox-install-action\`/\`setup-vp\` are minor bumps; no breaking changes called out in upstream release notes for our inputs.

## Test plan
- [ ] \`gh workflow run deploy-sandbox.yaml --ref ci/upgrade-action-versions\` (exercises \`actions/upload-artifact\` and \`actions/download-artifact\` via the composite actions)
- [ ] CI on this PR exercises \`setup-devbox\` / \`setup-moonbit\` / \`setup-typescript\` indirectly

🤖 Generated with [Claude Code](https://claude.com/claude-code)