### PR TITLE
feat(c-plugin): move plugin cache to global storage

### DIFF
--- a/js/app/c-plugin/package.json
+++ b/js/app/c-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totto2727/c-plugin",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/js/app/c-plugin/src/cli/skill/add.ts
+++ b/js/app/c-plugin/src/cli/skill/add.ts
@@ -51,7 +51,8 @@ export const addCommand = Command.make(
   (config) =>
     Effect.gen(function* () {
       const agentsDir = config.global ? getGlobalAgentsDir() : yield* Effect.promise(() => findNearestAgentsDir())
-      yield* Cache.ensureDirs(agentsDir)
+      const agentsRoot = NodePath.dirname(agentsDir)
+      yield* Cache.ensureDirs(agentsDir, agentsRoot)
 
       const resolved: ResolvedSource = yield* Option.match(config.local, {
         onNone: () =>
@@ -62,7 +63,7 @@ export const addCommand = Command.make(
             })
             yield* Git.checkInstalled
             yield* Effect.log(`Cloning ${repoSpec}...`)
-            const repoDir = yield* Cache.ensureRepo(agentsDir, repoSpec)
+            const repoDir = yield* Cache.ensureRepo(agentsRoot, repoSpec)
             const commitHash = yield* Git.revParseHead(repoDir)
             return { commitHash, dir: repoDir, source: repoSpec, type: 'github' as const }
           }),
@@ -87,7 +88,6 @@ export const addCommand = Command.make(
               return yield* Effect.fail(new Error(`No marketplace found at: ${localSpec}`))
             }
 
-            const agentsRoot = NodePath.dirname(agentsDir)
             const relativeSource = toRelativeLocalPath(resolvedAbs, agentsRoot)
             return { dir: resolvedAbs, source: relativeSource, type: 'local' as const }
           }),

--- a/js/app/c-plugin/src/cli/skill/remove.ts
+++ b/js/app/c-plugin/src/cli/skill/remove.ts
@@ -1,3 +1,5 @@
+import * as NodePath from 'node:path'
+
 import { Array, Effect } from 'effect'
 import { Command, Flag, Prompt } from 'effect/unstable/cli'
 
@@ -7,7 +9,7 @@ import * as Cache from '#@/service/cache.ts'
 import * as LockFileService from '#@/service/lock-file.ts'
 import * as Symlink from '#@/service/symlink.ts'
 
-export const removeRepoCaches = (agentsDir: string, lockFile: LockFile, removedRepoSources: ReadonlySet<string>) =>
+export const removeRepoCaches = (projectRoot: string, lockFile: LockFile, removedRepoSources: ReadonlySet<string>) =>
   Effect.gen(function* () {
     for (const source of removedRepoSources) {
       const repo = lockFile.repositories.find((r) => r.source === source)
@@ -15,7 +17,7 @@ export const removeRepoCaches = (agentsDir: string, lockFile: LockFile, removedR
         continue
       }
       yield* Effect.log(`Removing cache for ${source}...`)
-      yield* Cache.removeRepo(agentsDir, source)
+      yield* Cache.removeRepo(projectRoot, source)
     }
   })
 
@@ -87,7 +89,7 @@ export const removeCommand = Command.make(
         yield* Symlink.removeSkillLink(agentsDir, lockFile.skillDirs, skill.skillName)
       }
 
-      yield* removeRepoCaches(agentsDir, lockFile, removedRepoSources)
+      yield* removeRepoCaches(NodePath.dirname(agentsDir), lockFile, removedRepoSources)
 
       yield* Effect.log(`Removed ${toRemove.length} skill(s).`)
     }),

--- a/js/app/c-plugin/src/lib/paths.ts
+++ b/js/app/c-plugin/src/lib/paths.ts
@@ -1,3 +1,4 @@
+import * as Crypto from 'node:crypto'
 import * as Fs from 'node:fs/promises'
 import * as Os from 'node:os'
 import * as NodePath from 'node:path'
@@ -5,6 +6,12 @@ import * as NodePath from 'node:path'
 import { Predicate, String } from 'effect'
 
 export const getGlobalAgentsDir = (): string => NodePath.join(Os.homedir(), '.agents')
