### PR TITLE
feat(auth-helper): introduce shared workspace package for auth types and helpers

### DIFF
--- a/js/package/auth-helper/package.json
+++ b/js/package/auth-helper/package.json
@@ -1,5 +1,8 @@
 {
   "name": "auth-helper",
+
   "private": true,
   "type": "module"
+||||||| parent of 1cd7cada (feat(auth-helper): introduce shared workspace package for auth types, constants, and pure helpers)
+ 1cd7cada (feat(auth-helper): introduce shared workspace package for auth types, constants, and pure helpers)
 }

--- a/js/package/auth-helper/package.json
+++ b/js/package/auth-helper/package.json
@@ -1,8 +1,12 @@
 {
   "name": "auth-helper",
-
   "private": true,
-  "type": "module"
-||||||| parent of 1cd7cada (feat(auth-helper): introduce shared workspace package for auth types, constants, and pure helpers)
- 1cd7cada (feat(auth-helper): introduce shared workspace package for auth types, constants, and pure helpers)
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "devDependencies": {
+    "@totto2727/fp": "workspace:*",
+    "@types/node": "catalog:types"
+  }
 }

--- a/js/package/auth-helper/src/constants.ts
+++ b/js/package/auth-helper/src/constants.ts
@@ -1,0 +1,5 @@
+/** HttpOnly session cookie name shared by feed-platform-web and feed-platform-backend. */
+export const FEED_SESSION_COOKIE = 'feed-session'
+
+/** Base path for OAuth 2.1 endpoints on the identity-provider. */
+export const OAUTH_BASE_PATH = '/api/v1/auth/oauth'

--- a/js/package/auth-helper/src/cookie-translator.test.ts
+++ b/js/package/auth-helper/src/cookie-translator.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { extractBearerFromCookie } from './cookie-translator.ts'
+
+describe('extractBearerFromCookie', () => {
+  it('returns Bearer token when cookie is present', () => {
+    expect(extractBearerFromCookie('feed-session', 'feed-session=abc.def.ghi')).toBe('Bearer abc.def.ghi')
+  })
+
+  it('returns null when cookieHeader is undefined', () => {
+    expect(extractBearerFromCookie('feed-session')).toBeNull()
+  })
+
+  it('returns null when cookie name is not found', () => {
+    expect(extractBearerFromCookie('feed-session', 'other-cookie=xyz')).toBeNull()
+  })
+
+  it('returns null when cookie value is empty', () => {
+    expect(extractBearerFromCookie('feed-session', 'feed-session=')).toBeNull()
+  })
+
+  it('handles multiple cookies and finds the right one', () => {
+    expect(extractBearerFromCookie('feed-session', 'a=1; feed-session=tok.en; b=2')).toBe('Bearer tok.en')
+  })
+
+  it('handles JWT tokens with = padding in value', () => {
+    const token = 'aGVsbG8='
+    expect(extractBearerFromCookie('feed-session', `feed-session=${token}`)).toBe(`Bearer ${token}`)
+  })
+})

--- a/js/package/auth-helper/src/cookie-translator.ts
+++ b/js/package/auth-helper/src/cookie-translator.ts
@@ -1,0 +1,21 @@
+/**
+ * Extracts a cookie value by name from a `Cookie` header string and returns it
+ * as an `Authorization: Bearer <token>` value, or `null` if absent.
+ */
+export const extractBearerFromCookie = (cookieName: string, cookieHeader: string | undefined): string | null => {
+  if (cookieHeader === undefined) {
+    return null
+  }
+  for (const part of cookieHeader.split(';')) {
+    const [rawKey, ...valueParts] = part.split('=')
+    if (rawKey === undefined) {
+      continue
+    }
+    const key = rawKey.trim()
+    if (key === cookieName) {
+      const value = valueParts.join('=').trim()
+      return value !== '' ? `Bearer ${value}` : null
+    }
+  }
+  return null
+}

--- a/js/package/auth-helper/src/cookie-translator.ts
+++ b/js/package/auth-helper/src/cookie-translator.ts
@@ -2,7 +2,9 @@
  * Extracts a cookie value by name from a `Cookie` header string and returns it
  * as an `Authorization: Bearer <token>` value, or `null` if absent.
  */
