### PR TITLE
feat(nix): integrate meridian agent on darwin home-manager

### DIFF
--- a/nix/macos/flake.lock
+++ b/nix/macos/flake.lock
@@ -1,5 +1,52 @@
 {
   "nodes": {
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "import-tree": "import-tree",
+        "nixpkgs": [
+          "meridian",
+          "nixpkgs"
+        ],
+        "systems": [
+          "meridian",
+          "systems"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1770895533,
+        "narHash": "sha256-v3QaK9ugy9bN9RXDnjw0i2OifKmz2NnKM82agtqm/UY=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "c843f477b15f51151f8c6bcc886954699440a6e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "2.0.8",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -17,6 +64,43 @@
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/nix-community/home-manager/%2A"
+      }
+    },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1763762820,
+        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
+    "meridian": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1778089529,
+        "narHash": "sha256-pxEVE2JCqJTP7JKbja9UkCYScbi5XNsy8qb/bqP5OHc=",
+        "owner": "rynfar",
+        "repo": "meridian",
+        "rev": "0a7ec3a3668042b817e0af2904f41c2e5a55fbef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian",
+        "type": "github"
       }
     },
     "nix-darwin": {
@@ -52,6 +136,21 @@
         "url": "https://flakehub.com/f/NixOS/nixpkgs/0"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "npmpkgs": {
       "inputs": {
         "nixpkgs": [
@@ -74,9 +173,47 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "meridian": "meridian",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
         "npmpkgs": "npmpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "meridian",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/nix/macos/flake.nix
+++ b/nix/macos/flake.nix
@@ -15,6 +15,10 @@
       url = "https://flakehub.com/f/totto2727-dotfiles/npm-packages/*";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    meridian = {
+      url = "github:rynfar/meridian";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -24,6 +28,7 @@
       npmpkgs,
       home-manager,
       nix-darwin,
+      meridian,
     }:
     let
       hostname = "totto2727-macos";
@@ -90,6 +95,10 @@
               (import ../share/home-manager.nix { inherit username homedir; })
               // {
                 home-manager.users."${username}" = {
+                  imports = [
+                    (import ../share/meridian.nix { inherit meridian; })
+                  ];
+
                   home.stateVersion = stateVersion;
 
                   home.packages =
@@ -129,7 +138,12 @@
                       };
                     };
 
-                  services = (import ../share/programs-macos.nix { inherit pkgs; }).services;
+                  services = (import ../share/programs-macos.nix { inherit pkgs; }).services // {
+                    meridian = {
+                      enable = true;
+                      settings.sonnetModel = "sonnet[1m]";
+                    };
+                  };
 
                   home.sessionVariables = import ../share/session-variables.nix;
                   home.sessionPath = import ../share/session-path.nix;

--- a/nix/share/meridian.nix
+++ b/nix/share/meridian.nix
@@ -1,0 +1,82 @@
+# Meridian home-manager wrapper for darwin.
+#
+# The upstream module only emits a `systemd.user.services.meridian` unit, which
+# is a no-op on darwin home-manager because `systemd.user.enable` defaults to
+# `pkgs.stdenv.isLinux`. This wrapper imports the upstream module (so
+# `services.meridian` options and `home.packages` are wired up) and mirrors the
+# unit as a `launchd.agents.meridian` agent, deriving env vars from
+# `config.services.meridian.settings.*` so it stays in sync with the option
+# schema.
+#
+# Upstream module (env construction reproduced here verbatim):
+# https://github.com/rynfar/meridian/blob/0a7ec3a3668042b817e0af2904f41c2e5a55fbef/nix/hm-module.nix
+{ meridian }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.meridian;
+  s = cfg.settings;
+
+  # Workaround for the meridian 1.42.1 (rev 0a7ec3a) build under bun2nix's
+  # hoisted linker: `bun build --splitting` emits a shared chunk
+  # (tokenRefresh-*.js) with two `export {}` blocks that share identifiers,
+  # which Node.js rejects with "SyntaxError: Duplicate export of
+  # 'stopBackgroundRefresh'". The npm-published bundle does not hit this path
+  # because `npm install` produces a different node_modules layout. Drop
+  # `--splitting` from package.json's build script so bun emits one
+  # self-contained file per entry instead of generating shared chunks.
+  #
+  # If upstream removes `--splitting` from scripts.build this sed becomes a
+  # no-op (intentional). Source:
+  # https://github.com/rynfar/meridian/blob/0a7ec3a3668042b817e0af2904f41c2e5a55fbef/package.json
+  patchedMeridian = (meridian.packages.${pkgs.system}.meridian).overrideAttrs (old: {
+    postPatch = (old.postPatch or "") + ''
+      sed -i 's/ --splitting//g' package.json
+    '';
+  });
+in
+{
+  imports = [ meridian.homeManagerModules.default ];
+
+  config = lib.mkMerge [
+    {
+      services.meridian.package = lib.mkDefault patchedMeridian;
+    }
+
+    (lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isDarwin) {
+      launchd.agents.meridian = {
+        enable = true;
+        config = {
+          ProgramArguments = [ "${cfg.package}/bin/meridian" ];
+          RunAtLoad = true;
+          KeepAlive = true;
+          EnvironmentVariables = {
+            MERIDIAN_PORT = toString s.port;
+            MERIDIAN_HOST = s.host;
+            MERIDIAN_IDLE_TIMEOUT_SECONDS = toString s.idleTimeoutSeconds;
+          }
+          // lib.optionalAttrs (s.passthrough != null) {
+            MERIDIAN_PASSTHROUGH = if s.passthrough then "1" else "0";
+          }
+          // lib.optionalAttrs (s.defaultAgent != null) {
+            MERIDIAN_DEFAULT_AGENT = s.defaultAgent;
+          }
+          // lib.optionalAttrs (s.sonnetModel != null) {
+            MERIDIAN_SONNET_MODEL = s.sonnetModel;
+          }
+          // lib.optionalAttrs s.telemetry.persist {
+            MERIDIAN_TELEMETRY_PERSIST = "1";
+          }
+          // lib.optionalAttrs (s.telemetry.retentionDays != null) {
+            MERIDIAN_TELEMETRY_RETENTION_DAYS = toString s.telemetry.retentionDays;
+          }
+          // cfg.environment;
+        };
+      };
+    })
+  ];
+}


### PR DESCRIPTION
## Summary
- Wrap the upstream `meridian` home-manager module to emit a `launchd.agents.meridian` agent on darwin, since the upstream module only ships a `systemd.user.services.meridian` unit which is a no-op under darwin home-manager.
- Mirror env vars from `services.meridian.settings.*` so the launchd agent stays in sync with the upstream option schema.
- Patch out `bun build --splitting` to avoid a duplicate-export `SyntaxError` triggered by bun2nix's hoisted linker (npm install does not hit this path).

## Test plan
- [ ] `darwin-rebuild switch --flake nix/macos#totto2727-macos` succeeds
- [ ] `launchctl list | grep meridian` shows the agent loaded
- [ ] `meridian` process is reachable on the configured port and responds to a basic request

🤖 Generated with [Claude Code](https://claude.com/claude-code)