### PR TITLE
feat(feed-platform-web): add OAuth 2.1 PKCE client, auth middleware, and dashboard

### DIFF
--- a/js/app/feed-platform-web/app/app.tsx
+++ b/js/app/feed-platform-web/app/app.tsx
@@ -1,9 +1,16 @@
-import { Effect } from 'effect'
+import { FEED_SESSION_COOKIE } from 'auth-helper'
+import { Effect, Predicate } from 'effect'
 import { Hono } from 'hono'
 import { remixRenderer } from 'hono-remix-middleware'
 import { contextStorage } from 'hono/context-storage'
+import { getCookie } from 'hono/cookie'
 import { logger } from 'hono/logger'
 
+import { BackendClient, liveLayer } from '#@/feature/api/client.ts'
+import { handleAuthCallback } from '#@/feature/auth/callback.ts'
+import { authMiddleware } from '#@/feature/auth/middleware.ts'
+import type { AuthUser } from '#@/feature/auth/middleware.ts'
+import { buildAuthorizeUrl, generateChallenge, generateState, generateVerifier } from '#@/feature/auth/oauth-client.ts'
 import * as Greeting from '#@/feature/greeting.ts'
 import { middleware as runtimeMiddleware } from '#@/feature/runtime/hono.ts'
 import type { Variables } from '#@/feature/runtime/hono.ts'
@@ -14,7 +21,7 @@ import { Document } from '#@/ui/document.tsx'
 // Hono の `c.env` 経路を経由しない。Cloudflare 側 binding を後で追加する場合は
 // worker-configuration.d.ts の自動生成 `Env` interface を `Bindings` に渡す形で拡張する。
 interface AppEnv {
-  Variables: Variables
+  Variables: Variables & { user: AuthUser | null }
 }
 
 // middleware order は design.md L268-271 / hono-remix-cloudflare-example-structure.md §I1-6 に従い
@@ -28,6 +35,7 @@ const app: Hono<AppEnv> = new Hono<AppEnv>()
   .use(logger())
   .use(contextStorage())
   .use(runtimeMiddleware)
+  .use('*', authMiddleware)
   .use(
     '*',
     remixRenderer({
@@ -45,6 +53,32 @@ const app: Hono<AppEnv> = new Hono<AppEnv>()
       </Document>,
     ),
   )
+  .get('/login', async () => {
+    const idpBaseUrl = process.env.IDP_BASE_URL ?? 'http://localhost:8787'
+    const clientId = process.env.OAUTH_CLIENT_ID ?? 'feed-platform-web'
+    const webBaseUrl = process.env.WEB_BASE_URL ?? 'http://localhost:8788'
+
+    const verifier = generateVerifier()
+    const state = generateState()
+    const codeChallenge = await generateChallenge(verifier)
+
+    const redirectUri = `${webBaseUrl}/auth/callback`
+    const authorizeUrl = buildAuthorizeUrl({
+      clientId,
+      codeChallenge,
+      idpBaseUrl,
+      redirectUri,
+      state,
+    })
+
+    const headers = new Headers({ Location: authorizeUrl.toString() })
+    headers.append('Set-Cookie', `pkce_verifier=${verifier}; HttpOnly; SameSite=Lax; Path=/`)
+    headers.append('Set-Cookie', `oauth_state=${state}; HttpOnly; SameSite=Lax; Path=/`)
+
+    return new Response(null, { headers, status: 302 })
+  })
+  .get('/auth/callback', (c) => handleAuthCallback(c))
+  .get('/api/me-debug', (c) => c.json({ user: c.var.user }))
   .get('/api/v1/hello', (c) =>
     c.var.runtime.runPromise(
       Effect.gen(function* () {
@@ -53,5 +87,42 @@ const app: Hono<AppEnv> = new Hono<AppEnv>()
       }),
     ),
   )
+  .get('/dashboard', async (c) => {
+    const { user } = c.var
+    if (Predicate.isNullish(user)) {
+      return c.redirect('/login')
+    }
+    const feedSession = getCookie(c, FEED_SESSION_COOKIE) ?? ''
+    const { email, id } = await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const client = yield* BackendClient
+          return yield* client.callMe(feedSession)
+        }),
+        liveLayer,
+      ),
+    )
+    return c.render(
+      <Document>
+        <h1>Dashboard</h1>
+        <p>Logged in as: {email}</p>
+        <p>User ID: {id}</p>
+        <a href='/logout'>Logout</a>
+      </Document>,
+    )
+  })
+  .get('/logout', async (c) => {
+    const idpBaseUrl = process.env.IDP_BASE_URL ?? 'http://localhost:8787'
+    const token = getCookie(c, FEED_SESSION_COOKIE)
+    if (!Predicate.isNullish(token)) {
+      await fetch(`${idpBaseUrl}/api/v1/auth/sign-out`, {
+        headers: { Cookie: `${FEED_SESSION_COOKIE}=${token}` },
+        method: 'POST',
+      }).catch(() => null)
+    }
+    const headers = new Headers({ Location: '/login' })
+    headers.append('Set-Cookie', `${FEED_SESSION_COOKIE}=; Max-Age=0; Path=/; SameSite=Lax; HttpOnly`)
+    return new Response(null, { headers, status: 302 })
+  })
 
 export default app

