### PR TITLE
feat(oxlint-plugin): ban native Date via no-js-date rule + fix existing call sites

### DIFF
--- a/js/app/rss-graphql/app/feature/graphql/rss.ts
+++ b/js/app/rss-graphql/app/feature/graphql/rss.ts
@@ -1,5 +1,5 @@
 import { FeedType as FeedTypeForRawFeed } from '@mikaelporttila/rss'
-import { Effect, Predicate, Schema } from 'effect'
+import { DateTime, Effect, Predicate, Schema } from 'effect'
 import { Literals } from 'effect/Schema'
 import { NonEmptyStringResolver } from 'graphql-scalars'
 
@@ -148,6 +148,7 @@ export const initGraphQL = (builder: Builder) => {
           Effect.gen(function* () {
             const rssFetchClient = yield* makeRSSFetchClient
             const rss = yield* rssFetchClient(args.feedURL)
+            const nowIso = DateTime.formatIso(yield* DateTime.now)
 
             return {
               feed: {
@@ -172,20 +173,15 @@ export const initGraphQL = (builder: Builder) => {
                     description: entry.description?.value ?? '',
                     id: entry.id ?? '',
                     links: entry.links.map((link) => link.href).filter((v) => Predicate.isNotNullish(v)),
-                    publishedAt:
-                      entry.published?.toISOString() ?? entry.updated?.toISOString() ?? new Date().toISOString(),
+                    publishedAt: entry.published?.toISOString() ?? entry.updated?.toISOString() ?? nowIso,
                     title: entry.title?.value ?? '',
-                    updatedAt:
-                      entry.updated?.toISOString() ?? entry.published?.toISOString() ?? new Date().toISOString(),
+                    updatedAt: entry.updated?.toISOString() ?? entry.published?.toISOString() ?? nowIso,
                   })),
                 links: rss.links,
                 title: rss.title.value ?? '',
                 type: yield* decodeFeedType(rss.type),
                 updatedAt:
-                  rss.updateDate?.toISOString() ??
-                  rss.created?.toISOString() ??
-                  rss.published?.toISOString() ??
-                  new Date().toISOString(),
+                  rss.updateDate?.toISOString() ?? rss.created?.toISOString() ?? rss.published?.toISOString() ?? nowIso,
               },
               feedURL: args.feedURL,
             } as const satisfies FeedResponse

--- a/js/package/fp/src/effect/cuid.ts
+++ b/js/package/fp/src/effect/cuid.ts
@@ -1,7 +1,7 @@
 import { sha3_512 } from '@noble/hashes/sha3.js'
 import BaseX from 'base-x'
 import { BigNumber } from 'bignumber.js'
-import { Array, Context, Effect, Layer, Predicate, Schema } from 'effect'
+import { Array, Context, DateTime, Effect, Layer, Predicate, Schema } from 'effect'
 /*
  * MIT License
  * Copyright (c) 2022 Eric Elliott
@@ -172,7 +172,7 @@ export const init = ({
 
     // If we're lucky, the `.toString(36)` calls may reduce hashing rounds
     // by shortening the input to the hash function a little.
-    const time = Date.now().toString(36)
+    const time = DateTime.toEpochMillis(DateTime.nowUnsafe()).toString(36)
     const count = counter().toString(36)
 
     // The salt should be long enough to be globally unique across the full

--- a/js/package/oxlint-plugin/src/index.ts
+++ b/js/package/oxlint-plugin/src/index.ts
@@ -730,6 +730,65 @@ const requireDisableReasonRule: Rule = {
 }
 
 // ---------------------------------------------------------------------------
+// no-js-date
+// ---------------------------------------------------------------------------
+
+const FORBIDDEN_DATE_STATIC_METHODS: ReadonlySet<string> = new Set(['now', 'parse', 'UTC'])
+
+const isDateIdentifier = (node: unknown): boolean =>
+  Predicate.isObject(node) && node.type === 'Identifier' && node.name === 'Date'
+
+const getForbiddenDateStaticMethod = (node: unknown): string | null => {
+  if (
+    Predicate.isObject(node) &&
+    node.type === 'MemberExpression' &&
+    node.computed !== true &&
+    isDateIdentifier(node.object) &&
+    Predicate.isObject(node.property) &&
+    node.property.type === 'Identifier' &&
+    Predicate.isString(node.property.name) &&
+    FORBIDDEN_DATE_STATIC_METHODS.has(node.property.name)
+  ) {
+    return node.property.name
+  }
+  return null
+}
+
+const noJsDateRule: Rule = {
+  create(context: Context) {
+    return {
+      MemberExpression(node: unknown) {
+        if (!isReportable(node)) {
+          return
+        }
+        const method = getForbiddenDateStaticMethod(node)
+        if (Predicate.isNotNullish(method)) {
+          context.report({
+            message: `Use Effect \`DateTime\` / \`Duration\` instead of \`Date.${method}()\`. Native \`Date\` is allowed only at external-API boundaries.`,
+            node,
+          })
+        }
+      },
+      NewExpression(node: unknown) {
+        if (!isReportable(node)) {
+          return
+        }
+        if (Predicate.isObject(node) && isDateIdentifier(node.callee)) {
+          context.report({
+            message:
+              'Use Effect `DateTime` / `Duration` instead of `new Date()`. Native `Date` is allowed only at external-API boundaries.',
+            node,
+          })
+        }
+      },
+    }
+  },
+  meta: {
+    type: 'problem',
+  },
+}
+
+// ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
 
@@ -742,6 +801,7 @@ const plugin = {
     'force-string-empty': forceStringEmptyRule,
     'force-ts-extension': forceTsExtensionRule,
     'no-eslint-disable-comments': noEslintDisableRule,
+    'no-js-date': noJsDateRule,
     'no-let': noLetRule,
     'no-option-tag-comparison': noOptionTagComparisonRule,
     'no-sync-decode': noSyncDecodeRule,

--- a/js/package/oxlint-plugin/src/preset.ts
+++ b/js/package/oxlint-plugin/src/preset.ts
@@ -32,6 +32,7 @@ const preset: Preset = {
     'rules/force-string-empty': 'error',
     'rules/force-ts-extension': 'error',
     'rules/no-eslint-disable-comments': 'error',
+    'rules/no-js-date': 'error',
     'rules/no-let': 'error',
     'rules/no-option-tag-comparison': 'error',
     'rules/no-sync-decode': 'error',


### PR DESCRIPTION
## Summary

Adds a custom oxlint rule `rules/no-js-date` that bans the JavaScript-standard `new Date()`, `Date.now()`, `Date.parse()`, and `Date.UTC()`, and migrates the two existing call sites to Effect's `DateTime` module.

## Motivation

The codebase standardises on Effect's `DateTime` / `Duration` for time handling (typed, immutable, time-zone aware, integrates with the Effect runtime / Clock service). Mixing native `Date` defeats that uniformity and introduces subtle bugs (mutability, implicit local-time, untyped arithmetic). Enforcing this via lint keeps the rule machine-checked rather than living only in prose.

## Changes

### 1. `feat(oxlint-plugin): add no-js-date rule banning native Date`
- New `noJsDateRule` in [`js/package/oxlint-plugin/src/index.ts`](../blob/nicho-centipede/js/package/oxlint-plugin/src/index.ts) — matches `NewExpression` with `Date` callee and `MemberExpression` against the static methods `now` / `parse` / `UTC`.
- Registered as `'rules/no-js-date': 'error'` in the shared preset.

### 2. `refactor(rss-graphql): use Effect DateTime for missing-date fallbacks`
- Replace the three `new Date().toISOString()` fallbacks in `feature/graphql/rss.ts` with a single `nowIso` bound from `yield* DateTime.now` + `DateTime.formatIso`.
- Side-benefit: all three fallback fields now share the same instant instead of producing three slightly-different timestamps.

### 3. `refactor(fp): seed cuid timestamp from Effect DateTime`
- `Date.now().toString(36)` → `DateTime.toEpochMillis(DateTime.nowUnsafe()).toString(36)` in the synchronous CUID generator.

## Escape hatch

Native `Date` is still permitted at external-API boundaries (browser, third-party SDK, DB driver). Suppress with `// oxlint-disable-next-line rules/no-js-date -- <reason>` — the existing `require-disable-reason` rule enforces the `--` reason format.

## Verification

- `vp run check`: 4 `rules/no-js-date` violations resolved → 0. Remaining 11 errors are pre-existing (paraglide type-gen + saas-example), unrelated to this PR.
- `@package/oxlint-plugin` tests: 30/30 pass.
- `js/package/fp/src/effect/cuid.ts` tests: 23/23 pass.
- LSP diagnostics on touched files: clean.