### PR TITLE
chore(nix,ci): wire up roadmap publish and install mdt/roadmap

### DIFF
--- a/.github/workflows/deploy-roadmap.yaml
+++ b/.github/workflows/deploy-roadmap.yaml
@@ -1,0 +1,33 @@
+name: Publish @totto2727/roadmap
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-devbox
+
+      - uses: ./.github/actions/setup-typescript
+        with:
+          install-args: --filter @totto2727/roadmap...
+
+      - name: Build @totto2727/roadmap
+        shell: bash
+        run: |
+          eval "$(devbox shellenv)"
+          vp run -t @totto2727/roadmap#build
+
+      - name: Publish npm:@totto2727/roadmap
+        uses: ./.github/actions/publish-npm
+        with:
+          working-directory: js/app/roadmap

--- a/nix/macos/flake.lock
+++ b/nix/macos/flake.lock
@@ -7,12 +7,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1779103424,
-        "narHash": "sha256-hBYJz5jnRDjACPrwdD064zwMW+s5bdNlG/lNQipLhgM=",
-        "rev": "dd71501fb7005264feb4de78444a2e1518cd4f66",
-        "revCount": 6756,
+        "lastModified": 1779336838,
+        "narHash": "sha256-n1+l78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q+d8=",
+        "rev": "928d72376949e222ea4f07b44828a55b0136422e",
+        "revCount": 6785,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.6756%2Brev-dd71501fb7005264feb4de78444a2e1518cd4f66/019e3ada-3022-79c0-89fd-bdb1831fb861/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.6785%2Brev-928d72376949e222ea4f07b44828a55b0136422e/019e48cd-85e8-7ea3-a958-64f735715110/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -59,12 +59,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1778055827,
-        "narHash": "sha256-0TYOBQU/ZE0leb3j46IgZXKjhhyZC8hqbg1OpUKJupY=",
-        "rev": "d9b62e8ca4b8a536a43e97a2e7f16f28f78d6422",
-        "revCount": 11,
+        "lastModified": 1779456840,
+        "narHash": "sha256-EFwxtBsEaVH5D97sLHd3PPWrl1JUUI4J1fraxKGWCNI=",
+        "rev": "c2e8befaf84bd7bd3fa4efd1bd67aa8efadecdce",
+        "revCount": 12,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/totto2727-dotfiles/npm-packages/0.1.11%2Brev-d9b62e8ca4b8a536a43e97a2e7f16f28f78d6422/019dfc64-84eb-7033-ab47-aa04b7987a6b/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/totto2727-dotfiles/npm-packages/0.1.12%2Brev-c2e8befaf84bd7bd3fa4efd1bd67aa8efadecdce/019e4fe5-66b3-7d51-abd5-bf25a4d54dcb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/share/packages.nix
+++ b/nix/share/packages.nix
@@ -35,6 +35,14 @@ with pkgs;
     packageName = "@totto2727/wt";
   })
   (npm {
+    binName = "mdt";
+    packageName = "@totto2727/mdt";
+  })
+  (npm {
+    binName = "roadmap";
+    packageName = "@totto2727/roadmap";
+  })
+  (npm {
     binName = "codex";
     packageName = "@openai/codex";
   })


### PR DESCRIPTION
## Summary

- Add npm publish workflow for `@totto2727/roadmap` (mirrors `deploy-bw.yaml`).
- Register `@totto2727/mdt` and `@totto2727/roadmap` in `nix/share/packages.nix` via the `npm` wrapper.
- Bump `nix/macos/flake.lock`:
  - `npm-packages`: `d9b62e8` → `c2e8bef` (drops unsupported `npx --node` flag that broke under Node 24; defaults runtime to bun).
  - `home-manager`: revCount 6756 → 6785.

## Why

`js/app/*` ships 5 publishable CLIs (`bw`, `c-plugin`, `mdt`, `roadmap`, `wt`). Only `roadmap` was missing a publish workflow, and `mdt`/`roadmap` were not yet installed via the nix profile. The `npm-packages` bump is required so the new nix wrappers actually run on the current Node 24 toolchain.

## Test plan

- [ ] After merge, verify `deploy-roadmap` runs on next push to `main`.
- [ ] `nix profile upgrade` picks up the new `mdt`/`roadmap` binaries.
- [ ] `mdt --help` / `roadmap --help` resolve (no `MODULE_NOT_FOUND` regressions).