### PR TITLE
feat(c-plugin): preselect already-enabled skills in skill add prompt

### DIFF
--- a/js/app/c-plugin/package.json
+++ b/js/app/c-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totto2727/c-plugin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/js/app/c-plugin/src/cli/skill/add.ts
+++ b/js/app/c-plugin/src/cli/skill/add.ts
@@ -119,10 +119,20 @@ export const addCommand = Command.make(
         return
       }
 
-      const choices = allSkills.map((s) => ({
-        title: `${s.pluginName}/${s.skillName}`,
-        value: s,
-      }))
+      const lockFile = yield* LockFileService.read(agentsDir)
+      const existingRepo = lockFile.repositories.find((r) => r.source === resolved.source)
+      const alreadyEnabled = new Set(
+        (existingRepo?.plugins ?? []).flatMap((p) => p.enabledSkills.map((skill) => `${p.name}/${skill}`)),
+      )
+
+      const choices = allSkills.map((s) => {
+        const key = `${s.pluginName}/${s.skillName}`
+        return {
+          selected: alreadyEnabled.has(key),
+          title: key,
+          value: s,
+        }
+      })
 
       const selected = yield* Prompt.multiSelect({
         choices,
@@ -133,8 +143,6 @@ export const addCommand = Command.make(
         yield* Effect.log('No skills selected.')
         return
       }
-
-      const lockFile = yield* LockFileService.read(agentsDir)
 
       const pluginMap = new Map<string, PluginEntry>()
       for (const skill of selected) {
@@ -154,7 +162,6 @@ export const addCommand = Command.make(
         }
       }
 
-      const existingRepo = lockFile.repositories.find((r) => r.source === resolved.source)
       const mergedPlugins = mergePlugins(existingRepo?.plugins ?? [], [...pluginMap.values()])
       const newRepoEntry: RepositoryEntry =
         resolved.type === 'github'


### PR DESCRIPTION
## Summary

Re-running `c-plugin skill add <repo>` against a repository already present in the lock file now pre-selects the currently enabled skills in the multi-select prompt, instead of starting from an empty selection.

## Changes

- [add.ts](js/app/c-plugin/src/cli/skill/add.ts): read the lock file before the prompt, build a `Set<"plugin/skill">` of already-enabled entries for the same `source`, and pass `selected: true` on matching choices.
- Removed the now-redundant second lock-file lookup further down.
- Bumped `@totto2727/c-plugin` 0.3.1 → 0.3.2.

## Test plan

- `vp test run src/cli/skill/add.test.ts` → 10/10 pass.
- LSP diagnostics clean.
- Manual: `c-plugin skill add <repo>` against a repo with existing entries shows them pre-checked.