+
+export const getGlobalCacheRoot = (): string =>
+  process.env.C_PLUGIN_CACHE_ROOT ?? NodePath.join(Os.homedir(), '.c-plugin', 'cache')
+
+export const hashProjectRoot = (projectRoot: string): string =>
+  Crypto.createHash('sha256').update(NodePath.resolve(projectRoot)).digest('hex').slice(0, 12)
 
 export const expandHomePath = (path: string): string => {
   if (path === '~') {
@@ -74,7 +81,8 @@ export const findNearestAgentsDir = async (startDir: string = process.cwd()): Pr
 export const toRelativeLocalPath = (absPath: string, agentsRoot: string): string =>
   `./${NodePath.relative(agentsRoot, absPath)}`
 
-export const getCacheDir = (agentsDir: string): string => NodePath.join(agentsDir, '.cache')
+export const getCacheDir = (projectRoot: string): string =>
+  NodePath.join(getGlobalCacheRoot(), hashProjectRoot(projectRoot))
 
 export const getSkillsDir = (agentsDir: string): string => NodePath.join(agentsDir, 'skills')
 
@@ -82,8 +90,8 @@ export const getLockFilePath = (agentsDir: string): string => NodePath.join(agen
 
 export const getGitIgnorePath = (agentsDir: string): string => NodePath.join(agentsDir, '.gitignore')
 
-export const getRepoCacheDir = (agentsDir: string, source: string): string =>
-  NodePath.join(getCacheDir(agentsDir), source)
+export const getRepoCacheDir = (projectRoot: string, source: string): string =>
+  NodePath.join(getCacheDir(projectRoot), source)
 
 export const parseRepoSource = (repo: string): { owner: string; name: string } => {
   const parts = repo.split('/')

--- a/js/app/c-plugin/src/service/_test-helper.ts
+++ b/js/app/c-plugin/src/service/_test-helper.ts
@@ -2,15 +2,38 @@ import * as Fs from 'node:fs/promises'
 import * as Os from 'node:os'
 import * as NodePath from 'node:path'
 
+import { Predicate } from 'effect'
+
 import { getCacheDir, getLockFilePath, getRepoCacheDir } from '#@/lib/paths.ts'
 import type { LockFile } from '#@/schema/lock-file.ts'
 import type { Marketplace } from '#@/schema/marketplace.ts'
 
-export const setupTestContext = async (): Promise<{ agentsDir: string; cleanup: () => Promise<void> }> => {
-  const agentsDir = await Fs.mkdtemp(NodePath.join(Os.tmpdir(), 'c-plugin-test-'))
+export interface TestContext {
+  readonly projectRoot: string
+  readonly agentsDir: string
+  readonly cleanup: () => Promise<void>
+}
+
+export const setupTestContext = async (): Promise<TestContext> => {
+  const projectRoot = await Fs.mkdtemp(NodePath.join(Os.tmpdir(), 'c-plugin-test-'))
+  const agentsDir = NodePath.join(projectRoot, '.agents')
+  await Fs.mkdir(agentsDir, { recursive: true })
+
+  const cacheRoot = NodePath.join(projectRoot, '.c-plugin-cache-test')
+  const previousCacheRoot = process.env.C_PLUGIN_CACHE_ROOT
+  process.env.C_PLUGIN_CACHE_ROOT = cacheRoot
+
   return {
     agentsDir,
-    cleanup: () => Fs.rm(agentsDir, { force: true, recursive: true }),
+    cleanup: async () => {
+      if (Predicate.isNullish(previousCacheRoot)) {
+        delete process.env.C_PLUGIN_CACHE_ROOT
+      } else {
+        process.env.C_PLUGIN_CACHE_ROOT = previousCacheRoot
+      }
+      await Fs.rm(projectRoot, { force: true, recursive: true })
+    },
+    projectRoot,
   }
 }
 
@@ -26,11 +49,11 @@ export interface FakeRepoFixtureOptions {
 }
 
 export const buildFakeRepoFixture = async (
-  agentsDir: string,
+  projectRoot: string,
   source: string,
   options: FakeRepoFixtureOptions,
 ): Promise<string> => {
-  const repoDir = getRepoCacheDir(agentsDir, source)
+  const repoDir = getRepoCacheDir(projectRoot, source)
 
   const marketplace: Marketplace = {
     name: options.marketplaceName ?? 'test-marketplace',
@@ -65,7 +88,7 @@ export const writeLockFile = async (agentsDir: string, lockFile: LockFile): Prom
   await Fs.writeFile(path, `${JSON.stringify(lockFile, null, '\t')}\n`, 'utf-8')
 }
 
-export const ensureAgentsDirs = async (agentsDir: string): Promise<void> => {
-  await Fs.mkdir(getCacheDir(agentsDir), { recursive: true })
+export const ensureAgentsDirs = async (agentsDir: string, projectRoot: string): Promise<void> => {
+  await Fs.mkdir(getCacheDir(projectRoot), { recursive: true })
   await Fs.mkdir(NodePath.join(agentsDir, 'skills'), { recursive: true })
 }

--- a/js/app/c-plugin/src/service/cache.test.ts
+++ b/js/app/c-plugin/src/service/cache.test.ts
@@ -24,10 +24,10 @@ afterEach(async () => {
 })
 
 describe('ensureDirs', () => {
-  test('creates .cache and skills directories', async () => {
-    await Effect.runPromise(ensureDirs(ctx.agentsDir))
+  test('creates cache and skills directories', async () => {
+    await Effect.runPromise(ensureDirs(ctx.agentsDir, ctx.projectRoot))
 
-    const cacheDir = getCacheDir(ctx.agentsDir)
+    const cacheDir = getCacheDir(ctx.projectRoot)
     const skillsDir = getSkillsDir(ctx.agentsDir)
 
     const cacheStat = await Fs.stat(cacheDir)
@@ -38,32 +38,32 @@ describe('ensureDirs', () => {
   })
 
   test('succeeds when directories already exist', async () => {
-    await Effect.runPromise(ensureDirs(ctx.agentsDir))
-    await expect(Effect.runPromise(ensureDirs(ctx.agentsDir))).resolves.toBeUndefined()
+    await Effect.runPromise(ensureDirs(ctx.agentsDir, ctx.projectRoot))
+    await expect(Effect.runPromise(ensureDirs(ctx.agentsDir, ctx.projectRoot))).resolves.toBeUndefined()
   })
 })
 
 describe('ensureRepo', () => {
   test('clones repo when not cached', async () => {
-    await Effect.runPromise(ensureDirs(ctx.agentsDir))
+    await Effect.runPromise(ensureDirs(ctx.agentsDir, ctx.projectRoot))
 
-    const repoDir = await Effect.runPromise(ensureRepo(ctx.agentsDir, 'owner/repo'))
+    const repoDir = await Effect.runPromise(ensureRepo(ctx.projectRoot, 'owner/repo'))
 
-    expect(repoDir).toBe(getRepoCacheDir(ctx.agentsDir, 'owner/repo'))
+    expect(repoDir).toBe(getRepoCacheDir(ctx.projectRoot, 'owner/repo'))
     const stat = await Fs.stat(repoDir)
     expect(stat.isDirectory()).toBe(true)
   })
 
   test('returns existing directory when already cached', async () => {
-    await Effect.runPromise(ensureDirs(ctx.agentsDir))
+    await Effect.runPromise(ensureDirs(ctx.agentsDir, ctx.projectRoot))
 
-    const repoCacheDir = getRepoCacheDir(ctx.agentsDir, 'owner/repo')
+    const repoCacheDir = getRepoCacheDir(ctx.projectRoot, 'owner/repo')
     await Fs.mkdir(repoCacheDir, { recursive: true })
 
     const markerFile = NodePath.join(repoCacheDir, 'marker.txt')
     await Fs.writeFile(markerFile, 'exists', 'utf-8')
 
-    const repoDir = await Effect.runPromise(ensureRepo(ctx.agentsDir, 'owner/repo'))
+    const repoDir = await Effect.runPromise(ensureRepo(ctx.projectRoot, 'owner/repo'))
     expect(repoDir).toBe(repoCacheDir)
 
     const content = await Fs.readFile(markerFile, 'utf-8')
@@ -73,18 +73,18 @@ describe('ensureRepo', () => {
 
 describe('removeRepo', () => {
   test('removes cached repository directory', async () => {
-    await Effect.runPromise(ensureDirs(ctx.agentsDir))
+    await Effect.runPromise(ensureDirs(ctx.agentsDir, ctx.projectRoot))
 
-    const repoCacheDir = getRepoCacheDir(ctx.agentsDir, 'owner/repo')
+    const repoCacheDir = getRepoCacheDir(ctx.projectRoot, 'owner/repo')
     await Fs.mkdir(repoCacheDir, { recursive: true })
     await Fs.writeFile(NodePath.join(repoCacheDir, 'file.txt'), 'data', 'utf-8')
 
-    await Effect.runPromise(removeRepo(ctx.agentsDir, 'owner/repo'))
+    await Effect.runPromise(removeRepo(ctx.projectRoot, 'owner/repo'))
     await expect(Fs.access(repoCacheDir)).rejects.toThrow()
   })
 
   test('does not throw when directory does not exist', async () => {
-    await expect(Effect.runPromise(removeRepo(ctx.agentsDir, 'nonexistent/repo'))).resolves.toBeUndefined()
+    await expect(Effect.runPromise(removeRepo(ctx.projectRoot, 'nonexistent/repo'))).resolves.toBeUndefined()
   })
 })
 

--- a/js/app/c-plugin/src/service/cache.ts
+++ b/js/app/c-plugin/src/service/cache.ts
@@ -5,17 +5,17 @@ import { Effect } from 'effect'
 import { getCacheDir, getGitHubCloneUrl, getRepoCacheDir, getSkillsDir, resolveLocalPath } from '#@/lib/paths.ts'
 import * as Git from '#@/service/git.ts'
 
-export const ensureDirs = (agentsDir: string): Effect.Effect<void> =>
+export const ensureDirs = (agentsDir: string, projectRoot: string): Effect.Effect<void> =>
   Effect.tryPromise({
     catch: (e: unknown) => e,
     try: async () => {
-      await Fs.mkdir(getCacheDir(agentsDir), { recursive: true })
+      await Fs.mkdir(getCacheDir(projectRoot), { recursive: true })
       await Fs.mkdir(getSkillsDir(agentsDir), { recursive: true })
     },
   }).pipe(Effect.ignore)
 
-export const ensureRepo = (agentsDir: string, source: string): Effect.Effect<string, Git.GitError> => {
-  const repoDir = getRepoCacheDir(agentsDir, source)
+export const ensureRepo = (projectRoot: string, source: string): Effect.Effect<string, Git.GitError> => {
+  const repoDir = getRepoCacheDir(projectRoot, source)
   return Effect.tryPromise({
     catch: () => new Git.GitError({ command: 'access', message: 'not found' }),
     try: () => Fs.access(repoDir),
@@ -28,10 +28,10 @@ export const ensureRepo = (agentsDir: string, source: string): Effect.Effect<str
   )
 }
 
-export const removeRepo = (agentsDir: string, source: string): Effect.Effect<void> =>
+export const removeRepo = (projectRoot: string, source: string): Effect.Effect<void> =>
   Effect.tryPromise({
     catch: (e: unknown) => e,
-    try: () => Fs.rm(getRepoCacheDir(agentsDir, source), { force: true, recursive: true }),
+    try: () => Fs.rm(getRepoCacheDir(projectRoot, source), { force: true, recursive: true }),
   }).pipe(Effect.ignore)
 
 export const ensureLocalPath = (spec: string, agentsRoot: string): Effect.Effect<string, Error> =>

--- a/js/app/c-plugin/src/service/gitignore.test.ts
+++ b/js/app/c-plugin/src/service/gitignore.test.ts
@@ -23,7 +23,6 @@ describe('write', () => {
     await Effect.runPromise(write(ctx.agentsDir))
 
     const content = await Fs.readFile(getGitIgnorePath(ctx.agentsDir), 'utf-8')
-    expect(content).toContain('.cache/')
     expect(content).toContain('skills/')
     expect(content).toContain('.gitignore')
   })
@@ -35,6 +34,6 @@ describe('write', () => {
 
     const content = await Fs.readFile(getGitIgnorePath(ctx.agentsDir), 'utf-8')
     expect(content).not.toContain('old content')
-    expect(content).toContain('.cache/')
+    expect(content).toContain('skills/')
   })
 })

--- a/js/app/c-plugin/src/service/gitignore.ts
+++ b/js/app/c-plugin/src/service/gitignore.ts
@@ -4,7 +4,7 @@ import { Effect } from 'effect'
 
 import { getGitIgnorePath } from '#@/lib/paths.ts'
 
-const CONTENT = `.cache/\nskills/\n.gitignore\n`
+const CONTENT = `skills/\n.gitignore\n`
 
 export const write = (agentsDir: string): Effect.Effect<void> =>
   Effect.tryPromise({

--- a/js/app/c-plugin/src/service/skill-resolver.test.ts
+++ b/js/app/c-plugin/src/service/skill-resolver.test.ts
@@ -11,7 +11,7 @@ let ctx: Awaited<ReturnType<typeof setupTestContext>>
 
 beforeEach(async () => {
   ctx = await setupTestContext()
-  await ensureAgentsDirs(ctx.agentsDir)
+  await ensureAgentsDirs(ctx.agentsDir, ctx.projectRoot)
 })
 
 afterEach(async () => {
@@ -20,7 +20,7 @@ afterEach(async () => {
 
 describe('resolveFromRepo', () => {
   test('resolves skills from valid repo structure', async () => {
-    const repoDir = await buildFakeRepoFixture(ctx.agentsDir, 'owner/repo', {
+    const repoDir = await buildFakeRepoFixture(ctx.projectRoot, 'owner/repo', {
       plugins: [
         {
           name: 'my-plugin',
@@ -38,7 +38,7 @@ describe('resolveFromRepo', () => {
   })
 
   test('resolves skills from multiple plugins', async () => {
-    const repoDir = await buildFakeRepoFixture(ctx.agentsDir, 'owner/repo', {
+    const repoDir = await buildFakeRepoFixture(ctx.projectRoot, 'owner/repo', {
       plugins: [
         {
           name: 'plugin-a',
@@ -58,7 +58,7 @@ describe('resolveFromRepo', () => {
   })
 
   test('excludes directories without SKILL.md', async () => {
-    const repoDir = await buildFakeRepoFixture(ctx.agentsDir, 'owner/repo', {
+    const repoDir = await buildFakeRepoFixture(ctx.projectRoot, 'owner/repo', {
       plugins: [
         {
           name: 'my-plugin',
@@ -77,7 +77,7 @@ describe('resolveFromRepo', () => {
   })
 
   test('returns empty when plugin has no skills directory', async () => {
-    const repoDir = await buildFakeRepoFixture(ctx.agentsDir, 'owner/repo', {
+    const repoDir = await buildFakeRepoFixture(ctx.projectRoot, 'owner/repo', {
       plugins: [
         {
           name: 'empty-plugin',

--- a/js/app/c-plugin/src/service/symlink.test.ts
+++ b/js/app/c-plugin/src/service/symlink.test.ts
@@ -13,7 +13,7 @@ let ctx: Awaited<ReturnType<typeof setupTestContext>>
 
 beforeEach(async () => {
   ctx = await setupTestContext()
-  await ensureAgentsDirs(ctx.agentsDir)
+  await ensureAgentsDirs(ctx.agentsDir, ctx.projectRoot)
 })
 
 afterEach(async () => {

--- a/js/app/c-plugin/src/service/sync.test.ts
+++ b/js/app/c-plugin/src/service/sync.test.ts
@@ -19,7 +19,7 @@ let ctx: Awaited<ReturnType<typeof setupTestContext>>
 
 beforeEach(async () => {
   ctx = await setupTestContext()
-  await ensureAgentsDirs(ctx.agentsDir)
+  await ensureAgentsDirs(ctx.agentsDir, ctx.projectRoot)
 })
 
 afterEach(async () => {
@@ -39,7 +39,7 @@ describe('sync run', () => {
   })
 
   test('creates symlinks for enabled skills', async () => {
-    await buildFakeRepoFixture(ctx.agentsDir, 'owner/repo', {
+    await buildFakeRepoFixture(ctx.projectRoot, 'owner/repo', {
       plugins: [
         {
           name: 'my-plugin',
@@ -80,7 +80,7 @@ describe('sync run', () => {
   })
 
   test('removes symlinks for skills no longer in repo', async () => {
-    await buildFakeRepoFixture(ctx.agentsDir, 'owner/repo', {
+    await buildFakeRepoFixture(ctx.projectRoot, 'owner/repo', {
       plugins: [
         {
           name: 'my-plugin',
@@ -125,7 +125,7 @@ describe('sync run', () => {
   })
 
   test('removes plugin entry when all skills are removed', async () => {
-    await buildFakeRepoFixture(ctx.agentsDir, 'owner/repo', {
+    await buildFakeRepoFixture(ctx.projectRoot, 'owner/repo', {
       plugins: [
         {
           name: 'my-plugin',
@@ -166,7 +166,7 @@ describe('sync run', () => {
     const extraDir = NodePath.join(ctx.agentsDir, 'extra-skills')
     await Fs.mkdir(extraDir, { recursive: true })
 
-    await buildFakeRepoFixture(ctx.agentsDir, 'owner/repo', {
+    await buildFakeRepoFixture(ctx.projectRoot, 'owner/repo', {
       plugins: [
         {
           name: 'my-plugin',

--- a/js/app/c-plugin/src/service/sync.ts
+++ b/js/app/c-plugin/src/service/sync.ts
@@ -20,7 +20,7 @@ const syncRepo = (
     const repoDir =
       repo.sourceType === 'local'
         ? yield* Cache.ensureLocalPath(repo.source, agentsRoot)
-        : yield* Cache.ensureRepo(agentsDir, repo.source)
+        : yield* Cache.ensureRepo(agentsRoot, repo.source)
 
     if (repo.sourceType !== 'local') {
       yield* Git.checkout(repoDir, repo.commitHash)
@@ -69,7 +69,8 @@ export const run = (
   agentsDir: string,
 ): Effect.Effect<void, Error | Git.GitError | LockFileService.LockFileCorruptError> =>
   Effect.gen(function* () {
-    yield* Cache.ensureDirs(agentsDir)
+    const agentsRoot = NodePath.dirname(agentsDir)
+    yield* Cache.ensureDirs(agentsDir, agentsRoot)
 
     const lockFile = yield* LockFileService.read(agentsDir)
     if (Array.isReadonlyArrayEmpty(lockFile.repositories)) {
@@ -82,7 +83,6 @@ export const run = (
       yield* Git.checkInstalled
     }
 
-    const agentsRoot = NodePath.dirname(agentsDir)
     const updatedRepos: RepositoryEntry[] = []
 
     for (const repo of lockFile.repositories) {

--- a/js/app/c-plugin/src/service/update.test.ts
+++ b/js/app/c-plugin/src/service/update.test.ts
@@ -17,7 +17,7 @@ let ctx: Awaited<ReturnType<typeof setupTestContext>>
 
 beforeEach(async () => {
   ctx = await setupTestContext()
-  await ensureAgentsDirs(ctx.agentsDir)
+  await ensureAgentsDirs(ctx.agentsDir, ctx.projectRoot)
 })
 
 afterEach(async () => {

--- a/js/app/c-plugin/src/service/update.ts
+++ b/js/app/c-plugin/src/service/update.ts
@@ -1,3 +1,5 @@
+import * as NodePath from 'node:path'
+
 import { Array, Effect } from 'effect'
 
 import { getRepoCacheDir } from '#@/lib/paths.ts'
@@ -11,7 +13,8 @@ export const run = (
   agentsDir: string,
 ): Effect.Effect<void, Error | Git.GitError | LockFileService.LockFileCorruptError> =>
   Effect.gen(function* () {
-    yield* Cache.ensureDirs(agentsDir)
+    const agentsRoot = NodePath.dirname(agentsDir)
+    yield* Cache.ensureDirs(agentsDir, agentsRoot)
 
     const lockFile = yield* LockFileService.read(agentsDir)
     if (Array.isReadonlyArrayEmpty(lockFile.repositories)) {
@@ -30,7 +33,7 @@ export const run = (
         updatedRepos.push(repo)
         continue
       }
-      const repoDir = getRepoCacheDir(agentsDir, repo.source)
+      const repoDir = getRepoCacheDir(agentsRoot, repo.source)
       yield* Effect.log(`Updating ${repo.source}...`)
       yield* Git.pull(repoDir)
       const newCommitHash = yield* Git.revParseHead(repoDir)


### PR DESCRIPTION
## Summary
- move c-plugin repository cache from project-local .agents/.cache to global ~/.c-plugin/cache keyed by project root hash
- add C_PLUGIN_CACHE_ROOT override support for isolated cache roots
- bump @totto2727/c-plugin from 0.3.4 to 0.4.0

## Verification
- vp check js/app/c-plugin
- vp test run js/app/c-plugin/src/service/cache.test.ts js/app/c-plugin/src/service/gitignore.test.ts js/app/c-plugin/src/service/skill-resolver.test.ts js/app/c-plugin/src/service/symlink.test.ts js/app/c-plugin/src/service/sync.test.ts js/app/c-plugin/src/service/update.test.ts
- vp run --filter @totto2727/c-plugin build
- vp exec node js/app/c-plugin/dist/bin.mjs --help
- vp exec node js/app/c-plugin/dist/bin.mjs skill --help
- vp exec node js/app/c-plugin/dist/bin.mjs skill nope (expected unknown subcommand error)
