### PR TITLE
feat(c-plugin): add init lockfile command

### DIFF
--- a/.agents/skills/c-plugin/SKILL.md
+++ b/.agents/skills/c-plugin/SKILL.md
@@ -6,17 +6,20 @@ allowed-tools: Bash(c-plugin:*)
 
 # `c-plugin` — Claude Code Plugin manager
 
-Lockfile-driven installer for **Claude Code marketplaces** (also handles Cursor and Codex marketplace formats). State lives in `.agents/skills-lock.json` at the nearest ancestor that has one (or `~/.agents/` when `--global`).
+Lockfile-driven installer for **Claude Code marketplaces** (also handles Cursor and Codex marketplace formats). State lives in `.agents/c-plugin-lock.json` at the nearest ancestor that has one (or `~/.agents/` when `--global`).
 
 ## Concepts
 
 - **Marketplace root** — a directory containing `.claude-plugin/marketplace.json` (or `.cursor-plugin/` / `.codex-plugin/`). Its `plugins[].source` paths point at individual plugins; each plugin's `skills/<name>/SKILL.md` becomes an installable skill.
-- **Lockfile** — `.agents/skills-lock.json` pins each repo's source, marketplace kind, enabled skills per plugin, and (for GitHub sources) commit hash.
+- **Lockfile** — `.agents/c-plugin-lock.json` pins each repo's source, marketplace kind, enabled skills per plugin, and (for GitHub sources) commit hash.
 - **Skill targets** — extra directories that receive the same skill symlinks (e.g. `~/.claude/skills/`). Managed via `c-plugin skill target add|remove`.
 
 ## Most common flows
 
 ```bash
+# Initialize a project lock file in the current directory
+c-plugin init
+
 # Add from a GitHub marketplace
 c-plugin skill add totto2727-org/monorepo
 
@@ -100,7 +103,7 @@ git commit
 ```
 project/
 └── .agents/
