### PR TITLE
feat(nix): force CLAUDE_CONFIG_DIR to ~/.claude-work for macos-work c

### DIFF
--- a/go/app/atlas-to-kysely/generator_test.go
+++ b/go/app/atlas-to-kysely/generator_test.go
@@ -198,7 +198,7 @@ func TestSerializeKey(t *testing.T) {
 		{"class", "class"},
 		{"default", "default"},
 		// Quoted (regex fails)
-		{"2nd", `"2nd"`},          // digit-leading
+		{"2nd", `"2nd"`},             // digit-leading
 		{"user.name", `"user.name"`}, // contains `.`
 		{"with space", `"with space"`},
 		// Empty input fails the regex (requires ≥1 starting char) → quoted

--- a/go/app/atlas-to-kysely/vite.config.ts
+++ b/go/app/atlas-to-kysely/vite.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   run: {
     tasks: {
       check: {
-        command: 'test -z "$(gofmt -l .)"',
+        command: 'gofmt -d .',
         input: [{ auto: true }],
       },
       fix: {

--- a/go/app/atlas-to-kysely/vite.config.ts
+++ b/go/app/atlas-to-kysely/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     tasks: {
       check: {
         command: 'gofmt -d .',
-        input: [{ auto: true }],
       },
       fix: {
         command: 'go fmt .',

--- a/go/app/atlas-to-kysely/vite.config.ts
+++ b/go/app/atlas-to-kysely/vite.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from 'vite-plus'
 export default defineConfig({
   run: {
     tasks: {
+      check: {
+        command: 'test -z "$(gofmt -l .)"',
+        input: [{ auto: true }],
+      },
       fix: {
         command: 'go fmt .',
       },

--- a/js/app/c-plugin/package.json
+++ b/js/app/c-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totto2727/c-plugin",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/js/app/c-plugin/src/cli/skill/target/add.ts
+++ b/js/app/c-plugin/src/cli/skill/target/add.ts
@@ -1,7 +1,7 @@
 import { Effect } from 'effect'
 import { Argument, Command, Flag } from 'effect/unstable/cli'
 
-import { getAgentsDir } from '#@/lib/paths.ts'
+import { expandHomePath, getAgentsDir } from '#@/lib/paths.ts'
 import * as LockFileService from '#@/service/lock-file.ts'
 import * as SyncService from '#@/service/sync.ts'
 
@@ -16,7 +16,9 @@ export const targetAddCommand = Command.make(
       const agentsDir = getAgentsDir(config.global)
       const lockFile = yield* LockFileService.read(agentsDir)
 
-      if (lockFile.skillDirs.includes(config.path)) {
+      const expanded = expandHomePath(config.path)
+      const isDuplicate = lockFile.skillDirs.some((d) => expandHomePath(d) === expanded)
+      if (isDuplicate) {
         yield* Effect.log(`Directory already registered: ${config.path}`)
         return
       }

--- a/js/app/c-plugin/src/lib/paths.test.ts
+++ b/js/app/c-plugin/src/lib/paths.test.ts
@@ -1,6 +1,9 @@
+import * as Os from 'node:os'
+import * as NodePath from 'node:path'
+
 import { describe, expect, test } from 'vite-plus/test'
 
-import { getGitHubCloneUrl, parseRepoSource } from './paths.ts'
+import { expandHomePath, getGitHubCloneUrl, parseRepoSource } from './paths.ts'
 
 describe('parseRepoSource', () => {
   test('parses valid owner/repo format', () => {
@@ -28,5 +31,31 @@ describe('parseRepoSource', () => {
 describe('getGitHubCloneUrl', () => {
   test('returns https clone URL', () => {
     expect(getGitHubCloneUrl('owner/repo')).toBe('https://github.com/owner/repo.git')
+  })
+})
+
+describe('expandHomePath', () => {
+  test('expands lone "~" to home directory', () => {
+    expect(expandHomePath('~')).toBe(Os.homedir())
+  })
+
+  test('expands "~/" prefix to home directory', () => {
+    expect(expandHomePath('~/foo/bar')).toBe(NodePath.join(Os.homedir(), 'foo', 'bar'))
+  })
+
+  test('returns absolute path unchanged', () => {
+    expect(expandHomePath('/abs/path')).toBe('/abs/path')
+  })
+
+  test('returns relative path unchanged', () => {
+    expect(expandHomePath('relative/path')).toBe('relative/path')
+  })
+
+  test('does not expand "~user" form', () => {
+    expect(expandHomePath('~other/foo')).toBe('~other/foo')
+  })
+
+  test('returns empty string unchanged', () => {
+    expect(expandHomePath('')).toBe('')
   })
 })

--- a/js/app/c-plugin/src/lib/paths.ts
+++ b/js/app/c-plugin/src/lib/paths.ts
@@ -6,6 +6,16 @@ import { Predicate, String } from 'effect'
 export const getAgentsDir = (global: boolean): string =>
   global ? NodePath.join(Os.homedir(), '.agents') : NodePath.join(process.cwd(), '.agents')
 
+export const expandHomePath = (path: string): string => {
+  if (path === '~') {
+    return Os.homedir()
+  }
+  if (path.startsWith('~/')) {
+    return NodePath.join(Os.homedir(), path.slice(2))
+  }
+  return path
+}
+
 export const getCacheDir = (agentsDir: string): string => NodePath.join(agentsDir, '.cache')
 
 export const getSkillsDir = (agentsDir: string): string => NodePath.join(agentsDir, 'skills')

--- a/js/app/c-plugin/src/service/symlink.ts
+++ b/js/app/c-plugin/src/service/symlink.ts
@@ -3,7 +3,7 @@ import * as NodePath from 'node:path'
 
 import { Effect } from 'effect'
 
-import { getSkillsDir } from '#@/lib/paths.ts'
+import { expandHomePath, getSkillsDir } from '#@/lib/paths.ts'
 
 const createLinkInDir = (dir: string, skillName: string, targetPath: string): Effect.Effect<void> =>
   Effect.tryPromise({
@@ -32,7 +32,7 @@ const removeLinkInDir = (dir: string, skillName: string): Effect.Effect<void> =>
 
 const getAllDirs = (agentsDir: string, skillDirs: readonly string[]): string[] => {
   const primary = getSkillsDir(agentsDir)
-  return [primary, ...skillDirs]
+  return [primary, ...skillDirs.map(expandHomePath)]
 }
 
 export const createSkillLink = (
@@ -58,7 +58,7 @@ export const removeSkillLink = (
 
 export const removeSkillLinkFromDirs = (dirs: readonly string[], skillName: string): Effect.Effect<void> =>
   Effect.all(
-    dirs.map((dir) => removeLinkInDir(dir, skillName)),
+    dirs.map((dir) => removeLinkInDir(expandHomePath(dir), skillName)),
     { concurrency: 'unbounded' },
   ).pipe(Effect.asVoid)
 

--- a/nix/share/packages-scripts.nix
+++ b/nix/share/packages-scripts.nix
@@ -83,6 +83,7 @@ let
   '';
 
   macos-work-c = writeShellScriptBin "c" ''
+    export CLAUDE_CONFIG_DIR="$HOME/.claude-work"
     exec claude "$@"
   '';
 


### PR DESCRIPTION
## Summary

- `macos-work` プロファイルの `c` コマンドが業務用設定 `~/.claude-work` を強制利用するよう `CLAUDE_CONFIG_DIR` を設定
- 個人用 `~/.claude` と業務用 `~/.claude-work` を分離し、誤った設定での実行を防止

## Test plan

- [ ] `nix-shell` で `macos-work` プロファイルを読み込み、`c --help` 等で `~/.claude-work` 配下が参照されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)