### PR TITLE
ci: switch setup-moonbit to fork for full-hash pinning

### DIFF
--- a/.github/actions/setup-moonbit/action.yaml
+++ b/.github/actions/setup-moonbit/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install moonbit
-      uses: hustcer/setup-moonbit@90ea2eec0b33fff99a2a1d2825d723deb31eb621 # v1.20
+      uses: totto2727/setup-moonbit@fd52b0c75e10e5e9bdb9e17d8dedc520e93d1bd0 # fork of hustcer/setup-moonbit
       env:
         GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary

Replace `hustcer/setup-moonbit` with the `totto2727/setup-moonbit` fork to enable repository-wide full-commit-hash pinning for GitHub Actions.

The upstream `hustcer/setup-moonbit` uses version-based references internally, which prevents enabling strict hash-pinning at the repository level. The fork addresses this so all Actions can be pinned to exact commit hashes.

## Changes

- `.github/actions/setup-moonbit/action.yaml`: Switch `uses` from `hustcer/setup-moonbit@90ea2ee...` to `totto2727/setup-moonbit@fd52b0c7...` (full commit hash)