### PR TITLE
test(feed-platform-backend): real-jose e2e mock test for Bearer auth (ms-02 follow-up)

### DIFF
--- a/js/app/feed-platform-backend/src/feature/auth/jwt-e2e.test.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/jwt-e2e.test.ts
@@ -1,0 +1,156 @@
+import { Hono } from 'hono'
+import type * as JoseModule from 'jose'
+import { generateKeyPair, SignJWT } from 'jose'
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+import type { AppJWTPayload } from '#@/feature/auth/jwt-payload.ts'
+
+const IDP_BASE_URL = 'http://localhost:8787'
+const AUDIENCE = 'feed-platform-web'
+const TEST_KID = 'test-key-1'
+
+const issuerKeyPair = await generateKeyPair('ES256', { extractable: true })
+const otherKeyPair = await generateKeyPair('ES256', { extractable: true })
+
+vi.mock('jose', async (importOriginal) => {
+  const actual = await importOriginal<typeof JoseModule>()
+  return {
+    ...actual,
+    createRemoteJWKSet: () => () => Promise.resolve(issuerKeyPair.publicKey),
+  }
+})
+
+const { authMiddleware } = await import('./middleware.ts')
+
+const makeBackendApp = () =>
+  new Hono<{ Variables: { user: AppJWTPayload } }>().use('/api/*', authMiddleware).get('/api/v1/me', (c) => {
+    const { sub, email } = c.var.user
+    return c.json({ email, id: sub })
+  })
+
+const signValidJwt = (overrides: { sub?: string; email?: string } = {}) =>
+  new SignJWT({ email: overrides.email ?? 'alice@example.com' })
+    .setProtectedHeader({ alg: 'ES256', kid: TEST_KID })
+    .setSubject(overrides.sub ?? 'user-alice')
+    .setIssuer(IDP_BASE_URL)
+    .setAudience(AUDIENCE)
+    .setIssuedAt()
+    .setExpirationTime('10m')
+    .sign(issuerKeyPair.privateKey)
+
+describe('backend JWT verification — real ES256 signing + verification (e2e mock)', () => {
+  it('accepts a real ES256 JWT signed by the IdP key and returns the user', async () => {
+    const token = await signValidJwt()
+    const app = makeBackendApp()
+    const res = await app.request('/api/v1/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toStrictEqual({ email: 'alice@example.com', id: 'user-alice' })
+  })
+
+  it('returns 401 + WWW-Authenticate when Authorization header is missing', async () => {
+    const app = makeBackendApp()
+    const res = await app.request('/api/v1/me')
+    expect(res.status).toBe(401)
+    expect(res.headers.get('WWW-Authenticate')).toBe('Bearer error="invalid_token"')
+  })
+
+  it('returns 401 when Authorization header does not use Bearer scheme', async () => {
+    const app = makeBackendApp()
+    const res = await app.request('/api/v1/me', {
+      headers: { Authorization: 'Basic abc123' },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when Bearer token is empty', async () => {
+    const app = makeBackendApp()
+    const res = await app.request('/api/v1/me', {
+      headers: { Authorization: 'Bearer ' },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 for a JWT signed by a different (untrusted) key', async () => {
+    const token = await new SignJWT({ email: 'alice@example.com' })
+      .setProtectedHeader({ alg: 'ES256', kid: TEST_KID })
+      .setSubject('user-alice')
+      .setIssuer(IDP_BASE_URL)
+      .setAudience(AUDIENCE)
+      .setIssuedAt()
+      .setExpirationTime('10m')
+      .sign(otherKeyPair.privateKey)
+    const app = makeBackendApp()
+    const res = await app.request('/api/v1/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 for a JWT with the wrong issuer claim', async () => {
+    const token = await new SignJWT({ email: 'alice@example.com' })
+      .setProtectedHeader({ alg: 'ES256', kid: TEST_KID })
+      .setSubject('user-alice')
+      .setIssuer('https://evil.example.com')
+      .setAudience(AUDIENCE)
+      .setIssuedAt()
+      .setExpirationTime('10m')
+      .sign(issuerKeyPair.privateKey)
+    const app = makeBackendApp()
+    const res = await app.request('/api/v1/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 for a JWT with the wrong audience claim', async () => {
+    const token = await new SignJWT({ email: 'alice@example.com' })
+      .setProtectedHeader({ alg: 'ES256', kid: TEST_KID })
+      .setSubject('user-alice')
+      .setIssuer(IDP_BASE_URL)
+      .setAudience('other-client')
+      .setIssuedAt()
+      .setExpirationTime('10m')
+      .sign(issuerKeyPair.privateKey)
+    const app = makeBackendApp()
+    const res = await app.request('/api/v1/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 for an expired JWT (exp in the past)', async () => {
+    const token = await new SignJWT({ email: 'alice@example.com' })
+      .setProtectedHeader({ alg: 'ES256', kid: TEST_KID })
+      .setSubject('user-alice')
+      .setIssuer(IDP_BASE_URL)
+      .setAudience(AUDIENCE)
+      .setIssuedAt(0)
+      .setExpirationTime(1)
+      .sign(issuerKeyPair.privateKey)
+    const app = makeBackendApp()
+    const res = await app.request('/api/v1/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 for a JWT signed with HS256 instead of the required ES256', async () => {
+    const hsKey = new Uint8Array(32)
+    hsKey.fill(0xab)
+    const token = await new SignJWT({ email: 'alice@example.com' })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setSubject('user-alice')
+      .setIssuer(IDP_BASE_URL)
+      .setAudience(AUDIENCE)
+      .setIssuedAt()
+      .setExpirationTime('10m')
+      .sign(hsKey)
+    const app = makeBackendApp()
+    const res = await app.request('/api/v1/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(res.status).toBe(401)
+  })
+})


### PR DESCRIPTION
## Summary (follow-up to ms-02)

Adds a real-jose end-to-end mock test (`jwt-e2e.test.ts`) covering the backend Bearer auth path. Closes the F3 manual-QA gap that was deferred in ms-02 because running three live Cloudflare workers + driving a browser through PKCE is not viable from CI / headless environments.

**Stacked on PR-D (#146)** — uses the JWT middleware shipped there. Do not merge until #143 → #146 are in.

## What changes

- New file: `js/app/feed-platform-backend/src/feature/auth/jwt-e2e.test.ts`
- No production code changes.

## What this test actually exercises

The existing `jwt.test.ts` and `middleware.test.ts` mock `jose` **entirely**, so they never run the real ES256 signature + claims validation. This new test fills that gap:

- generates a real ES256 keypair with `jose.generateKeyPair('ES256')`
- mocks **only** `createRemoteJWKSet` (the network boundary) — everything else is real jose
- runs the production `authMiddleware` against an in-process Hono app
- signs real JWTs with real keys and asserts that `jwtVerify` accepts / rejects them correctly

## Coverage

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Valid ES256 JWT (correct iss / aud / exp, signed by IdP key) | `200` + `{ email, id }` |
| 2 | No `Authorization` header | `401` + `WWW-Authenticate: Bearer error="invalid_token"` |
| 3 | Non-Bearer scheme (`Basic abc123`) | `401` |
| 4 | Empty bearer token (`Bearer `) | `401` |
| 5 | Signed by an untrusted key | `401` |
| 6 | Wrong `iss` claim | `401` |
| 7 | Wrong `aud` claim | `401` |
| 8 | Expired (`exp` in past) | `401` |
| 9 | `alg=HS256` instead of `ES256` | `401` |

## Why not run three live workers locally

I evaluated the live-worker path first (per the request: "必要であれば複数サーバー起動して接続してテスト 無理なら一旦モックで独立して動作検証"):

- `identity-provider` would need: Better Auth schema migrations applied, an OAuth client record (`client_id=feed-platform-web`, `redirect_uri=http://localhost:8788/auth/callback`), ES256 signing keys provisioned, a passkey or magic-link user seeded.
- A real browser to drive the PKCE redirect chain end-to-end.
- All three workers on independent ports (`:8787/:8788/:8789` per `wrangler.jsonc`).

That setup is not reproducible from a headless CLI session and would not run in CI. The mock-based path verifies the cryptographic + middleware boundary deterministically and runs in ~13 ms.

## Verification

```bash
$ vp test run src/feature/auth/jwt-e2e.test.ts
Test Files  1 passed (1)
     Tests  9 passed (9)
$ vp check
pass: All 18 files are correctly formatted
pass: Found no warnings, lint errors, or type errors in 14 files
```

## Stacking

```
main
  └── feat/ms-02-pr-auth-helper (#143)
        └── feat/ms-02-pr-backend-jwt (#146)
              └── feat/ms-02-pr-e2e-mock-test  ← THIS PR
```

**Merge order: #143 → #146 → this PR.**

## Commits

- `ee244300` test(feed-platform-backend): add real-jose ES256 + JWKS-stub e2e mock for /api/v1/me

## Roadmap

- Roadmap: `feed-platform`
- Milestone: `ms-02-auth-passkey-magiclink` (follow-up; milestone already marked completed in #145)
- Resolves: F3 deferred manual-QA item from `.sisyphus/plans/feed-platform-ms-02-completion.md`
