### PR TITLE
refactor(nix): split c/d commands between macos and macos-work

### DIFF
--- a/nix/macos-work/flake.nix
+++ b/nix/macos-work/flake.nix
@@ -83,6 +83,7 @@
                     (import ../share/packages.nix { inherit pkgs npm; })
                     ++ (import ../share/packages-dev.nix { inherit pkgs; })
                     ++ (import ../share/packages-macos.nix { inherit pkgs; })
+                    ++ (import ../share/packages-scripts.nix { inherit pkgs; }).macos-work
                     ++ (with pkgs; [
                       docker
                     ]);

--- a/nix/macos/flake.nix
+++ b/nix/macos/flake.nix
@@ -96,6 +96,7 @@
                     (import ../share/packages.nix { inherit pkgs npm; })
                     ++ (import ../share/packages-dev.nix { inherit pkgs; })
                     ++ (import ../share/packages-macos.nix { inherit pkgs; })
+                    ++ (import ../share/packages-scripts.nix { inherit pkgs; }).macos
                     ++ (with pkgs; [
                       gopls
                       air

--- a/nix/share/packages-macos.nix
+++ b/nix/share/packages-macos.nix
@@ -1,9 +1,5 @@
 { pkgs }:
-let
-  mcp = import ./packages-scripts.nix { inherit pkgs; };
-in
 [
   pkgs.pinentry_mac
   pkgs.kanata-with-cmd
 ]
-++ mcp.full

--- a/nix/share/packages-scripts.nix
+++ b/nix/share/packages-scripts.nix
@@ -3,6 +3,45 @@
 let
   inherit (pkgs) writeShellScriptBin;
 
+  # --- shared wrappers (no secrets) ---
+
+  exocortex-mcp = writeShellScriptBin "exocortex-mcp" ''
+    exec ${pkgs.uv}/bin/uvx \
+      --from "git+https://github.com/fuwasegu/exocortex" \
+      exocortex --mode proxy --ensure-server "$@"
+  '';
+
+  docker-credential-gh = writeShellScriptBin "docker-credential-gh" ''
+    set -e
+
+    cmd="$1"
+    if [ "erase" = "$cmd" ]; then
+      cat - >/dev/null
+      exit 0
+    fi
+    if [ "store" = "$cmd" ]; then
+      cat - >/dev/null
+      exit 0
+    fi
+    if [ "get" != "$cmd" ]; then
+      exit 1
+    fi
+
+    host="$(cat -)"
+    host="''${host#https://}"
+    host="''${host%/}"
+    if [ "$host" != "ghcr.io" ] && [ "$host" != "docker.pkg.github.com" ]; then
+      exit 1
+    fi
+
+    token="$(gh config get -h github.com oauth_token)"
+    if [ -z "$token" ]; then
+      exit 1
+    fi
+
+    printf '{"Username":"%s", "Secret":"%s"}\n' "$(gh config get -h github.com user)" "$token"
+  '';
+
   # --- wrappers with pass-cli (macos) ---
 
   macos-zai-mcp-server = writeShellScriptBin "zai-mcp-server" ''
@@ -41,45 +80,6 @@ let
     export CLOUDFLARE_API_TOKEN="$(pass-cli get cloudflare/browser-rendering-api-key --quiet -f password)"
     export CLOUDFLARE_ACCOUNT_ID="$(pass-cli get cloudflare/account-id --quiet -f password)"
     exec claude "$@"
-  '';
-
-  # --- shared wrappers (no secrets) ---
-
-  exocortex-mcp = writeShellScriptBin "exocortex-mcp" ''
-    exec ${pkgs.uv}/bin/uvx \
-      --from "git+https://github.com/fuwasegu/exocortex" \
-      exocortex --mode proxy --ensure-server "$@"
-  '';
-
-  docker-credential-gh = writeShellScriptBin "docker-credential-gh" ''
-    set -e
-
-    cmd="$1"
-    if [ "erase" = "$cmd" ]; then
-      cat - >/dev/null
-      exit 0
-    fi
-    if [ "store" = "$cmd" ]; then
-      cat - >/dev/null
-      exit 0
-    fi
-    if [ "get" != "$cmd" ]; then
-      exit 1
-    fi
-
-    host="$(cat -)"
-    host="''${host#https://}"
-    host="''${host%/}"
-    if [ "$host" != "ghcr.io" ] && [ "$host" != "docker.pkg.github.com" ]; then
-      exit 1
-    fi
-
-    token="$(gh config get -h github.com oauth_token)"
-    if [ -z "$token" ]; then
-      exit 1
-    fi
-
-    printf '{"Username":"%s", "Secret":"%s"}\n' "$(gh config get -h github.com user)" "$token"
   '';
 
   macos-work-c = writeShellScriptBin "c" ''

--- a/nix/share/packages-scripts.nix
+++ b/nix/share/packages-scripts.nix
@@ -82,7 +82,15 @@ let
     printf '{"Username":"%s", "Secret":"%s"}\n' "$(gh config get -h github.com user)" "$token"
   '';
 
+  macos-work-c = writeShellScriptBin "c" ''
+    exec claude "$@"
+  '';
+
   # --- wrappers without pass-cli (sandbox, OpenShell injects env vars) ---
+
+  sandbox-c = writeShellScriptBin "c" ''
+    exec claude "$@"
+  '';
 
   sandbox-zai-mcp-server = writeShellScriptBin "zai-mcp-server" ''
     export Z_AI_MODE="ZAI"
@@ -122,6 +130,7 @@ in
   macos-work = [
     exocortex-mcp
     docker-credential-gh
+    macos-work-c
   ];
 
   sandbox = [
@@ -131,5 +140,6 @@ in
     sandbox-brave-search-mcp
     sandbox-web-reader-mcp
     docker-credential-gh
+    sandbox-c
   ];
 }

--- a/nix/share/packages-scripts.nix
+++ b/nix/share/packages-scripts.nix
@@ -117,12 +117,11 @@ in
 {
   macos = [
     exocortex-mcp
+    docker-credential-gh
     macos-zai-mcp-server
     macos-zread-mcp
     macos-brave-search-mcp
     macos-web-reader-mcp
-    docker-credential-gh
-    # macos only
     macos-d
     macos-c
   ];

--- a/nix/share/packages-scripts.nix
+++ b/nix/share/packages-scripts.nix
@@ -128,7 +128,6 @@ in
   ];
 
   macos-work = [
-    exocortex-mcp
     docker-credential-gh
     macos-work-c
   ];

--- a/nix/share/packages-scripts.nix
+++ b/nix/share/packages-scripts.nix
@@ -3,41 +3,41 @@
 let
   inherit (pkgs) writeShellScriptBin;
 
-  # --- wrappers with pass-cli (full) ---
+  # --- wrappers with pass-cli (macos) ---
 
-  full-zai-mcp-server = writeShellScriptBin "zai-mcp-server" ''
+  macos-zai-mcp-server = writeShellScriptBin "zai-mcp-server" ''
     export Z_AI_API_KEY="$(pass-cli get z-ai/api-key --quiet -f password)"
     export Z_AI_MODE="ZAI"
     exec ${pkgs.bun}/bin/bunx -y @z_ai/mcp-server "$@"
   '';
 
-  full-zread-mcp = writeShellScriptBin "zread-mcp" ''
+  macos-zread-mcp = writeShellScriptBin "zread-mcp" ''
     export Z_AI_API_KEY="$(pass-cli get z-ai/api-key --quiet -f password)"
     exec ${pkgs.uv}/bin/uvx mcp-proxy --transport streamablehttp \
       --headers Authorization "Bearer $Z_AI_API_KEY" \
       https://api.z.ai/api/mcp/zread/mcp "$@"
   '';
 
-  full-brave-search-mcp = writeShellScriptBin "brave-search-mcp" ''
+  macos-brave-search-mcp = writeShellScriptBin "brave-search-mcp" ''
     export BRAVE_API_KEY="$(pass-cli get brave-search/api-key --quiet -f password)"
     exec ${pkgs.bun}/bin/bunx -y @brave/brave-search-mcp-server "$@"
   '';
 
-  full-web-reader-mcp = writeShellScriptBin "web-reader-mcp" ''
+  macos-web-reader-mcp = writeShellScriptBin "web-reader-mcp" ''
     export Z_AI_API_KEY="$(pass-cli get z-ai/api-key --quiet -f password)"
     exec ${pkgs.uv}/bin/uvx mcp-proxy --transport streamablehttp \
       --headers Authorization "Bearer $Z_AI_API_KEY" \
       https://api.z.ai/api/mcp/web_reader/mcp "$@"
   '';
 
-  full-d = writeShellScriptBin "d" ''
+  macos-d = writeShellScriptBin "d" ''
     export Z_AI_API_KEY="$(pass-cli get z-ai/api-key --quiet -f password)"
     export CLOUDFLARE_API_TOKEN="$(pass-cli get cloudflare/browser-rendering-api-key --quiet -f password)"
     export CLOUDFLARE_ACCOUNT_ID="$(pass-cli get cloudflare/account-id --quiet -f password)"
     exec droid "$@"
   '';
 
-  full-c = writeShellScriptBin "c" ''
+  macos-c = writeShellScriptBin "c" ''
     export CLOUDFLARE_API_TOKEN="$(pass-cli get cloudflare/browser-rendering-api-key --quiet -f password)"
     export CLOUDFLARE_ACCOUNT_ID="$(pass-cli get cloudflare/account-id --quiet -f password)"
     exec claude "$@"
@@ -107,16 +107,21 @@ let
 
 in
 {
-  full = [
+  macos = [
     exocortex-mcp
-    full-zai-mcp-server
-    full-zread-mcp
-    full-brave-search-mcp
-    full-web-reader-mcp
+    macos-zai-mcp-server
+    macos-zread-mcp
+    macos-brave-search-mcp
+    macos-web-reader-mcp
     docker-credential-gh
-    # full only
-    full-d
-    full-c
+    # macos only
+    macos-d
+    macos-c
+  ];
+
+  macos-work = [
+    exocortex-mcp
+    docker-credential-gh
   ];
 
   sandbox = [


### PR DESCRIPTION
## Summary

- `packages-scripts.nix` の `full-*` プレフィックスを `macos-*` に統一、セット名 `full` を `macos` にリネーム
- `macos-work` セットを新設（`d` コマンドなし、素の `c` コマンドのみ）
- `sandbox` にも素の `c` コマンドを追加
- `packages-macos.nix` から scripts 参照を分離し、nixpkgs パッケージのみに整理
- 各 flake から `packages-scripts.nix` を直接インポートし、環境ごとのプロパティ（`.macos` / `.macos-work` / `.sandbox`）を指定する形に統一

## Test plan

- [ ] `nix/macos` でビルドし `c`・`d` コマンドが動作することを確認
- [ ] `nix/macos-work` でビルドし `c` コマンドのみ存在し `d` コマンドがないことを確認
- [ ] `nix/sandbox` でビルドし `c` コマンドが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)