### PR TITLE
chore(cli): bump versions

### DIFF
--- a/js/app/bw/package.json
+++ b/js/app/bw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totto2727/bw",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/js/app/c-plugin/package.json
+++ b/js/app/c-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totto2727/c-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/js/app/mdt/package.json
+++ b/js/app/mdt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totto2727/mdt",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/js/app/roadmap/package.json
+++ b/js/app/roadmap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totto2727/roadmap",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/js/app/wt/package.json
+++ b/js/app/wt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totto2727/wt",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR bumps the versions of all CLI packages in the monorepo.

## Changes

| Package | Old | New | Reason |
|---|---|---|---|
| @totto2727/bw | 0.1.6 | 0.1.7 | refactor: normalize error payloads, replace node platform usage |
| @totto2727/c-plugin | 0.4.0 | 0.5.0 | feat: init command, global cache, rename lockfile; refactor: shared error payloads, platform services |
| @totto2727/mdt | 0.1.1 | 0.1.2 | refactor: normalize error payloads, replace node platform usage |
| @totto2727/roadmap | 0.3.0 | 0.4.0 | feat: milestone tasks with schema v2 |
| @totto2727/wt | 0.1.3 | 0.1.4 | refactor: schema-backed worktree predicates, replace node platform usage |

- c-plugin and roadmap received minor bumps due to feature additions
- All other packages received patch bumps for refactoring and fixes