+// oxlint-disable rules/force-predicate rules/force-string-empty -- zero-runtime-deps
 export const extractBearerFromCookie = (cookieName: string, cookieHeader: string | undefined): string | null => {
+  // oxlint-disable-next-line rules/force-predicate -- no Predicate in zero-runtime-deps
   if (cookieHeader === undefined) {
     return null
   }

--- a/js/package/auth-helper/src/index.ts
+++ b/js/package/auth-helper/src/index.ts
@@ -3,4 +3,4 @@ export * from './constants.ts'
 // oxlint-disable-next-line oxc/no-barrel-file -- intentional barrel re-export of auth-helper modules
 export * from './cookie-translator.ts'
 // oxlint-disable-next-line oxc/no-barrel-file -- intentional barrel re-export of auth-helper modules
-export * from './jwt-payload.ts'
+export type * from './jwt-payload.ts'

--- a/js/package/auth-helper/src/index.ts
+++ b/js/package/auth-helper/src/index.ts
@@ -1,0 +1,6 @@
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional barrel re-export of auth-helper modules
+export * from './constants.ts'
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional barrel re-export of auth-helper modules
+export * from './cookie-translator.ts'
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional barrel re-export of auth-helper modules
+export * from './jwt-payload.ts'

--- a/js/package/auth-helper/src/jwt-payload.ts
+++ b/js/package/auth-helper/src/jwt-payload.ts
@@ -1,0 +1,5 @@
+export interface AppJWTPayload {
+  readonly sub: string
+  readonly iat: number
+  readonly exp: number
+}

--- a/js/package/auth-helper/tsconfig.json
+++ b/js/package/auth-helper/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": ["@totto2727/fp/tsconfig/vite"],
+  "compilerOptions": {
+    "types": ["vite-plus/client", "node"]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,7 +597,14 @@ importers:
         specifier: 'catalog:'
         version: 0.1.19(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
 
-  js/package/auth-helper: {}
+  js/package/auth-helper:
+    devDependencies:
+      '@totto2727/fp':
+        specifier: workspace:*
+        version: link:../fp
+      '@types/node':
+        specifier: catalog:types
+        version: 24.12.2
 
   js/package/effect-hono:
     devDependencies:
@@ -6176,17 +6183,6 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@5.10.0)(kysely@0.28.12)(nanostores@1.2.0)':
-    dependencies:
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.6)
-      jose: 5.10.0
-      kysely: 0.28.12
-      nanostores: 1.2.0
-      zod: 4.3.6
-
   '@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)':
     dependencies:
       '@better-auth/utils': 0.3.1
@@ -6200,23 +6196,23 @@ snapshots:
 
   '@better-auth/drizzle-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@5.10.0)(kysely@0.28.12)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
   '@better-auth/kysely-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.12)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@5.10.0)(kysely@0.28.12)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       kysely: 0.28.12
 
   '@better-auth/memory-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@5.10.0)(kysely@0.28.12)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
   '@better-auth/mongo-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(mongodb@7.1.0)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@5.10.0)(kysely@0.28.12)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       mongodb: 7.1.0
 
@@ -6244,12 +6240,12 @@ snapshots:
 
   '@better-auth/prisma-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@5.10.0)(kysely@0.28.12)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
   '@better-auth/telemetry@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@5.10.0)(kysely@0.28.12)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
 
@@ -8837,7 +8833,7 @@ snapshots:
 
   better-auth@1.5.5(@tanstack/react-start@1.167.48(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(mongodb@7.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.7):
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@5.10.0)(kysely@0.28.12)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
       '@better-auth/kysely-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.12)
       '@better-auth/memory-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)


### PR DESCRIPTION
## ms-02 PR 7/8 — 共有ライブラリ auth-helper

3 パッケージ (identity-provider, feed-platform-backend, feed-platform-web) で重複する型・定数・純関数を 1 つの workspace package に抽出。

### 変更内容
- **js/package/auth-helper/**: zero-runtime-dep 共有ライブラリ
  - **src/jwt-payload.ts**: `AppJWTPayload` 型 (sub, iat, exp)
  - **src/constants.ts**: `FEED_SESSION_COOKIE`, `OAUTH_BASE_PATH`
  - **src/cookie-translator.ts**: `extractBearerFromCookie()` 純関数
  - **src/index.ts**: barrel export (oxlint no-barrel-file disable)
  - **src/cookie-translator.test.ts**: 6 vitest テスト
- **feed-platform-backend**: AppJWTPayload 型を auth-helper から import
- **feed-platform-web**: FEED_SESSION_COOKIE 定数を auth-helper から import

### Stack
- Base: feat/ms-02-pr6-backend-rs
- Next: feat/ms-02-pr8-adr-progress