--- a/js/app/feed-platform-web/app/app.tsx
+++ b/js/app/feed-platform-web/app/app.tsx
@@ -1,4 +1,3 @@
-import { FEED_SESSION_COOKIE } from 'auth-helper'
 import { Effect, Predicate } from 'effect'
 import { Hono } from 'hono'
 import { remixRenderer } from 'hono-remix-middleware'
@@ -8,6 +7,7 @@ import { logger } from 'hono/logger'
 
 import { BackendClient, liveLayer } from '#@/feature/api/client.ts'
 import { handleAuthCallback } from '#@/feature/auth/callback.ts'
+import { FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
 import { authMiddleware } from '#@/feature/auth/middleware.ts'
 import type { AuthUser } from '#@/feature/auth/middleware.ts'
 import { buildAuthorizeUrl, generateChallenge, generateState, generateVerifier } from '#@/feature/auth/oauth-client.ts'

--- a/js/app/feed-platform-web/app/app.tsx
+++ b/js/app/feed-platform-web/app/app.tsx
@@ -115,6 +115,7 @@ const app: Hono<AppEnv> = new Hono<AppEnv>()
     const idpBaseUrl = process.env.IDP_BASE_URL ?? 'http://localhost:8787'
     const token = getCookie(c, FEED_SESSION_COOKIE)
     if (!Predicate.isNullish(token)) {
+      // oxlint-disable-next-line rules/no-fetch -- external IdP sign-out endpoint
       await fetch(`${idpBaseUrl}/api/v1/auth/sign-out`, {
         headers: { Cookie: `${FEED_SESSION_COOKIE}=${token}` },
         method: 'POST',

--- a/js/app/feed-platform-web/app/feature/api/client.test.ts
+++ b/js/app/feed-platform-web/app/feature/api/client.test.ts
@@ -1,0 +1,50 @@
+import { Effect, Exit } from 'effect'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import { BackendClient, liveLayer } from './client.ts'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const runWith = <A, E>(effect: Effect.Effect<A, E, typeof BackendClient.Identifier>) =>
+  Effect.runPromise(Effect.provide(effect, liveLayer))
+
+describe('BackendClient.callMe', () => {
+  it('sends Authorization Bearer header to backend', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ email: 'user@example.com', id: 'user-1' }),
+      ok: true,
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const result = await runWith(
+      Effect.gen(function* () {
+        const client = yield* BackendClient
+        return yield* client.callMe('test-jwt')
+      }),
+    )
+
+    expect(result).toStrictEqual({ email: 'user@example.com', id: 'user-1' })
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/me'),
+      expect.objectContaining({ headers: { Authorization: 'Bearer test-jwt' } }),
+    )
+  })
+
+  it('fails with BackendError when response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }))
+
+    const exit = await Effect.runPromiseExit(
+      Effect.provide(
+        Effect.gen(function* () {
+          const client = yield* BackendClient
+          return yield* client.callMe('bad-jwt')
+        }),
+        liveLayer,
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+})

--- a/js/app/feed-platform-web/app/feature/api/client.ts
+++ b/js/app/feed-platform-web/app/feature/api/client.ts
@@ -22,6 +22,7 @@ export const liveLayer = Layer.succeed(BackendClient, {
     Effect.tryPromise({
       catch: (cause) => new BackendError({ cause }),
       try: async () => {
+        // oxlint-disable-next-line rules/no-fetch -- external backend API
         const res = await fetch(`${BACKEND_BASE_URL}/api/v1/me`, {
           headers: { Authorization: `Bearer ${feedSession}` },
         })

--- a/js/app/feed-platform-web/app/feature/api/client.ts
+++ b/js/app/feed-platform-web/app/feature/api/client.ts
@@ -1,0 +1,47 @@
+import { Context, Data, Effect, Layer, Predicate } from 'effect'
+
+export interface UserDTO {
+  readonly id: string
+  readonly email: string
+}
+
+export class BackendError extends Data.TaggedError('BackendError')<{
+  cause: unknown
+}> {}
+
+interface BackendClientService {
+  readonly callMe: (feedSession: string) => Effect.Effect<UserDTO, BackendError>
+}
+
+export const BackendClient = Context.Service<BackendClientService>('BackendClient')
+
+const BACKEND_BASE_URL = process.env.BACKEND_BASE_URL ?? 'http://localhost:8789'
+
+export const liveLayer = Layer.succeed(BackendClient, {
+  callMe: (feedSession: string) =>
+    Effect.tryPromise({
+      catch: (cause) => new BackendError({ cause }),
+      try: async () => {
+        const res = await fetch(`${BACKEND_BASE_URL}/api/v1/me`, {
+          headers: { Authorization: `Bearer ${feedSession}` },
+        })
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`)
+        }
+        const data: unknown = await res.json()
+        if (!Predicate.isObject(data)) {
+          throw new TypeError('Invalid response shape')
+        }
+        const { id } = data
+        const { email } = data
+        if (!Predicate.isString(id) || !Predicate.isString(email)) {
+          throw new TypeError('Invalid response fields')
+        }
+        return { email, id }
+      },
+    }),
+})
+
+export const mockLayer = Layer.succeed(BackendClient, {
+  callMe: () => Effect.succeed({ email: 'mock@example.com', id: 'mock-user' }),
+})

--- a/js/app/feed-platform-web/app/feature/auth/callback.test.ts
+++ b/js/app/feed-platform-web/app/feature/auth/callback.test.ts
@@ -1,6 +1,7 @@
-import { FEED_SESSION_COOKIE } from 'auth-helper'
 import { Hono } from 'hono'
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import { FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
 
 import { handleAuthCallback } from './callback.ts'
 

--- a/js/app/feed-platform-web/app/feature/auth/callback.test.ts
+++ b/js/app/feed-platform-web/app/feature/auth/callback.test.ts
@@ -1,0 +1,68 @@
+import { FEED_SESSION_COOKIE } from 'auth-helper'
+import { Hono } from 'hono'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import { handleAuthCallback } from './callback.ts'
+
+const makeApp = () => new Hono().get('/auth/callback', (c) => handleAuthCallback(c))
+
+const makeCookieHeader = (pairs: Record<string, string>) =>
+  Object.entries(pairs)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ')
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('handleAuthCallback', () => {
+  it('returns 403 when state mismatches', async () => {
+    const app = makeApp()
+    const res = await app.request('/auth/callback?code=abc&state=wrong', {
+      headers: { cookie: makeCookieHeader({ oauth_state: 'correct', pkce_verifier: 'ver' }) },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('redirects to /dashboard and sets feed-session on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ access_token: 'jwt-token-here' }),
+        ok: true,
+      }),
+    )
+    const app = makeApp()
+    const res = await app.request('/auth/callback?code=authcode&state=mystate', {
+      headers: { cookie: makeCookieHeader({ oauth_state: 'mystate', pkce_verifier: 'verifier123' }) },
+    })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('/dashboard')
+    const cookies = res.headers.getSetCookie()
+    expect(cookies.some((c) => c.startsWith(`${FEED_SESSION_COOKIE}=jwt-token-here`))).toBe(true)
+  })
+
+  it('returns 401 when token endpoint returns non-200', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
+    const app = makeApp()
+    const res = await app.request('/auth/callback?code=authcode&state=mystate', {
+      headers: { cookie: makeCookieHeader({ oauth_state: 'mystate', pkce_verifier: 'verifier123' }) },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when access_token is missing from response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ error: 'invalid_grant' }),
+        ok: true,
+      }),
+    )
+    const app = makeApp()
+    const res = await app.request('/auth/callback?code=authcode&state=mystate', {
+      headers: { cookie: makeCookieHeader({ oauth_state: 'mystate', pkce_verifier: 'verifier123' }) },
+    })
+    expect(res.status).toBe(401)
+  })
+})

--- a/js/app/feed-platform-web/app/feature/auth/callback.ts
+++ b/js/app/feed-platform-web/app/feature/auth/callback.ts
@@ -1,7 +1,8 @@
-import { FEED_SESSION_COOKIE } from 'auth-helper'
 import { Predicate, String } from 'effect'
 import type { Context } from 'hono'
 import { getCookie } from 'hono/cookie'
+
+import { FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
 
 export const handleAuthCallback = async (c: Context): Promise<Response> => {
   const code = c.req.query('code')
@@ -31,8 +32,8 @@ export const handleAuthCallback = async (c: Context): Promise<Response> => {
     grant_type: 'authorization_code',
     redirect_uri: redirectUri,
   }
-  if (clientSecret.length > 0) {
-    bodyParams['client_secret'] = clientSecret
+  if (String.isNonEmpty(clientSecret)) {
+    bodyParams.client_secret = clientSecret
   }
 
   const tokenRes = await fetch(`${idpBaseUrl}/api/v1/auth/oauth2/token`, {

--- a/js/app/feed-platform-web/app/feature/auth/callback.ts
+++ b/js/app/feed-platform-web/app/feature/auth/callback.ts
@@ -1,0 +1,65 @@
+import { FEED_SESSION_COOKIE } from 'auth-helper'
+import { Predicate, String } from 'effect'
+import type { Context } from 'hono'
+import { getCookie } from 'hono/cookie'
+
+export const handleAuthCallback = async (c: Context): Promise<Response> => {
+  const code = c.req.query('code')
+  const state = c.req.query('state')
+
+  const storedState = getCookie(c, 'oauth_state')
+  const verifier = getCookie(c, 'pkce_verifier')
+
+  if (Predicate.isNullish(state) || Predicate.isNullish(storedState) || state !== storedState) {
+    return new Response('state mismatch', { status: 403 })
+  }
+
+  if (Predicate.isNullish(code) || Predicate.isNullish(verifier)) {
+    return new Response('missing code or verifier', { status: 400 })
+  }
+
+  const idpBaseUrl = process.env.IDP_BASE_URL ?? 'http://localhost:8787'
+  const clientId = process.env.OAUTH_CLIENT_ID ?? 'feed-platform-web'
+  const clientSecret = process.env.OAUTH_CLIENT_SECRET ?? ''
+  const webBaseUrl = process.env.WEB_BASE_URL ?? 'http://localhost:8788'
+  const redirectUri = `${webBaseUrl}/auth/callback`
+
+  const bodyParams: Record<string, string> = {
+    client_id: clientId,
+    code,
+    code_verifier: verifier,
+    grant_type: 'authorization_code',
+    redirect_uri: redirectUri,
+  }
+  if (clientSecret.length > 0) {
+    bodyParams['client_secret'] = clientSecret
+  }
+
+  const tokenRes = await fetch(`${idpBaseUrl}/api/v1/auth/oauth2/token`, {
+    body: new URLSearchParams(bodyParams).toString(),
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    method: 'POST',
+  })
+
+  if (!tokenRes.ok) {
+    return new Response('auth failed', { status: 401 })
+  }
+
+  const tokenJson: unknown = await tokenRes.json()
+  if (!Predicate.isObject(tokenJson)) {
+    return new Response('auth failed', { status: 401 })
+  }
+
+  const accessToken = tokenJson.access_token
+
+  if (!Predicate.isString(accessToken) || String.isEmpty(accessToken)) {
+    return new Response('auth failed', { status: 401 })
+  }
+
+  const headers = new Headers({ Location: '/dashboard' })
+  headers.append('Set-Cookie', `${FEED_SESSION_COOKIE}=${accessToken}; HttpOnly; SameSite=Lax; Path=/`)
+  headers.append('Set-Cookie', 'pkce_verifier=; Max-Age=0; Path=/; SameSite=Lax; HttpOnly')
+  headers.append('Set-Cookie', 'oauth_state=; Max-Age=0; Path=/; SameSite=Lax; HttpOnly')
+
+  return new Response(null, { headers, status: 302 })
+}

--- a/js/app/feed-platform-web/app/feature/auth/callback.ts
+++ b/js/app/feed-platform-web/app/feature/auth/callback.ts
@@ -36,6 +36,7 @@ export const handleAuthCallback = async (c: Context): Promise<Response> => {
     bodyParams.client_secret = clientSecret
   }
 
+  // oxlint-disable-next-line rules/no-fetch -- external OAuth 2.1 token endpoint
   const tokenRes = await fetch(`${idpBaseUrl}/api/v1/auth/oauth2/token`, {
     body: new URLSearchParams(bodyParams).toString(),
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/js/app/feed-platform-web/app/feature/auth/constants.ts
+++ b/js/app/feed-platform-web/app/feature/auth/constants.ts
@@ -1,0 +1,1 @@
+export const FEED_SESSION_COOKIE = 'feed-session'

--- a/js/app/feed-platform-web/app/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-web/app/feature/auth/middleware.test.ts
@@ -1,6 +1,7 @@
-import { FEED_SESSION_COOKIE } from 'auth-helper'
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import { FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
 
 const mockJwtVerify = vi.fn()
 

--- a/js/app/feed-platform-web/app/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-web/app/feature/auth/middleware.test.ts
@@ -1,0 +1,52 @@
+import { FEED_SESSION_COOKIE } from 'auth-helper'
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+const mockJwtVerify = vi.fn()
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn().mockReturnValue({}),
+  jwtVerify: mockJwtVerify,
+}))
+
+const { authMiddleware } = await import('./middleware.ts')
+
+const makeApp = () =>
+  new Hono<{ Variables: { user: { id: string; email: string } | null } }>()
+    .use('*', authMiddleware)
+    .get('/test', (c) => c.json({ user: c.var.user }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('authMiddleware', () => {
+  it('sets user to null when no cookie present', async () => {
+    const app = makeApp()
+    const res = await app.request('/test')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toStrictEqual({ user: null })
+  })
+
+  it('sets user from valid JWT payload', async () => {
+    mockJwtVerify.mockResolvedValue({
+      payload: { email: 'test@example.com', sub: 'user-123' },
+    })
+    const app = makeApp()
+    const res = await app.request('/test', {
+      headers: { cookie: `${FEED_SESSION_COOKIE}=valid.jwt.token` },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toStrictEqual({ user: { email: 'test@example.com', id: 'user-123' } })
+  })
+
+  it('sets user to null when JWT verification fails', async () => {
+    mockJwtVerify.mockRejectedValue(new Error('Invalid JWT'))
+    const app = makeApp()
+    const res = await app.request('/test', {
+      headers: { cookie: `${FEED_SESSION_COOKIE}=tampered.jwt.token` },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toStrictEqual({ user: null })
+  })
+})

--- a/js/app/feed-platform-web/app/feature/auth/middleware.ts
+++ b/js/app/feed-platform-web/app/feature/auth/middleware.ts
@@ -1,8 +1,9 @@
-import { FEED_SESSION_COOKIE } from 'auth-helper'
 import { Predicate } from 'effect'
 import { getCookie } from 'hono/cookie'
 import { createMiddleware } from 'hono/factory'
 import { createRemoteJWKSet, jwtVerify } from 'jose'
+
+import { FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
 
 export interface AuthUser {
   readonly id: string

--- a/js/app/feed-platform-web/app/feature/auth/middleware.ts
+++ b/js/app/feed-platform-web/app/feature/auth/middleware.ts
@@ -1,0 +1,36 @@
+import { FEED_SESSION_COOKIE } from 'auth-helper'
+import { Predicate } from 'effect'
+import { getCookie } from 'hono/cookie'
+import { createMiddleware } from 'hono/factory'
+import { createRemoteJWKSet, jwtVerify } from 'jose'
+
+export interface AuthUser {
+  readonly id: string
+  readonly email: string
+}
+
+const jwks = createRemoteJWKSet(new URL(`${process.env.IDP_BASE_URL ?? 'http://localhost:8787'}/api/v1/auth/jwks`))
+
+export const authMiddleware = createMiddleware<{
+  Variables: { user: AuthUser | null }
+}>(async (c, next) => {
+  const token = getCookie(c, FEED_SESSION_COOKIE)
+
+  if (Predicate.isNullish(token)) {
+    c.set('user', null)
+    await next()
+    return
+  }
+
+  try {
+    const { payload } = await jwtVerify(token, jwks)
+    const { sub } = payload
+    const email = Predicate.isString(payload.email) ? payload.email : ''
+    c.set('user', Predicate.isNullish(sub) ? null : { email, id: sub })
+  } catch (error) {
+    console.warn('[auth] JWT verification failed:', error instanceof Error ? error.message : String(error))
+    c.set('user', null)
+  }
+
+  await next()
+})

--- a/js/app/feed-platform-web/app/feature/auth/oauth-client.test.ts
+++ b/js/app/feed-platform-web/app/feature/auth/oauth-client.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vite-plus/test'
+
+import { buildAuthorizeUrl, generateChallenge, generateState, generateVerifier } from './oauth-client.ts'
+
+describe('PKCE', () => {
+  test('verifier is 43 chars URL-safe base64', () => {
+    const verifier = generateVerifier()
+
+    expect(verifier).toMatch(/^[\w-]+$/)
+    expect(verifier.length).toBe(43)
+  })
+
+  test('challenge is SHA-256 of verifier (S256)', async () => {
+    const verifier = generateVerifier()
+
+    const challenge = await generateChallenge(verifier)
+    const repeatedChallenge = await generateChallenge(verifier)
+
+    expect(challenge).toBe(repeatedChallenge)
+    expect(challenge).toMatch(/^[\w-]+$/)
+  })
+
+  test('state is 43 chars URL-safe base64', () => {
+    const state = generateState()
+
+    expect(state).toMatch(/^[\w-]+$/)
+    expect(state.length).toBe(43)
+  })
+})
+
+describe('buildAuthorizeUrl', () => {
+  test('includes required OAuth 2.1 + PKCE params', async () => {
+    const verifier = generateVerifier()
+    const challenge = await generateChallenge(verifier)
+    const state = generateState()
+
+    const url = buildAuthorizeUrl({
+      clientId: 'test-client',
+      codeChallenge: challenge,
+      idpBaseUrl: 'https://idp.example.com',
+      redirectUri: 'https://web.example.com/auth/callback',
+      state,
+    })
+
+    expect(url.pathname).toBe('/api/v1/auth/oauth2/authorize')
+    expect(url.searchParams.get('code_challenge')).toBe(challenge)
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(url.searchParams.get('client_id')).toBe('test-client')
+    expect(url.searchParams.get('redirect_uri')).toBe('https://web.example.com/auth/callback')
+    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.searchParams.get('scope')).toBe('openid profile email')
+    expect(url.searchParams.get('state')).toBe(state)
+    expect(url.searchParams.get('code_challenge_method')).not.toBe('plain')
+  })
+})

--- a/js/app/feed-platform-web/app/feature/auth/oauth-client.ts
+++ b/js/app/feed-platform-web/app/feature/auth/oauth-client.ts
@@ -1,0 +1,43 @@
+const toBase64Url = (buffer: ArrayBuffer): string =>
+  btoa(String.fromCodePoint(...new Uint8Array(buffer)))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '')
+
+export const generateVerifier = (): string => {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return toBase64Url(bytes.buffer)
+}
+
+export const generateChallenge = async (verifier: string): Promise<string> => {
+  const data = new TextEncoder().encode(verifier)
+  const hash = await crypto.subtle.digest('SHA-256', data)
+  return toBase64Url(hash)
+}
+
+export const generateState = (): string => {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return toBase64Url(bytes.buffer)
+}
+
+export interface AuthorizeParams {
+  readonly clientId: string
+  readonly redirectUri: string
+  readonly idpBaseUrl: string
+  readonly codeChallenge: string
+  readonly state: string
+}
+
+export const buildAuthorizeUrl = (params: AuthorizeParams): URL => {
+  const url = new URL('/api/v1/auth/oauth2/authorize', params.idpBaseUrl)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('client_id', params.clientId)
+  url.searchParams.set('redirect_uri', params.redirectUri)
+  url.searchParams.set('code_challenge', params.codeChallenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  url.searchParams.set('state', params.state)
+  url.searchParams.set('scope', 'openid profile email')
+  return url
+}

--- a/js/app/feed-platform-web/package.json
+++ b/js/app/feed-platform-web/package.json
@@ -13,7 +13,6 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "catalog:cloudflare",
     "@totto2727/fp": "workspace:*",
-    "auth-helper": "workspace:*",
     "better-auth": "catalog:auth",
     "effect": "catalog:effect",
     "effect-hono": "workspace:*",

--- a/js/app/feed-platform-web/vite.config.ts
+++ b/js/app/feed-platform-web/vite.config.ts
@@ -11,14 +11,22 @@ const taskInput = defineTaskInputFromOutput({
   },
 })
 
+// @cloudflare/vite-plugin rejects resolve.external injected by Vite+ in vitest mode.
+// Unit tests do not need live Cloudflare bindings, so skip the plugin for tests.
+const isTest = Boolean(process.env.VITEST)
+
 export default defineConfig({
-  plugins: [remix({ clientEntry: 'app/assets/entry.ts' }), cloudflare()],
+  plugins: [remix({ clientEntry: 'app/assets/entry.ts' }), ...(isTest ? [] : [cloudflare()])],
   run: {
     tasks: {
       build: {
         command: 'vp build',
         dependsOn: ['setup'],
         input: taskInput.build,
+      },
+      check: {
+        command: 'vp check',
+        dependsOn: ['setup'],
       },
       setup: {
         command: '',

--- a/js/app/feed-platform-web/wrangler.jsonc
+++ b/js/app/feed-platform-web/wrangler.jsonc
@@ -14,6 +14,13 @@
     "enabled": true,
     "head_sampling_rate": 1,
   },
+  "vars": {
+    "IDP_BASE_URL": "http://localhost:8787",
+    "OAUTH_CLIENT_ID": "feed-platform-web",
+    "WEB_BASE_URL": "http://localhost:8788",
+    "BACKEND_BASE_URL": "http://localhost:8789",
+    "OAUTH_CLIENT_SECRET": "dev-secret-pkce-not-used",
+  },
   "placement": {
     "mode": "smart",
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,9 +275,6 @@ importers:
       '@totto2727/fp':
         specifier: workspace:*
         version: link:../../package/fp
-      auth-helper:
-        specifier: workspace:*
-        version: link:../../package/auth-helper
       better-auth:
         specifier: catalog:auth
         version: 1.5.5(@tanstack/react-start@1.167.48(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(mongodb@7.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.7)


### PR DESCRIPTION
## ms-02 PR 5/8 — feed-platform-web OAuth 2.1 PKCE

- OAuth 2.1 PKCE authorization code flow client
- Auth middleware with JWT verification via JWKS
- Cookie-to-Bearer BFF pattern
- Protected /dashboard route

### Stack
- Base: feat/ms-02-pr4-idp-ui