### PR TITLE
feat(nix): migrate MCP wrapper scripts from chezmoi to Nix

### DIFF
--- a/nix/sandbox/flake.nix
+++ b/nix/sandbox/flake.nix
@@ -47,7 +47,9 @@
               home.username = username;
               home.homeDirectory = homedir;
 
-              home.packages = import ../share/packages.nix { inherit pkgs npm; };
+              home.packages =
+                (import ../share/packages.nix { inherit pkgs npm; })
+                ++ (import ../share/packages-scripts.nix { inherit pkgs; }).sandbox;
 
               programs = (import ../share/programs.nix) // {
                 home-manager.enable = true;

--- a/nix/share/packages-macos.nix
+++ b/nix/share/packages-macos.nix
@@ -1,5 +1,9 @@
 { pkgs }:
+let
+  mcp = import ./packages-scripts.nix { inherit pkgs; };
+in
 [
   pkgs.pinentry_mac
   pkgs.kanata-with-cmd
 ]
+++ mcp.full

--- a/nix/share/packages-scripts.nix
+++ b/nix/share/packages-scripts.nix
@@ -1,0 +1,130 @@
+{ pkgs }:
+
+let
+  inherit (pkgs) writeShellScriptBin;
+
+  # --- wrappers with pass-cli (full) ---
+
+  full-zai-mcp-server = writeShellScriptBin "zai-mcp-server" ''
+    export Z_AI_API_KEY="$(pass-cli get z-ai/api-key --quiet -f password)"
+    export Z_AI_MODE="ZAI"
+    exec ${pkgs.bun}/bin/bunx -y @z_ai/mcp-server "$@"
+  '';
+
+  full-zread-mcp = writeShellScriptBin "zread-mcp" ''
+    export Z_AI_API_KEY="$(pass-cli get z-ai/api-key --quiet -f password)"
+    exec ${pkgs.uv}/bin/uvx mcp-proxy --transport streamablehttp \
+      --headers Authorization "Bearer $Z_AI_API_KEY" \
+      https://api.z.ai/api/mcp/zread/mcp "$@"
+  '';
+
+  full-brave-search-mcp = writeShellScriptBin "brave-search-mcp" ''
+    export BRAVE_API_KEY="$(pass-cli get brave-search/api-key --quiet -f password)"
+    exec ${pkgs.bun}/bin/bunx -y @brave/brave-search-mcp-server "$@"
+  '';
+
+  full-web-reader-mcp = writeShellScriptBin "web-reader-mcp" ''
+    export Z_AI_API_KEY="$(pass-cli get z-ai/api-key --quiet -f password)"
+    exec ${pkgs.uv}/bin/uvx mcp-proxy --transport streamablehttp \
+      --headers Authorization "Bearer $Z_AI_API_KEY" \
+      https://api.z.ai/api/mcp/web_reader/mcp "$@"
+  '';
+
+  full-d = writeShellScriptBin "d" ''
+    export Z_AI_API_KEY="$(pass-cli get z-ai/api-key --quiet -f password)"
+    export CLOUDFLARE_API_TOKEN="$(pass-cli get cloudflare/browser-rendering-api-key --quiet -f password)"
+    export CLOUDFLARE_ACCOUNT_ID="$(pass-cli get cloudflare/account-id --quiet -f password)"
+    exec droid "$@"
+  '';
+
+  full-c = writeShellScriptBin "c" ''
+    export CLOUDFLARE_API_TOKEN="$(pass-cli get cloudflare/browser-rendering-api-key --quiet -f password)"
+    export CLOUDFLARE_ACCOUNT_ID="$(pass-cli get cloudflare/account-id --quiet -f password)"
+    exec claude "$@"
+  '';
+
+  # --- shared wrappers (no secrets) ---
+
+  exocortex-mcp = writeShellScriptBin "exocortex-mcp" ''
+    exec ${pkgs.uv}/bin/uv tool run \
+      --from "git+https://github.com/fuwasegu/exocortex" \
+      exocortex --mode proxy --ensure-server "$@"
+  '';
+
+  docker-credential-gh = writeShellScriptBin "docker-credential-gh" ''
+    set -e
+
+    cmd="$1"
+    if [ "erase" = "$cmd" ]; then
+      cat - >/dev/null
+      exit 0
+    fi
+    if [ "store" = "$cmd" ]; then
+      cat - >/dev/null
+      exit 0
+    fi
+    if [ "get" != "$cmd" ]; then
+      exit 1
+    fi
+
+    host="$(cat -)"
+    host="''${host#https://}"
+    host="''${host%/}"
+    if [ "$host" != "ghcr.io" ] && [ "$host" != "docker.pkg.github.com" ]; then
+      exit 1
+    fi
+
+    token="$(gh config get -h github.com oauth_token)"
+    if [ -z "$token" ]; then
+      exit 1
+    fi
+
+    printf '{"Username":"%s", "Secret":"%s"}\n' "$(gh config get -h github.com user)" "$token"
+  '';
+
+  # --- wrappers without pass-cli (sandbox, OpenShell injects env vars) ---
+
+  sandbox-zai-mcp-server = writeShellScriptBin "zai-mcp-server" ''
+    export Z_AI_MODE="ZAI"
+    exec ${pkgs.bun}/bin/bunx -y @z_ai/mcp-server "$@"
+  '';
+
+  sandbox-zread-mcp = writeShellScriptBin "zread-mcp" ''
+    exec ${pkgs.uv}/bin/uvx mcp-proxy --transport streamablehttp \
+      --headers Authorization "Bearer $Z_AI_API_KEY" \
+      https://api.z.ai/api/mcp/zread/mcp "$@"
+  '';
+
+  sandbox-brave-search-mcp = writeShellScriptBin "brave-search-mcp" ''
+    exec ${pkgs.bun}/bin/bunx -y @brave/brave-search-mcp-server "$@"
+  '';
+
+  sandbox-web-reader-mcp = writeShellScriptBin "web-reader-mcp" ''
+    exec ${pkgs.uv}/bin/uvx mcp-proxy --transport streamablehttp \
+      --headers Authorization "Bearer $Z_AI_API_KEY" \
+      https://api.z.ai/api/mcp/web_reader/mcp "$@"
+  '';
+
+in
+{
+  full = [
+    exocortex-mcp
+    full-zai-mcp-server
+    full-zread-mcp
+    full-brave-search-mcp
+    full-web-reader-mcp
+    docker-credential-gh
+    # full only
+    full-d
+    full-c
+  ];
+
+  sandbox = [
+    exocortex-mcp
+    sandbox-zai-mcp-server
+    sandbox-zread-mcp
+    sandbox-brave-search-mcp
+    sandbox-web-reader-mcp
+    docker-credential-gh
+  ];
+}

