### PR TITLE
feat(feed-platform-backend): add JWT verification and protected /api/v1/me endpoint

### DIFF
--- a/js/app/feed-platform-backend/package.json
+++ b/js/app/feed-platform-backend/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@totto2727/fp": "workspace:*",
-    "auth-helper": "workspace:*",
     "effect": "catalog:effect",
     "effect-hono": "workspace:*",
     "hono": "catalog:hono",

--- a/js/app/feed-platform-backend/src/feature/auth/jwt-payload.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/jwt-payload.ts
@@ -1,0 +1,5 @@
+export interface AppJWTPayload {
+  readonly sub: string
+  readonly iat: number
+  readonly exp: number
+}

--- a/js/app/feed-platform-backend/src/feature/auth/jwt.test.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/jwt.test.ts
@@ -1,0 +1,61 @@
+import { Effect, Exit } from 'effect'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+const mockJwtVerify = vi.fn()
+const mockCreateRemoteJWKSet = vi.fn().mockReturnValue({})
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: mockCreateRemoteJWKSet,
+  jwtVerify: mockJwtVerify,
+}))
+
+const { JwtService, liveLayer } = await import('./jwt.ts')
+
+const runVerify = (token: string) =>
+  Effect.runPromiseExit(
+    Effect.provide(
+      Effect.gen(function* () {
+        const jwt = yield* JwtService
+        return yield* jwt.verify(token)
+      }),
+      liveLayer,
+    ),
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('JwtService', () => {
+  it('returns payload for a valid JWT', async () => {
+    mockJwtVerify.mockResolvedValue({
+      payload: { exp: 9_999_999, iat: 1_000_000, sub: 'user-123' },
+    })
+    const exit = await runVerify('valid.jwt.token')
+    expect(Exit.isSuccess(exit)).toBe(true)
+    if (Exit.isSuccess(exit)) {
+      expect(exit.value).toStrictEqual({ exp: 9_999_999, iat: 1_000_000, sub: 'user-123' })
+    }
+  })
+
+  it('fails with JwtVerifyError for an invalid JWT', async () => {
+    mockJwtVerify.mockRejectedValue(new Error('signature verification failed'))
+    const exit = await runVerify('tampered.jwt.token')
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it('fails with JwtVerifyError for wrong issuer', async () => {
+    mockJwtVerify.mockRejectedValue(new Error('unexpected "iss" claim value'))
+    const exit = await runVerify('wrong-issuer.jwt.token')
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it('createRemoteJWKSet is called once at module scope (JWKS cache)', async () => {
+    mockJwtVerify.mockResolvedValue({
+      payload: { exp: 9_999_999, iat: 1_000_000, sub: 'user-1' },
+    })
+    await runVerify('token-1')
+    await runVerify('token-2')
+    expect(mockCreateRemoteJWKSet).toHaveBeenCalledTimes(0)
+  })
+})

--- a/js/app/feed-platform-backend/src/feature/auth/jwt.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/jwt.ts
@@ -1,0 +1,44 @@
+import type { AppJWTPayload } from 'auth-helper'
+import { Context, Data, Effect, Layer, Predicate } from 'effect'
+import { createRemoteJWKSet, jwtVerify } from 'jose'
+
+export class JwtVerifyError extends Data.TaggedError('JwtVerifyError')<{
+  readonly cause: unknown
+}> {}
+
+interface JwtService {
+  readonly verify: (token: string) => Effect.Effect<AppJWTPayload, JwtVerifyError>
+}
+
+export const JwtService = Context.Service<JwtService>('JwtService')
+
+const IDP_JWKS_URL = process.env.IDP_JWKS_URL ?? 'http://localhost:8787/api/v1/auth/jwks'
+const IDP_BASE_URL = process.env.IDP_BASE_URL ?? 'http://localhost:8787'
+const FEED_PLATFORM_AUDIENCE = process.env.FEED_PLATFORM_AUDIENCE ?? 'feed-platform-web'
+
+const remoteJwkSet = createRemoteJWKSet(new URL(IDP_JWKS_URL))
+
+export const liveLayer = Layer.succeed(JwtService, {
+  verify: (token: string) =>
+    Effect.tryPromise({
+      catch: (cause) => new JwtVerifyError({ cause }),
+      try: async () => {
+        const { payload } = await jwtVerify(token, remoteJwkSet, {
+          algorithms: ['ES256'],
+          audience: FEED_PLATFORM_AUDIENCE,
+          issuer: IDP_BASE_URL,
+        })
+        const { sub, iat, exp } = payload
+        if (!Predicate.isString(sub)) {
+          throw new TypeError('Missing sub claim')
+        }
+        if (!Predicate.isNumber(iat)) {
+          throw new TypeError('Missing iat claim')
+        }
+        if (!Predicate.isNumber(exp)) {
+          throw new TypeError('Missing exp claim')
+        }
+        return { exp, iat, sub }
+      },
+    }),
+})

--- a/js/app/feed-platform-backend/src/feature/auth/jwt.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/jwt.ts
@@ -1,6 +1,7 @@
-import type { AppJWTPayload } from 'auth-helper'
 import { Context, Data, Effect, Layer, Predicate } from 'effect'
 import { createRemoteJWKSet, jwtVerify } from 'jose'
+
+import type { AppJWTPayload } from '#@/feature/auth/jwt-payload.ts'
 
 export class JwtVerifyError extends Data.TaggedError('JwtVerifyError')<{
   readonly cause: unknown

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
@@ -1,0 +1,59 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+const mockJwtVerify = vi.fn()
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn().mockReturnValue({}),
+  jwtVerify: mockJwtVerify,
+}))
+
+const { authMiddleware } = await import('./middleware.ts')
+
+const makeApp = () =>
+  new Hono<{ Variables: { user: { sub: string; iat: number; exp: number } } }>()
+    .use('/api/*', authMiddleware)
+    .get('/api/v1/me', (c) => c.json(c.var.user))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('authMiddleware', () => {
+  it('sets user and passes through for a valid Bearer token', async () => {
+    mockJwtVerify.mockResolvedValue({
+      payload: { exp: 9_999_999, iat: 1_000_000, sub: 'user-123' },
+    })
+    const app = makeApp()
+    const res = await app.request('/api/v1/me', {
+      headers: { Authorization: 'Bearer valid.jwt.token' },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toStrictEqual({ exp: 9_999_999, iat: 1_000_000, sub: 'user-123' })
+  })
+
+  it('returns 401 when Authorization header is absent', async () => {
+    const app = makeApp()
+    const res = await app.request('/api/v1/me')
+    expect(res.status).toBe(401)
+    expect(res.headers.get('WWW-Authenticate')).toBe('Bearer error="invalid_token"')
+  })
+
+  it('returns 401 when only a Cookie is present (no Authorization)', async () => {
+    const app = makeApp()
+    const res = await app.request('/api/v1/me', {
+      headers: { Cookie: 'feed-session=valid.jwt.token' },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 for an invalid Bearer token', async () => {
+    mockJwtVerify.mockRejectedValue(new Error('signature verification failed'))
+    const app = makeApp()
+    const res = await app.request('/api/v1/me', {
+      headers: { Authorization: 'Bearer tampered.jwt.token' },
+    })
+    expect(res.status).toBe(401)
+    expect(res.headers.get('WWW-Authenticate')).toBe('Bearer error="invalid_token"')
+  })
+})

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.ts
@@ -1,7 +1,7 @@
-import type { AppJWTPayload } from 'auth-helper'
 import { Effect, Exit, Predicate, String } from 'effect'
 import { createMiddleware } from 'hono/factory'
 
+import type { AppJWTPayload } from '#@/feature/auth/jwt-payload.ts'
 import { JwtService, liveLayer } from '#@/feature/auth/jwt.ts'
 
 export const authMiddleware = createMiddleware<{

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.ts
@@ -1,0 +1,38 @@
+import type { AppJWTPayload } from 'auth-helper'
+import { Effect, Exit, Predicate, String } from 'effect'
+import { createMiddleware } from 'hono/factory'
+
+import { JwtService, liveLayer } from '#@/feature/auth/jwt.ts'
+
+export const authMiddleware = createMiddleware<{
+  Variables: { user: AppJWTPayload }
+}>(async (c, next) => {
+  const authorization = c.req.header('Authorization')
+  if (Predicate.isNullish(authorization) || !authorization.startsWith('Bearer ')) {
+    return c.json({ error: 'Unauthorized' }, 401, {
+      'WWW-Authenticate': 'Bearer error="invalid_token"',
+    })
+  }
+  const token = authorization.slice('Bearer '.length)
+  if (String.isEmpty(token)) {
+    return c.json({ error: 'Unauthorized' }, 401, {
+      'WWW-Authenticate': 'Bearer error="invalid_token"',
+    })
+  }
+  const exit = await Effect.runPromiseExit(
+    Effect.provide(
+      Effect.gen(function* () {
+        const jwt = yield* JwtService
+        return yield* jwt.verify(token)
+      }),
+      liveLayer,
+    ),
+  )
+  if (!Exit.isSuccess(exit)) {
+    return c.json({ error: 'Unauthorized' }, 401, {
+      'WWW-Authenticate': 'Bearer error="invalid_token"',
+    })
+  }
+  c.set('user', exit.value)
+  return next()
+})

--- a/js/app/feed-platform-backend/src/worker/bff/worker.ts
+++ b/js/app/feed-platform-backend/src/worker/bff/worker.ts
@@ -1,8 +1,10 @@
+import type { AppJWTPayload } from 'auth-helper'
 import { Effect } from 'effect'
 import { Hono } from 'hono'
 import { contextStorage } from 'hono/context-storage'
 import { logger } from 'hono/logger'
 
+import { authMiddleware } from '#@/feature/auth/middleware.ts'
 import * as Health from '#@/feature/health.ts'
 import type { Variables } from '#@/feature/runtime/hono.ts'
 import { middleware as runtimeMiddleware } from '#@/feature/runtime/hono.ts'
@@ -12,7 +14,7 @@ import { middleware as runtimeMiddleware } from '#@/feature/runtime/hono.ts'
 // Hono の `c.env` 経路を経由しない。Cloudflare 側 binding を後で追加する場合は
 // worker-configuration.d.ts の自動生成 `Env` interface を `Bindings` に渡す形で拡張する。
 interface AppEnv {
-  Variables: Variables
+  Variables: Variables & { user: AppJWTPayload }
 }
 
 // BFF entry: ms-01 段階では health entry と同形の Hello World を返すのみ。
@@ -31,5 +33,7 @@ const app = new Hono<AppEnv>()
       }),
     ),
   )
+  .use('/api/*', authMiddleware)
+  .get('/api/v1/me', (c) => c.json(c.var.user))
 
 export default app

--- a/js/app/feed-platform-backend/src/worker/bff/worker.ts
+++ b/js/app/feed-platform-backend/src/worker/bff/worker.ts
@@ -1,9 +1,9 @@
-import type { AppJWTPayload } from 'auth-helper'
 import { Effect } from 'effect'
 import { Hono } from 'hono'
 import { contextStorage } from 'hono/context-storage'
 import { logger } from 'hono/logger'
 
+import type { AppJWTPayload } from '#@/feature/auth/jwt-payload.ts'
 import { authMiddleware } from '#@/feature/auth/middleware.ts'
 import * as Health from '#@/feature/health.ts'
 import type { Variables } from '#@/feature/runtime/hono.ts'

--- a/js/app/feed-platform-backend/src/worker/bff/wrangler.jsonc
+++ b/js/app/feed-platform-backend/src/worker/bff/wrangler.jsonc
@@ -11,4 +11,9 @@
   "placement": {
     "mode": "smart",
   },
+  "vars": {
+    "IDP_BASE_URL": "http://localhost:8787",
+    "IDP_JWKS_URL": "http://localhost:8787/api/v1/auth/jwks",
+    "FEED_PLATFORM_AUDIENCE": "feed-platform-web",
+  },
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,9 +248,6 @@ importers:
       '@totto2727/fp':
         specifier: workspace:*
         version: link:../../package/fp
-      auth-helper:
-        specifier: workspace:*
-        version: link:../../package/auth-helper
       effect:
         specifier: catalog:effect
         version: 4.0.0-beta.65


### PR DESCRIPTION
## ms-02 PR 6/8 — feed-platform-backend JWT verification

- JWT verification service with JWKS remote key set
- Bearer-only auth middleware (no Cookie support)
- Protected /api/v1/me endpoint

### Stack
- Base: feat/ms-02-pr5-web-oauth