-    ├── skills-lock.json     # pinned state
+    ├── c-plugin-lock.json   # pinned state
     ├── skills/              # symlinks created by sync
     └── .cache/<owner>/<repo>/   # GitHub clones (full history, not shallow)
 ```

--- a/js/app/c-plugin/src/bin.ts
+++ b/js/app/c-plugin/src/bin.ts
@@ -4,6 +4,7 @@ import { Cause, Console, Effect } from 'effect'
 import { Command } from 'effect/unstable/cli'
 
 import { devMarketplaceSyncCommand } from '#@/cli/dev/marketplace/sync.ts'
+import { initCommand } from '#@/cli/init.ts'
 import { addCommand } from '#@/cli/skill/add.ts'
 import { removeCommand } from '#@/cli/skill/remove.ts'
 import { syncCommand } from '#@/cli/skill/sync.ts'
@@ -35,7 +36,7 @@ const devCommand = Command.make('dev').pipe(
 
 const app = Command.make('c-plugin').pipe(
   Command.withDescription('CLI to manage Claude Code Plugin resources'),
-  Command.withSubcommands([skillCommand, devCommand]),
+  Command.withSubcommands([initCommand, skillCommand, devCommand]),
 )
 
 const program = app.pipe(

--- a/js/app/c-plugin/src/cli/init.test.ts
+++ b/js/app/c-plugin/src/cli/init.test.ts
@@ -1,0 +1,53 @@
+import * as Fs from 'node:fs/promises'
+import * as Os from 'node:os'
+import * as NodePath from 'node:path'
+
+import { Effect } from 'effect'
+import { afterEach, describe, expect, test } from 'vite-plus/test'
+
+import { getLockFilePath } from '#@/lib/paths.ts'
+import { emptyLockFile } from '#@/schema/lock-file.ts'
+
+import { initCommand, initLockFile } from './init.ts'
+
+const tmpDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tmpDirs.splice(0).map((dir) => Fs.rm(dir, { force: true, recursive: true })))
+})
+
+const mkTmp = async (): Promise<string> => {
+  const dir = await Fs.mkdtemp(NodePath.join(Os.tmpdir(), 'c-plugin-init-test-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+describe('initCommand', () => {
+  test('is importable', () => {
+    expect(initCommand).toBeDefined()
+  })
+})
+
+describe('initLockFile', () => {
+  test('creates only an empty lock file under .agents in the target directory', async () => {
+    const projectRoot = await mkTmp()
+    const lockPath = getLockFilePath(NodePath.join(projectRoot, '.agents'))
+
+    await Effect.runPromise(initLockFile(projectRoot))
+
+    await expect(Fs.readFile(lockPath, 'utf-8')).resolves.toBe(`${JSON.stringify(emptyLockFile, null, '\t')}\n`)
+    await expect(Fs.readdir(NodePath.join(projectRoot, '.agents'))).resolves.toStrictEqual(['c-plugin-lock.json'])
+  })
+
+  test('does not overwrite an existing lock file', async () => {
+    const projectRoot = await mkTmp()
+    const lockPath = getLockFilePath(NodePath.join(projectRoot, '.agents'))
+    await Fs.mkdir(NodePath.dirname(lockPath), { recursive: true })
+    await Fs.writeFile(lockPath, '{"version":1,"repositories":[],"skillDirs":["/keep"]}\n', 'utf-8')
+
+    await expect(Effect.runPromise(initLockFile(projectRoot))).rejects.toThrow()
+    await expect(Fs.readFile(lockPath, 'utf-8')).resolves.toBe(
+      '{"version":1,"repositories":[],"skillDirs":["/keep"]}\n',
+    )
+  })
+})

--- a/js/app/c-plugin/src/cli/init.ts
+++ b/js/app/c-plugin/src/cli/init.ts
@@ -1,0 +1,24 @@
+import * as Fs from 'node:fs/promises'
+import * as NodePath from 'node:path'
+
+import { Effect } from 'effect'
+import { Command } from 'effect/unstable/cli'
+
+import { getLockFilePath } from '#@/lib/paths.ts'
+import { emptyLockFile } from '#@/schema/lock-file.ts'
+
+export const initLockFile = (projectRoot: string): Effect.Effect<void, unknown> =>
+  Effect.tryPromise({
+    catch: (e: unknown) => e,
+    try: async () => {
+      const agentsDir = NodePath.join(projectRoot, '.agents')
+      const lockPath = getLockFilePath(agentsDir)
+
+      await Fs.mkdir(agentsDir, { recursive: true })
+      await Fs.writeFile(lockPath, `${JSON.stringify(emptyLockFile, null, '\t')}\n`, { encoding: 'utf-8', flag: 'wx' })
+    },
+  })
+
+export const initCommand = Command.make('init', {}, () => initLockFile(process.cwd())).pipe(
+  Command.withDescription('Create an empty lock file in the current directory'),
+)

--- a/js/app/c-plugin/src/lib/paths.test.ts
+++ b/js/app/c-plugin/src/lib/paths.test.ts
@@ -8,6 +8,7 @@ import {
   expandHomePath,
   findAgentsRoot,
   findNearestAgentsDir,
+  LOCK_FILE_NAME,
   getGitHubCloneUrl,
   isHomePath,
   isLocalPath,
@@ -176,7 +177,7 @@ describe('findNearestAgentsDir', () => {
     const root = await Fs.mkdtemp(NodePath.join(Os.tmpdir(), 'c-plugin-agents-dir-'))
     const agentsDir = NodePath.join(root, '.agents')
     await Fs.mkdir(agentsDir, { recursive: true })
-    await Fs.writeFile(NodePath.join(agentsDir, 'skills-lock.json'), '{}', 'utf-8')
+    await Fs.writeFile(NodePath.join(agentsDir, LOCK_FILE_NAME), '{}', 'utf-8')
     const nested = NodePath.join(root, 'a', 'b', 'c')
     await Fs.mkdir(nested, { recursive: true })
 
@@ -187,7 +188,7 @@ describe('findNearestAgentsDir', () => {
     const root = await Fs.mkdtemp(NodePath.join(Os.tmpdir(), 'c-plugin-agents-dir-'))
     const agentsDir = NodePath.join(root, '.agents')
     await Fs.mkdir(agentsDir, { recursive: true })
-    await Fs.writeFile(NodePath.join(agentsDir, 'skills-lock.json'), '{}', 'utf-8')
+    await Fs.writeFile(NodePath.join(agentsDir, LOCK_FILE_NAME), '{}', 'utf-8')
 
     await expect(findNearestAgentsDir(root)).resolves.toBe(agentsDir)
   })
@@ -197,7 +198,9 @@ describe('findNearestAgentsDir', () => {
     const nested = NodePath.join(root, 'a', 'b')
     await Fs.mkdir(nested, { recursive: true })
 
-    await expect(findNearestAgentsDir(nested)).rejects.toThrow('Could not find .agents directory with skills-lock.json')
+    await expect(findNearestAgentsDir(nested)).rejects.toThrow(
+      `Could not find .agents directory with ${LOCK_FILE_NAME}`,
+    )
   })
 })
 

--- a/js/app/c-plugin/src/lib/paths.ts
+++ b/js/app/c-plugin/src/lib/paths.ts
@@ -5,6 +5,8 @@ import * as NodePath from 'node:path'
 
 import { Predicate, String } from 'effect'
 
+export const LOCK_FILE_NAME = 'c-plugin-lock.json'
+
 export const getGlobalAgentsDir = (): string => NodePath.join(Os.homedir(), '.agents')
 
 export const getGlobalCacheRoot = (): string =>
@@ -64,7 +66,7 @@ export const findAgentsRoot = async (startDir: string = process.cwd()): Promise<
 export const findNearestAgentsDir = async (startDir: string = process.cwd()): Promise<string> => {
   const currentDir = NodePath.resolve(startDir)
   const agentsDir = NodePath.join(currentDir, '.agents')
-  const lockPath = NodePath.join(agentsDir, 'skills-lock.json')
+  const lockPath = NodePath.join(agentsDir, LOCK_FILE_NAME)
 
   try {
     await Fs.access(lockPath)
@@ -72,7 +74,7 @@ export const findNearestAgentsDir = async (startDir: string = process.cwd()): Pr
   } catch {
     const parentDir = NodePath.dirname(currentDir)
     if (parentDir === currentDir) {
-      throw new Error('Could not find .agents directory with skills-lock.json')
+      throw new Error(`Could not find .agents directory with ${LOCK_FILE_NAME}`)
     }
     return await findNearestAgentsDir(parentDir)
   }
@@ -86,7 +88,7 @@ export const getCacheDir = (projectRoot: string): string =>
 
 export const getSkillsDir = (agentsDir: string): string => NodePath.join(agentsDir, 'skills')
 
-export const getLockFilePath = (agentsDir: string): string => NodePath.join(agentsDir, 'skills-lock.json')
+export const getLockFilePath = (agentsDir: string): string => NodePath.join(agentsDir, LOCK_FILE_NAME)
 
 export const getGitIgnorePath = (agentsDir: string): string => NodePath.join(agentsDir, '.gitignore')
 

--- a/js/app/c-plugin/src/service/discover.test.ts
+++ b/js/app/c-plugin/src/service/discover.test.ts
@@ -4,6 +4,8 @@ import * as NodePath from 'node:path'
 import { Effect } from 'effect'
 import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
 
+import { LOCK_FILE_NAME } from '#@/lib/paths.ts'
+
 import { setupTestContext } from './_test-helper.ts'
 import { collectAgentsDirs } from './discover.ts'
 
@@ -20,7 +22,7 @@ afterEach(async () => {
 
 const writeLockFile = async (agentsDir: string): Promise<void> => {
   await Fs.mkdir(agentsDir, { recursive: true })
-  await Fs.writeFile(NodePath.join(agentsDir, 'skills-lock.json'), '{}', 'utf-8')
+  await Fs.writeFile(NodePath.join(agentsDir, LOCK_FILE_NAME), '{}', 'utf-8')
 }
 
 describe('collectAgentsDirs', () => {


### PR DESCRIPTION
## Summary

- Rename the c-plugin lockfile from `.agents/skills-lock.json` to `.agents/c-plugin-lock.json`.
- Add `c-plugin init` to create an empty lockfile under the current directory's `.agents/` directory.
- Update tests and skill documentation for the new lockfile name and init command.

## Verification

- `vp check`
- `vp test run "src/cli/init.test.ts" "src/lib/paths.test.ts" "src/service/discover.test.ts" "src/service/lock-file.test.ts"`
- `vp run --filter @totto2727/c-plugin build`
- Built CLI e2e check: `c-plugin init` generated only `.agents/c-plugin-lock.json` with empty lock content.