--- a/nix/share/packages-scripts.nix
+++ b/nix/share/packages-scripts.nix
@@ -46,7 +46,7 @@ let
   # --- shared wrappers (no secrets) ---
 
   exocortex-mcp = writeShellScriptBin "exocortex-mcp" ''
-    exec ${pkgs.uv}/bin/uv tool run \
+    exec ${pkgs.uv}/bin/uvx \
       --from "git+https://github.com/fuwasegu/exocortex" \
       exocortex --mode proxy --ensure-server "$@"
   '';


### PR DESCRIPTION
## Summary

Migrate MCP wrapper scripts (exocortex-mcp, zai-mcp-server, zread-mcp, brave-search-mcp, web-reader-mcp, d, c, docker-credential-gh) from chezmoi to Nix-managed `home.packages` via `packages-scripts.nix`.

### Key changes
- **`nix/share/packages-scripts.nix`**: New file providing `full` and `sandbox` sets
  - `full`: uses `pass-cli` for secret injection (macos, macos-work)
  - `sandbox`: relies on OpenShell for env var injection (no pass-cli dependency)
- **`nix/share/packages-macos.nix`**: Merges `packages-scripts.nix` full set
- **`nix/sandbox/flake.nix`**: Adds `packages-scripts.nix` sandbox set

### Commits
- `47bf4eb` feat(nix): migrate MCP wrapper scripts from chezmoi to Nix
- `ce5a75b` refactor(nix): use uvx instead of uv tool run in exocortex wrapper