### PR TITLE
fix(auth): complete local oauth flow

### DIFF
--- a/.agents/skills/feed-platform-local-runtime/SKILL.md
+++ b/.agents/skills/feed-platform-local-runtime/SKILL.md
@@ -25,13 +25,39 @@ The goal is to choose the right local topology before running commands, so IdP, 
 - Treat `wrangler dev` as the production-like Worker runtime. Treat `vp dev` as the hot-reload Vite development runtime for Remix apps.
 - If you change startup configuration, regenerate Worker types with the package setup task.
 
+## Effect + Hono Runtime and Env Policy
+
+Choose the env strategy from the runtime entrypoint. Do not mix Vite-only signals into direct Wrangler Workers.
+
+### Vite-managed Remix apps
+
+Use this pattern for `identity-provider` and `feed-platform-web` Vite/Cloudflare-plugin development paths:
+
+- Runtime construction may branch on `import.meta.env.PROD` because Vite replaces it.
+- Production/runtime bindings come from Hono/Cloudflare `ctx.env` through the app env layer.
+- Local Vite development can use a fixed `devLayer` for deterministic endpoints and DB URLs.
+- Keep the Vite dev layer aligned with the root port registry and the app's Wrangler config.
+
+### Direct Wrangler Workers
+
+Use this pattern for `feed-platform-backend`, which runs Worker entries directly through Wrangler:
+
+- Do not use `import.meta.env.PROD` for app behavior. It is a Vite convention and is not the source of truth for direct Wrangler execution.
+- Build the Effect runtime at the Hono/Worker boundary from `ctx.env` and provide app env once at the top level, for example `Runtime.make(ctx.env)` -> `AppEnv.makeLayer(env)`.
+- Middleware and services should consume `ctx.var.runtime` / Effect services. They should not create local env fallback layers or branch between dev/prod themselves.
+- Fixed local values must live under the Wrangler local environment, for example `env.local.vars` in `wrangler.jsonc` / `[env.local.vars]` in `wrangler.toml`.
+- Local scripts and type generation that need those fixed values must pass `--env local`.
+- Deploy scripts must not pass `--env local`; otherwise local-only URLs can be pushed to production.
+- Because Wrangler bindings such as `vars` are not inherited across environments, do not put local-only feed/IdP URLs in top-level `vars`.
+- Unit tests that call Hono directly must pass an explicit test binding object to `app.request(...)`; do not add application `devLayer` fallbacks only to satisfy tests.
+
 ## Local Port Map
 
 See the root [local port registry](../../../LOCAL_PORTS.md). Do not duplicate port values in this skill.
 
 IdP and feed-platform-web must be treated as separate database boundaries. Production runs separate databases, so local development should also use separate DB files and ports instead of sharing one libSQL endpoint.
 
-Backend BFF Wrangler vars must stay aligned with the IdP URL in the root port registry.
+Backend BFF local Wrangler vars under `env.local.vars` must stay aligned with the IdP URL in the root port registry.
 
 ## One-Time / Preflight Setup
 
@@ -161,7 +187,7 @@ vp run --filter feed-platform-backend dev:bff
 vp run --filter feed-platform-backend dev:health
 ```
 
-If backend env vars change, edit `src/worker/bff/wrangler.jsonc`, then regenerate types:
+If backend local env vars change, edit `src/worker/bff/wrangler.jsonc` under `env.local.vars`, then regenerate types:
 
 ```bash
 vp run --filter feed-platform-backend setup:cloudflare:bff

--- a/js/app/feed-platform-backend/AGENTS.md
+++ b/js/app/feed-platform-backend/AGENTS.md
@@ -1,0 +1,17 @@
+# feed-platform-backend
+
+## Authentication flow reference
+
+- See `../identity-provider/docs/auth-flow.md` for the feed login flow,
+  OAuth/OIDC compliance status, and security hardening checklist.
+
+When editing backend auth code, check that document first. The current backend
+example depends on:
+
+- `src/feature/auth/jwt.ts` for IdP JWKS verification, expected issuer, expected
+  audience, and required claims.
+- `src/feature/auth/middleware.ts` for `Authorization: Bearer ...` enforcement.
+- `src/worker/bff/worker.ts` for the protected `/api/v1/me` endpoint.
+
+Production follow-up from the IdP document: the backend should authorize API
+access with a proper access token or introspection result, not an OIDC ID token.

--- a/js/app/feed-platform-backend/AGENTS.md
+++ b/js/app/feed-platform-backend/AGENTS.md
@@ -13,5 +13,6 @@ example depends on:
 - `src/feature/auth/middleware.ts` for `Authorization: Bearer ...` enforcement.
 - `src/worker/bff/worker.ts` for the protected `/api/v1/me` endpoint.
 
-Production follow-up from the IdP document: the backend should authorize API
-access with a proper access token or introspection result, not an OIDC ID token.
+The backend must authorize API access with the resource-specific JWT access token
+for `feed-platform-backend`. Keep rejecting OIDC ID tokens, including tokens that
+have a valid signature but do not carry `token_use=access`.

--- a/js/app/feed-platform-backend/package.json
+++ b/js/app/feed-platform-backend/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "deploy:bff": "wrangler deploy --config src/worker/bff/wrangler.jsonc",
     "deploy:health": "wrangler deploy --config src/worker/health/wrangler.jsonc",
-    "dev:bff": "wrangler dev --config src/worker/bff/wrangler.jsonc",
+    "dev:bff": "wrangler dev --env local --config src/worker/bff/wrangler.jsonc",
     "dev:health": "wrangler dev --config src/worker/health/wrangler.jsonc"
   },
   "devDependencies": {

--- a/js/app/feed-platform-backend/src/feature/auth/jwt.test.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/jwt.test.ts
@@ -14,7 +14,7 @@ vi.mock('jose', () => ({
 const { Service, layer } = await import('./jwt.ts')
 
 const localBindings = {
-  FEED_PLATFORM_AUDIENCE: 'feed-platform-web',
+  FEED_PLATFORM_AUDIENCE: 'feed-platform-backend',
   IDP_BASE_URL: 'http://localhost:8787',
   IDP_JWKS_URL: 'http://localhost:8787/api/v1/auth/jwks',
 } satisfies AppEnv.Type
@@ -42,6 +42,7 @@ describe('JwtService', () => {
         exp: 9_999_999,
         iat: 1_000_000,
         sub: 'user-123',
+        token_use: 'access',
       },
     })
     const exit = await runVerify('valid.jwt.token')
@@ -52,13 +53,14 @@ describe('JwtService', () => {
         exp: 9_999_999,
         iat: 1_000_000,
         sub: 'user-123',
+        token_use: 'access',
       })
     }
   })
 
   it('returns payload without iat/exp when IdP omits them', async () => {
     mockJwtVerify.mockResolvedValue({
-      payload: { email: 'user@example.com', sub: 'user-123' },
+      payload: { email: 'user@example.com', sub: 'user-123', token_use: 'access' },
     })
     const exit = await runVerify('short.lived.token')
     expect(Exit.isSuccess(exit)).toBe(true)
@@ -66,6 +68,7 @@ describe('JwtService', () => {
       expect(exit.value).toStrictEqual({
         email: 'user@example.com',
         sub: 'user-123',
+        token_use: 'access',
       })
     }
   })
@@ -84,9 +87,17 @@ describe('JwtService', () => {
 
   it('fails with JwtVerifyError when email claim is missing', async () => {
     mockJwtVerify.mockResolvedValue({
-      payload: { exp: 9_999_999, iat: 1_000_000, sub: 'user-123' },
+      payload: { exp: 9_999_999, iat: 1_000_000, sub: 'user-123', token_use: 'access' },
     })
     const exit = await runVerify('no-email.jwt.token')
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it('fails with JwtVerifyError when token_use is not access', async () => {
+    mockJwtVerify.mockResolvedValue({
+      payload: { email: 'user@example.com', sub: 'user-123' },
+    })
+    const exit = await runVerify('id-token.jwt.token')
     expect(Exit.isFailure(exit)).toBe(true)
   })
 
@@ -94,7 +105,7 @@ describe('JwtService', () => {
     const testLayer = layer.pipe(
       Layer.provide(
         AppEnv.makeLayer({
-          FEED_PLATFORM_AUDIENCE: 'feed-platform-web',
+          FEED_PLATFORM_AUDIENCE: 'feed-platform-backend',
           IDP_BASE_URL: 'http://localhost:8787',
           IDP_JWKS_URL: 'http://localhost:8787/api/v1/auth/jwks-cache-test',
         }),
@@ -117,6 +128,7 @@ describe('JwtService', () => {
         exp: 9_999_999,
         iat: 1_000_000,
         sub: 'user-1',
+        token_use: 'access',
       },
     })
     expect(mockCreateRemoteJWKSet).toHaveBeenCalledTimes(0)

--- a/js/app/feed-platform-backend/src/feature/auth/jwt.test.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/jwt.test.ts
@@ -13,6 +13,12 @@ vi.mock('jose', () => ({
 
 const { Service, layer } = await import('./jwt.ts')
 
+const localBindings = {
+  FEED_PLATFORM_AUDIENCE: 'feed-platform-web',
+  IDP_BASE_URL: 'http://localhost:8787',
+  IDP_JWKS_URL: 'http://localhost:8787/api/v1/auth/jwks',
+} satisfies AppEnv.Type
+
 const runVerify = (token: string) =>
   Effect.runPromiseExit(
     Effect.provide(
@@ -20,7 +26,7 @@ const runVerify = (token: string) =>
         const jwt = yield* Service
         return yield* jwt.verify(token)
       }),
-      layer.pipe(Layer.provide(AppEnv.devLayer)),
+      layer.pipe(Layer.provide(AppEnv.makeLayer(localBindings))),
     ),
   )
 

--- a/js/app/feed-platform-backend/src/feature/auth/jwt.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/jwt.ts
@@ -40,7 +40,7 @@ export const layer = Layer.effect(
             const { payload } = await jwtVerify(token, remoteJwkSet, {
               algorithms: ['ES256'],
               audience: env.FEED_PLATFORM_AUDIENCE,
-              issuer: env.IDP_BASE_URL,
+              issuer: `${env.IDP_BASE_URL}/api/v1/auth`,
             })
             const { sub, email, iat, exp } = payload as {
               sub?: unknown

--- a/js/app/feed-platform-backend/src/feature/auth/jwt.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/jwt.ts
@@ -42,11 +42,16 @@ export const layer = Layer.effect(
               audience: env.FEED_PLATFORM_AUDIENCE,
               issuer: `${env.IDP_BASE_URL}/api/v1/auth`,
             })
-            const { sub, email, iat, exp } = payload as {
+            const { sub, email, token_use, scope, iat, exp } = payload as {
               sub?: unknown
               email?: unknown
+              token_use?: unknown
+              scope?: unknown
               iat?: unknown
               exp?: unknown
+            }
+            if (token_use !== 'access') {
+              throw new TypeError('Missing access token marker')
             }
             if (!Predicate.isString(sub)) {
               throw new TypeError('Missing sub claim')
@@ -56,7 +61,9 @@ export const layer = Layer.effect(
             }
             return {
               email,
+              ...(Predicate.isString(scope) ? { scope } : {}),
               sub,
+              token_use,
               ...(Predicate.isNumber(iat) ? { iat } : {}),
               ...(Predicate.isNumber(exp) ? { exp } : {}),
             }

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
@@ -14,6 +14,12 @@ const { authMiddleware } = await import('./middleware.ts')
 const { middleware: runtimeMiddleware } = await import('#@/feature/runtime/hono.ts')
 const { default: bffWorker } = await import('#@/worker/bff/worker.ts')
 
+const bindings = {
+  FEED_PLATFORM_AUDIENCE: 'feed-platform-web',
+  IDP_BASE_URL: 'http://localhost:8787',
+  IDP_JWKS_URL: 'http://localhost:8787/api/v1/auth/jwks',
+}
+
 const makeApp = () => {
   const app = new Hono<Env>()
   app.use(runtimeMiddleware)
@@ -37,9 +43,7 @@ describe('authMiddleware', () => {
       },
     })
     const app = makeApp()
-    const res = await app.request('/api/v1/me', {
-      headers: { Authorization: 'Bearer valid.jwt.token' },
-    })
+    const res = await app.request('/api/v1/me', { headers: { Authorization: 'Bearer valid.jwt.token' } }, bindings)
     expect(res.status).toBe(200)
     expect(await res.json()).toStrictEqual({
       email: 'user@example.com',
@@ -51,25 +55,21 @@ describe('authMiddleware', () => {
 
   it('returns 401 when Authorization header is absent', async () => {
     const app = makeApp()
-    const res = await app.request('/api/v1/me')
+    const res = await app.request('/api/v1/me', {}, bindings)
     expect(res.status).toBe(401)
     expect(res.headers.get('WWW-Authenticate')).toBe('Bearer error="invalid_token"')
   })
 
   it('returns 401 when only a Cookie is present (no Authorization)', async () => {
     const app = makeApp()
-    const res = await app.request('/api/v1/me', {
-      headers: { Cookie: 'feed-session=valid.jwt.token' },
-    })
+    const res = await app.request('/api/v1/me', { headers: { Cookie: 'feed-session=valid.jwt.token' } }, bindings)
     expect(res.status).toBe(401)
   })
 
   it('returns 401 for an invalid Bearer token', async () => {
     mockJwtVerify.mockRejectedValue(new Error('signature verification failed'))
     const app = makeApp()
-    const res = await app.request('/api/v1/me', {
-      headers: { Authorization: 'Bearer tampered.jwt.token' },
-    })
+    const res = await app.request('/api/v1/me', { headers: { Authorization: 'Bearer tampered.jwt.token' } }, bindings)
     expect(res.status).toBe(401)
     expect(res.headers.get('WWW-Authenticate')).toBe('Bearer error="invalid_token"')
   })
@@ -83,9 +83,11 @@ describe('authMiddleware', () => {
         sub: 'worker-user',
       },
     })
-    const res = await bffWorker.request('/api/v1/me', {
-      headers: { Authorization: 'Bearer worker.jwt.token' },
-    })
+    const res = await bffWorker.request(
+      '/api/v1/me',
+      { headers: { Authorization: 'Bearer worker.jwt.token' } },
+      bindings,
+    )
     expect(res.status).toBe(200)
     expect(await res.json()).toStrictEqual({
       email: 'worker@example.com',

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
@@ -16,7 +16,7 @@ const { middleware: runtimeMiddleware } = await import('#@/feature/runtime/hono.
 const { default: bffWorker } = await import('#@/worker/bff/worker.ts')
 
 const localBindings = {
-  FEED_PLATFORM_AUDIENCE: 'feed-platform-web',
+  FEED_PLATFORM_AUDIENCE: 'feed-platform-backend',
   IDP_BASE_URL: 'http://localhost:8787',
   IDP_JWKS_URL: 'http://localhost:8787/api/v1/auth/jwks',
 } satisfies AppEnv.Type
@@ -41,6 +41,7 @@ describe('authMiddleware', () => {
         exp: 9_999_999,
         iat: 1_000_000,
         sub: 'user-123',
+        token_use: 'access',
       },
     })
     const app = makeApp()
@@ -51,6 +52,7 @@ describe('authMiddleware', () => {
       exp: 9_999_999,
       iat: 1_000_000,
       sub: 'user-123',
+      token_use: 'access',
     })
   })
 
@@ -86,6 +88,7 @@ describe('authMiddleware', () => {
         exp: 9_999_999,
         iat: 1_000_000,
         sub: 'worker-user',
+        token_use: 'access',
       },
     })
     const res = await bffWorker.request(
@@ -99,6 +102,7 @@ describe('authMiddleware', () => {
       exp: 9_999_999,
       iat: 1_000_000,
       sub: 'worker-user',
+      token_use: 'access',
     })
   })
 })

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
-import * as AppEnv from '#@/feature/env.ts'
+import type * as AppEnv from '#@/feature/env.ts'
 import type { Env } from '#@/feature/share/lib/hono/context.ts'
 
 const { mockJwtVerify } = vi.hoisted(() => ({ mockJwtVerify: vi.fn() }))
@@ -15,7 +15,11 @@ const { authMiddleware } = await import('./middleware.ts')
 const { middleware: runtimeMiddleware } = await import('#@/feature/runtime/hono.ts')
 const { default: bffWorker } = await import('#@/worker/bff/worker.ts')
 
-const bindings = AppEnv.dev
+const localBindings = {
+  FEED_PLATFORM_AUDIENCE: 'feed-platform-web',
+  IDP_BASE_URL: 'http://localhost:8787',
+  IDP_JWKS_URL: 'http://localhost:8787/api/v1/auth/jwks',
+} satisfies AppEnv.Type
 
 const makeApp = () => {
   const app = new Hono<Env>()
@@ -40,7 +44,7 @@ describe('authMiddleware', () => {
       },
     })
     const app = makeApp()
-    const res = await app.request('/api/v1/me', { headers: { Authorization: 'Bearer valid.jwt.token' } }, bindings)
+    const res = await app.request('/api/v1/me', { headers: { Authorization: 'Bearer valid.jwt.token' } }, localBindings)
     expect(res.status).toBe(200)
     expect(await res.json()).toStrictEqual({
       email: 'user@example.com',
@@ -52,21 +56,25 @@ describe('authMiddleware', () => {
 
   it('returns 401 when Authorization header is absent', async () => {
     const app = makeApp()
-    const res = await app.request('/api/v1/me', {}, bindings)
+    const res = await app.request('/api/v1/me', {}, localBindings)
     expect(res.status).toBe(401)
     expect(res.headers.get('WWW-Authenticate')).toBe('Bearer error="invalid_token"')
   })
 
   it('returns 401 when only a Cookie is present (no Authorization)', async () => {
     const app = makeApp()
-    const res = await app.request('/api/v1/me', { headers: { Cookie: 'feed-session=valid.jwt.token' } }, bindings)
+    const res = await app.request('/api/v1/me', { headers: { Cookie: 'feed-session=valid.jwt.token' } }, localBindings)
     expect(res.status).toBe(401)
   })
 
   it('returns 401 for an invalid Bearer token', async () => {
     mockJwtVerify.mockRejectedValue(new Error('signature verification failed'))
     const app = makeApp()
-    const res = await app.request('/api/v1/me', { headers: { Authorization: 'Bearer tampered.jwt.token' } }, bindings)
+    const res = await app.request(
+      '/api/v1/me',
+      { headers: { Authorization: 'Bearer tampered.jwt.token' } },
+      localBindings,
+    )
     expect(res.status).toBe(401)
     expect(res.headers.get('WWW-Authenticate')).toBe('Bearer error="invalid_token"')
   })
@@ -83,7 +91,7 @@ describe('authMiddleware', () => {
     const res = await bffWorker.request(
       '/api/v1/me',
       { headers: { Authorization: 'Bearer worker.jwt.token' } },
-      bindings,
+      localBindings,
     )
     expect(res.status).toBe(200)
     expect(await res.json()).toStrictEqual({

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
+import * as AppEnv from '#@/feature/env.ts'
 import type { Env } from '#@/feature/share/lib/hono/context.ts'
 
 const { mockJwtVerify } = vi.hoisted(() => ({ mockJwtVerify: vi.fn() }))
@@ -14,11 +15,7 @@ const { authMiddleware } = await import('./middleware.ts')
 const { middleware: runtimeMiddleware } = await import('#@/feature/runtime/hono.ts')
 const { default: bffWorker } = await import('#@/worker/bff/worker.ts')
 
-const bindings = {
-  FEED_PLATFORM_AUDIENCE: 'feed-platform-web',
-  IDP_BASE_URL: 'http://localhost:8787',
-  IDP_JWKS_URL: 'http://localhost:8787/api/v1/auth/jwks',
-}
+const bindings = AppEnv.dev
 
 const makeApp = () => {
   const app = new Hono<Env>()

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.ts
@@ -4,8 +4,13 @@ import * as Jwt from '#@/feature/auth/jwt.ts'
 import * as Env from '#@/feature/env.ts'
 import { factory } from '#@/feature/share/lib/hono/factory.ts'
 
-const makeJwtLayer = (env: Env.Type) =>
-  Jwt.layer.pipe(Layer.provide(import.meta.env.PROD ? Env.makeLayer(env) : Env.devLayer))
+const makeJwtLayer = (env: Env.Type) => {
+  try {
+    return Jwt.layer.pipe(Layer.provide(import.meta.env.PROD ? Env.makeLayer(env) : Env.devLayer))
+  } catch {
+    return Jwt.layer.pipe(Layer.provide(Env.devLayer))
+  }
+}
 
 export const authMiddleware = factory.createMiddleware((ctx, next) =>
   // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.ts
@@ -1,45 +1,33 @@
-import { Effect, Layer, Predicate, Result, String } from 'effect'
+import { Effect, Predicate, Result, String } from 'effect'
 
 import * as Jwt from '#@/feature/auth/jwt.ts'
-import * as Env from '#@/feature/env.ts'
 import { factory } from '#@/feature/share/lib/hono/factory.ts'
-
-const makeJwtLayer = (env: Env.Type) => {
-  try {
-    return Jwt.layer.pipe(Layer.provide(import.meta.env.PROD ? Env.makeLayer(env) : Env.devLayer))
-  } catch {
-    return Jwt.layer.pipe(Layer.provide(Env.devLayer))
-  }
-}
 
 export const authMiddleware = factory.createMiddleware((ctx, next) =>
   // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.
-  Effect.runPromise(
-    Effect.provide(
-      Effect.gen(function* () {
-        const authorization = ctx.req.header('Authorization')
-        if (Predicate.isNullish(authorization) || !authorization.startsWith('Bearer ')) {
-          return ctx.json({ error: 'Unauthorized' }, 401, {
-            'WWW-Authenticate': 'Bearer error="invalid_token"',
-          })
-        }
-        const token = authorization.slice('Bearer '.length)
-        if (String.isEmpty(token)) {
-          return ctx.json({ error: 'Unauthorized' }, 401, {
-            'WWW-Authenticate': 'Bearer error="invalid_token"',
-          })
-        }
-        const jwt = yield* Jwt.Service
-        const result = yield* Effect.result(jwt.verify(token))
-        if (Result.isFailure(result)) {
-          return ctx.json({ error: 'Unauthorized' }, 401, {
-            'WWW-Authenticate': 'Bearer error="invalid_token"',
-          })
-        }
-        ctx.set('user', result.success)
-        return yield* Effect.promise(() => next())
-      }),
-      makeJwtLayer(ctx.env),
-    ),
+  ctx.var.runtime.runPromise(
+    Effect.gen(function* () {
+      const authorization = ctx.req.header('Authorization')
+      if (Predicate.isNullish(authorization) || !authorization.startsWith('Bearer ')) {
+        return ctx.json({ error: 'Unauthorized' }, 401, {
+          'WWW-Authenticate': 'Bearer error="invalid_token"',
+        })
+      }
+      const token = authorization.slice('Bearer '.length)
+      if (String.isEmpty(token)) {
+        return ctx.json({ error: 'Unauthorized' }, 401, {
+          'WWW-Authenticate': 'Bearer error="invalid_token"',
+        })
+      }
+      const jwt = yield* Jwt.Service
+      const result = yield* Effect.result(jwt.verify(token))
+      if (Result.isFailure(result)) {
+        return ctx.json({ error: 'Unauthorized' }, 401, {
+          'WWW-Authenticate': 'Bearer error="invalid_token"',
+        })
+      }
+      ctx.set('user', result.success)
+      return yield* Effect.promise(() => next())
+    }),
   ),
 )

--- a/js/app/feed-platform-backend/src/feature/env.ts
+++ b/js/app/feed-platform-backend/src/feature/env.ts
@@ -9,11 +9,3 @@ export interface Type {
 export const Service = Context.Service<Type>('@app/feed-platform-backend/feature/env/Service')
 
 export const makeLayer = (env: Type) => Layer.succeed(Service, env)
-
-export const dev = {
-  FEED_PLATFORM_AUDIENCE: 'feed-platform-web',
-  IDP_BASE_URL: 'http://localhost:8787',
-  IDP_JWKS_URL: 'http://localhost:8787/api/v1/auth/jwks',
-} satisfies Type as Type
-
-export const devLayer = Layer.succeed(Service, dev)

--- a/js/app/feed-platform-backend/src/feature/env.ts
+++ b/js/app/feed-platform-backend/src/feature/env.ts
@@ -10,8 +10,10 @@ export const Service = Context.Service<Type>('@app/feed-platform-backend/feature
 
 export const makeLayer = (env: Type) => Layer.succeed(Service, env)
 
-export const devLayer = Layer.succeed(Service, {
+export const dev = {
   FEED_PLATFORM_AUDIENCE: 'feed-platform-web',
   IDP_BASE_URL: 'http://localhost:8787',
   IDP_JWKS_URL: 'http://localhost:8787/api/v1/auth/jwks',
-} satisfies Type as Type)
+} satisfies Type as Type
+
+export const devLayer = Layer.succeed(Service, dev)

--- a/js/app/feed-platform-backend/src/feature/runtime/hono.ts
+++ b/js/app/feed-platform-backend/src/feature/runtime/hono.ts
@@ -10,7 +10,7 @@ export interface Variables {
 // try/finally による明示的な `runtime.dispose()` 呼び出しは不要。
 // saas-example/src/feature/runtime/hono.ts:5-11 と同形。
 export const middleware = factory.createMiddleware(async (ctx, next) => {
-  await using runtime = Runtime.make()
+  await using runtime = Runtime.make(ctx.env)
   ctx.set('runtime', runtime.instance)
   await next()
 })

--- a/js/app/feed-platform-backend/src/feature/runtime/server.ts
+++ b/js/app/feed-platform-backend/src/feature/runtime/server.ts
@@ -1,15 +1,19 @@
 import { Layer, ManagedRuntime } from 'effect'
-import { dynamicLoggerLayer, Env, makeDisposableRuntime } from 'effect-hono'
+import { dynamicLoggerLayer, Env as RuntimeEnv, makeDisposableRuntime } from 'effect-hono'
 
+import * as Jwt from '../auth/jwt.ts'
+import * as AppEnv from '../env.ts'
 import * as Greeting from '../greeting.ts'
 import * as Health from '../health.ts'
 
-const makeRuntime = () =>
+const makeRuntime = (env: AppEnv.Type) =>
   ManagedRuntime.make(
     Health.layer.pipe(
       Layer.provideMerge(Greeting.layer),
+      Layer.provideMerge(Jwt.layer),
       Layer.provideMerge(dynamicLoggerLayer),
-      Layer.provide(Env.layer),
+      Layer.provideMerge(RuntimeEnv.layer),
+      Layer.provideMerge(AppEnv.makeLayer(env)),
     ),
   )
 
@@ -20,6 +24,5 @@ export type Runtime = ReturnType<typeof makeRuntime>
 // consumer 側は `makeRuntime` 関数定義のみを持ち、wrapper class / interface は library に委譲。
 export const DisposableRuntime = makeDisposableRuntime(makeRuntime)
 
-// 公開 entry: Hono middleware から `await using runtime = Runtime.make()` 形で利用される。
-// ENV 取得は Env.layer (process.env.NODE_ENV 由来) に内部化したため引数は不要。
-export const make = () => new DisposableRuntime()
+// 公開 entry: Hono middleware から `await using runtime = Runtime.make(ctx.env)` 形で利用される。
+export const make = (env: AppEnv.Type) => new DisposableRuntime(env)

--- a/js/app/feed-platform-backend/src/worker/bff/wrangler.jsonc
+++ b/js/app/feed-platform-backend/src/worker/bff/wrangler.jsonc
@@ -15,9 +15,13 @@
     "ip": "127.0.0.1",
     "port": 8788,
   },
-  "vars": {
-    "IDP_BASE_URL": "http://localhost:8787",
-    "IDP_JWKS_URL": "http://localhost:8787/api/v1/auth/jwks",
-    "FEED_PLATFORM_AUDIENCE": "feed-platform-web",
+  "env": {
+    "local": {
+      "vars": {
+        "IDP_BASE_URL": "http://localhost:8787",
+        "IDP_JWKS_URL": "http://localhost:8787/api/v1/auth/jwks",
+        "FEED_PLATFORM_AUDIENCE": "feed-platform-web",
+      },
+    },
   },
 }

--- a/js/app/feed-platform-backend/src/worker/bff/wrangler.jsonc
+++ b/js/app/feed-platform-backend/src/worker/bff/wrangler.jsonc
@@ -20,7 +20,7 @@
       "vars": {
         "IDP_BASE_URL": "http://localhost:8787",
         "IDP_JWKS_URL": "http://localhost:8787/api/v1/auth/jwks",
-        "FEED_PLATFORM_AUDIENCE": "feed-platform-web",
+        "FEED_PLATFORM_AUDIENCE": "feed-platform-backend",
       },
     },
   },

--- a/js/app/feed-platform-backend/vite.config.ts
+++ b/js/app/feed-platform-backend/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
         dependsOn: ['setup:cloudflare:bff', 'setup:cloudflare:health'],
       },
       'setup:cloudflare:bff': {
-        command: 'wrangler types --config src/worker/bff/wrangler.jsonc src/worker/bff/worker-configuration.d.ts',
+        command:
+          'wrangler types --env local --config src/worker/bff/wrangler.jsonc src/worker/bff/worker-configuration.d.ts',
         input: taskInput.setup['cloudflare:bff'],
       },
       'setup:cloudflare:health': {

--- a/js/app/feed-platform-web/AGENTS.md
+++ b/js/app/feed-platform-web/AGENTS.md
@@ -1,0 +1,19 @@
+# feed-platform-web
+
+## Authentication flow reference
+
+- See `../identity-provider/docs/auth-flow.md` for the feed login flow,
+  OAuth/OIDC compliance status, and security hardening checklist.
+
+When editing feed auth code, check that document first. The current feed example
+depends on:
+
+- `app/feature/auth/oauth-client.ts` for authorization URL, PKCE, state, and
+  nonce generation.
+- `app/feature/auth/callback.ts` for code exchange, nonce verification, and
+  session cookie creation.
+- `app/feature/auth/middleware.ts` for ID-token session verification.
+- `app/feature/api/client.ts` for calls to `feed-platform-backend`.
+
+Production follow-up from the IdP document: use a proper API access token or
+introspection flow instead of using an ID token as the backend bearer token.

--- a/js/app/feed-platform-web/AGENTS.md
+++ b/js/app/feed-platform-web/AGENTS.md
@@ -11,9 +11,11 @@ depends on:
 - `app/feature/auth/oauth-client.ts` for authorization URL, PKCE, state, and
   nonce generation.
 - `app/feature/auth/callback.ts` for code exchange, nonce verification, and
-  session cookie creation.
+  session cookie creation plus server-side access/refresh token storage.
 - `app/feature/auth/middleware.ts` for ID-token session verification.
-- `app/feature/api/client.ts` for calls to `feed-platform-backend`.
+- `app/feature/api/client.ts` for calls to `feed-platform-backend` using the
+  server-side JWT access token, not the `feed-session` ID token.
 
-Production follow-up from the IdP document: use a proper API access token or
-introspection flow instead of using an ID token as the backend bearer token.
+The backend bearer token must be the resource-specific JWT access token obtained
+with `resource=feed-platform-backend`. Keep `feed-session` scoped to web session
+identity.

--- a/js/app/feed-platform-web/app/app.tsx
+++ b/js/app/feed-platform-web/app/app.tsx
@@ -27,6 +27,7 @@ import { Document } from '#@/ui/document.tsx'
 
 const TokenResponse = Schema.Struct({
   access_token: Schema.String,
+  id_token: Schema.optional(Schema.String),
   refresh_token: Schema.optional(Schema.String),
 })
 
@@ -52,6 +53,7 @@ const logoutFromIdp = (idpBaseUrl: string, sessionCookieValue: string) =>
   Effect.gen(function* () {
     const client = yield* HttpClient.HttpClient
     const request = HttpClientRequest.post(`${idpBaseUrl}/api/v1/auth/sign-out`, {
+      body: HttpBody.jsonUnsafe({}),
       headers: { Cookie: `${FEED_SESSION_COOKIE}=${sessionCookieValue}` },
     })
     yield* client.execute(request)
@@ -177,7 +179,7 @@ const app: Hono<Env> = new Hono<Env>()
           return ctx.redirect('/login')
         }
 
-        setCookie(ctx, FEED_SESSION_COOKIE, tokenData.access_token, {
+        setCookie(ctx, FEED_SESSION_COOKIE, tokenData.id_token ?? tokenData.access_token, {
           httpOnly: true,
           path: '/',
           sameSite: 'Lax',

--- a/js/app/feed-platform-web/app/app.tsx
+++ b/js/app/feed-platform-web/app/app.tsx
@@ -8,7 +8,7 @@ import { logger } from 'hono/logger'
 
 import { BackendClient } from '#@/feature/api/client.ts'
 import { handleAuthCallback } from '#@/feature/auth/callback.ts'
-import { FEED_REFRESH_COOKIE, FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
+import { FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
 import { authMiddleware } from '#@/feature/auth/middleware.ts'
 import { storeNonce } from '#@/feature/auth/nonce-store.ts'
 import {
@@ -18,6 +18,7 @@ import {
   generateState,
   generateVerifier,
 } from '#@/feature/auth/oauth-client.ts'
+import { deleteRefreshToken, getRefreshToken, replaceRefreshToken } from '#@/feature/auth/refresh-store.ts'
 import { Service as DBService } from '#@/feature/db/kysely.ts'
 import * as AppEnv from '#@/feature/env.ts'
 import * as Greeting from '#@/feature/greeting.ts'
@@ -130,12 +131,15 @@ const app: Hono<Env> = new Hono<Env>()
     ctx.var.runtime.runPromise(
       Effect.gen(function* () {
         const { user } = ctx.var
-        if (Predicate.isNullish(user)) {
+        const sessionToken = getCookie(ctx, FEED_SESSION_COOKIE)
+        if (Predicate.isNullish(user) && Predicate.isNullish(sessionToken)) {
           return ctx.redirect('/login')
         }
         const env = yield* AppEnv.Service
         const client = yield* BackendClient
-        const callMeResult = yield* client.callMe().pipe(Effect.orElseSucceed(() => null))
+        const callMeResult = Predicate.isNullish(user)
+          ? null
+          : yield* client.callMe().pipe(Effect.orElseSucceed(() => null))
         if (!Predicate.isNullish(callMeResult)) {
           return ctx.render(
             <Document>
@@ -147,10 +151,15 @@ const app: Hono<Env> = new Hono<Env>()
           )
         }
 
-        const refreshToken = getCookie(ctx, FEED_REFRESH_COOKIE)
+        const db = yield* DBService
+        if (Predicate.isNullish(sessionToken)) {
+          deleteCookie(ctx, FEED_SESSION_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
+          return ctx.redirect('/login')
+        }
+        const now = DateTime.toEpochMillis(yield* DateTime.now)
+        const refreshToken = yield* Effect.promise(() => getRefreshToken(db, sessionToken, now))
         if (Predicate.isNullish(refreshToken)) {
           deleteCookie(ctx, FEED_SESSION_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
-          deleteCookie(ctx, FEED_REFRESH_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
           return ctx.redirect('/login')
         }
 
@@ -158,6 +167,7 @@ const app: Hono<Env> = new Hono<Env>()
           client_id: env.OAUTH_CLIENT_ID,
           grant_type: 'refresh_token',
           refresh_token: refreshToken,
+          resource: env.BACKEND_RESOURCE,
         }
         if (String.isNonEmpty(env.OAUTH_CLIENT_SECRET)) {
           bodyParams.client_secret = env.OAUTH_CLIENT_SECRET
@@ -165,8 +175,8 @@ const app: Hono<Env> = new Hono<Env>()
 
         const tokenData = yield* refreshTokens(env.IDP_BASE_URL, bodyParams).pipe(Effect.orElseSucceed(() => null))
         if (Predicate.isNullish(tokenData)) {
+          yield* Effect.promise(() => deleteRefreshToken(db, sessionToken))
           deleteCookie(ctx, FEED_SESSION_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
-          deleteCookie(ctx, FEED_REFRESH_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
           return ctx.redirect('/login')
         }
 
@@ -174,24 +184,24 @@ const app: Hono<Env> = new Hono<Env>()
           .callMeWithAccessToken(tokenData.access_token)
           .pipe(Effect.orElseSucceed(() => null))
         if (Predicate.isNullish(retryResult)) {
+          yield* Effect.promise(() => deleteRefreshToken(db, sessionToken))
           deleteCookie(ctx, FEED_SESSION_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
-          deleteCookie(ctx, FEED_REFRESH_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
           return ctx.redirect('/login')
         }
 
-        setCookie(ctx, FEED_SESSION_COOKIE, tokenData.id_token ?? tokenData.access_token, {
+        const nextSessionToken = tokenData.id_token ?? sessionToken
+        setCookie(ctx, FEED_SESSION_COOKIE, nextSessionToken, {
           httpOnly: true,
           path: '/',
           sameSite: 'Lax',
         })
-        if (!Predicate.isNullish(tokenData.refresh_token) && String.isNonEmpty(tokenData.refresh_token)) {
-          setCookie(ctx, FEED_REFRESH_COOKIE, tokenData.refresh_token, {
-            httpOnly: true,
-            maxAge: 2_592_000,
-            path: '/',
-            sameSite: 'Lax',
-          })
-        }
+        const nextRefreshToken =
+          !Predicate.isNullish(tokenData.refresh_token) && String.isNonEmpty(tokenData.refresh_token)
+            ? tokenData.refresh_token
+            : refreshToken
+        yield* Effect.promise(() =>
+          replaceRefreshToken(db, sessionToken, nextSessionToken, nextRefreshToken, tokenData.access_token, now),
+        )
 
         return ctx.render(
           <Document>
@@ -209,12 +219,13 @@ const app: Hono<Env> = new Hono<Env>()
     ctx.var.runtime.runPromise(
       Effect.gen(function* () {
         const env = yield* AppEnv.Service
+        const db = yield* DBService
         const token = getCookie(ctx, FEED_SESSION_COOKIE)
         if (!Predicate.isNullish(token)) {
           yield* logoutFromIdp(env.IDP_BASE_URL, token).pipe(Effect.ignore)
+          yield* Effect.promise(() => deleteRefreshToken(db, token))
         }
         deleteCookie(ctx, FEED_SESSION_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
-        deleteCookie(ctx, FEED_REFRESH_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
         return ctx.redirect('/login')
       }),
     ),

--- a/js/app/feed-platform-web/app/app.tsx
+++ b/js/app/feed-platform-web/app/app.tsx
@@ -28,7 +28,7 @@ import { Document } from '#@/ui/document.tsx'
 
 const TokenResponse = Schema.Struct({
   access_token: Schema.String,
-  id_token: Schema.optional(Schema.String),
+  id_token: Schema.String,
   refresh_token: Schema.optional(Schema.String),
 })
 
@@ -145,7 +145,7 @@ const app: Hono<Env> = new Hono<Env>()
             <Document>
               <h1>Dashboard</h1>
               <p>Logged in as: {callMeResult.email}</p>
-              <p>User ID: {callMeResult.id}</p>
+              <p>Subject: {callMeResult.sub}</p>
               <a href='/logout'>Logout</a>
             </Document>,
           )
@@ -189,7 +189,7 @@ const app: Hono<Env> = new Hono<Env>()
           return ctx.redirect('/login')
         }
 
-        const nextSessionToken = tokenData.id_token ?? sessionToken
+        const nextSessionToken = tokenData.id_token
         setCookie(ctx, FEED_SESSION_COOKIE, nextSessionToken, {
           httpOnly: true,
           path: '/',
@@ -207,7 +207,7 @@ const app: Hono<Env> = new Hono<Env>()
           <Document>
             <h1>Dashboard</h1>
             <p>Logged in as: {retryResult.email}</p>
-            <p>User ID: {retryResult.id}</p>
+            <p>Subject: {retryResult.sub}</p>
             <a href='/logout'>Logout</a>
           </Document>,
         )

--- a/js/app/feed-platform-web/app/feature/api/client.test.ts
+++ b/js/app/feed-platform-web/app/feature/api/client.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Predicate, Result } from 'effect'
+import { Effect, Layer, Predicate } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { Hono } from 'hono'
 import { contextStorage } from 'hono/context-storage'
@@ -39,7 +39,7 @@ const makeTestLayer = (db: DB.Instance) =>
   )
 
 const successResponse = () =>
-  Promise.resolve(Response.json({ email: 'user@example.com', id: 'user-1' }, { status: 200 }))
+  Promise.resolve(Response.json({ email: 'user@example.com', sub: 'user-1' }, { status: 200 }))
 
 const validExpiresAt = 4_102_444_800_000
 
@@ -55,8 +55,12 @@ const requestCallMe = (db: DB.Instance, cookie?: string) => {
         Effect.provide(
           Effect.gen(function* () {
             const client = yield* BackendClient
-            const exit = yield* Effect.result(client.callMe())
-            return Result.isSuccess(exit) ? { data: exit.success, ok: true } : { ok: false }
+            return yield* client.callMe().pipe(
+              Effect.match({
+                onFailure: () => ({ ok: false }),
+                onSuccess: (data) => ({ data, ok: true }),
+              }),
+            )
           }),
           makeTestLayer(db),
         ),
@@ -74,8 +78,12 @@ const requestCallMeWithAccessToken = () => {
         Effect.provide(
           Effect.gen(function* () {
             const client = yield* BackendClient
-            const exit = yield* Effect.result(client.callMeWithAccessToken('test-jwt'))
-            return Result.isSuccess(exit) ? { data: exit.success, ok: true } : { ok: false }
+            return yield* client.callMeWithAccessToken('test-jwt').pipe(
+              Effect.match({
+                onFailure: () => ({ ok: false }),
+                onSuccess: (data) => ({ data, ok: true }),
+              }),
+            )
           }),
           makeTestLayer(db),
         ),
@@ -110,9 +118,9 @@ describe('BackendClient.callMe', () => {
     const missingCookieResponse = await requestCallMe(db)
     const failedBackendResponse = await requestCallMeWithAccessToken()
 
-    expect(await cookieResponse.json()).toStrictEqual({ data: { email: 'user@example.com', id: 'user-1' }, ok: true })
+    expect(await cookieResponse.json()).toStrictEqual({ data: { email: 'user@example.com', sub: 'user-1' }, ok: true })
     expect(await accessTokenResponse.json()).toStrictEqual({
-      data: { email: 'user@example.com', id: 'user-1' },
+      data: { email: 'user@example.com', sub: 'user-1' },
       ok: true,
     })
     expect(await missingCookieResponse.json()).toMatchObject({ ok: false })
@@ -123,5 +131,16 @@ describe('BackendClient.callMe', () => {
     expect(firstRequestUrl).toBe('http://localhost:8789/api/v1/me')
     const firstRequestInit = mockFetch.mock.calls[0]?.[1]
     expect(firstRequestInit?.headers).toMatchObject({ authorization: 'Bearer stored-access-jwt' })
+  })
+
+  it('rejects backend responses that provide id without sub', async () => {
+    const mockFetch = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      .mockResolvedValue(Response.json({ email: 'user@example.com', id: 'user-1' }, { status: 200 }))
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await requestCallMeWithAccessToken()
+
+    expect(await response.json()).toStrictEqual({ ok: false })
   })
 })

--- a/js/app/feed-platform-web/app/feature/api/client.test.ts
+++ b/js/app/feed-platform-web/app/feature/api/client.test.ts
@@ -5,6 +5,7 @@ import { contextStorage } from 'hono/context-storage'
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
 
 import { FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
+import * as DB from '#@/feature/db/kysely.ts'
 import * as Env from '#@/feature/env.ts'
 import type { Env as HonoEnv } from '#@/feature/share/lib/hono/context.ts'
 
@@ -12,6 +13,7 @@ import { BackendClient, liveLayer } from './client.ts'
 
 const testEnv = {
   BACKEND_BASE_URL: 'http://localhost:8789',
+  BACKEND_RESOURCE: 'feed-platform-backend',
   DATABASE_AUTH_TOKEN: '',
   DATABASE_URL: ':memory:',
   IDP_BASE_URL: 'https://idp.example.com',
@@ -19,17 +21,34 @@ const testEnv = {
   OAUTH_CLIENT_SECRET: 'dev-secret',
 } satisfies Env.Type
 
-const makeTestLayer = () => Layer.merge(liveLayer, FetchHttpClient.layer).pipe(Layer.provide(Env.makeLayer(testEnv)))
+const createRefreshSessionTable = async (db: DB.Instance): Promise<void> => {
+  await db.schema
+    .createTable('oauth_refresh_session')
+    .addColumn('session_token', 'text', (column) => column.primaryKey().notNull())
+    .addColumn('access_token', 'text', (column) => column.notNull())
+    .addColumn('refresh_token', 'text', (column) => column.notNull())
+    .addColumn('expires_at', 'integer', (column) => column.notNull())
+    .execute()
+}
+
+const makeTestLayer = (db: DB.Instance) =>
+  liveLayer.pipe(
+    Layer.provideMerge(FetchHttpClient.layer),
+    Layer.provideMerge(Layer.succeed(DB.Service, db)),
+    Layer.provide(Env.makeLayer(testEnv)),
+  )
 
 const successResponse = () =>
   Promise.resolve(Response.json({ email: 'user@example.com', id: 'user-1' }, { status: 200 }))
+
+const validExpiresAt = 4_102_444_800_000
 
 afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
 })
 
-const requestCallMe = (cookie?: string) => {
+const requestCallMe = (db: DB.Instance, cookie?: string) => {
   const app = new Hono<HonoEnv>().use(contextStorage()).get('/test', async (ctx) =>
     ctx.json(
       await Effect.runPromise(
@@ -39,7 +58,7 @@ const requestCallMe = (cookie?: string) => {
             const exit = yield* Effect.result(client.callMe())
             return Result.isSuccess(exit) ? { data: exit.success, ok: true } : { ok: false }
           }),
-          makeTestLayer(),
+          makeTestLayer(db),
         ),
       ),
     ),
@@ -48,6 +67,7 @@ const requestCallMe = (cookie?: string) => {
 }
 
 const requestCallMeWithAccessToken = () => {
+  const db = DB.makeInMemory()
   const app = new Hono<HonoEnv>().use(contextStorage()).get('/test', async (ctx) =>
     ctx.json(
       await Effect.runPromise(
@@ -57,7 +77,7 @@ const requestCallMeWithAccessToken = () => {
             const exit = yield* Effect.result(client.callMeWithAccessToken('test-jwt'))
             return Result.isSuccess(exit) ? { data: exit.success, ok: true } : { ok: false }
           }),
-          makeTestLayer(),
+          makeTestLayer(db),
         ),
       ),
     ),
@@ -67,16 +87,27 @@ const requestCallMeWithAccessToken = () => {
 
 describe('BackendClient.callMe', () => {
   it('reads authorization from Hono context and supports refresh-token retry calls', async () => {
+    const db = DB.makeInMemory()
+    await createRefreshSessionTable(db)
+    await db
+      .insertInto('oauthRefreshSession')
+      .values({
+        accessToken: 'stored-access-jwt',
+        expiresAt: validExpiresAt,
+        refreshToken: 'refresh-token',
+        sessionToken: 'id-token-session',
+      })
+      .execute()
     const mockFetch = vi
-      .fn()
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
       .mockImplementationOnce(successResponse)
       .mockImplementationOnce(successResponse)
       .mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 401 })))
     vi.stubGlobal('fetch', mockFetch)
 
-    const cookieResponse = await requestCallMe(`${FEED_SESSION_COOKIE}=test-jwt`)
+    const cookieResponse = await requestCallMe(db, `${FEED_SESSION_COOKIE}=id-token-session`)
     const accessTokenResponse = await requestCallMeWithAccessToken()
-    const missingCookieResponse = await requestCallMe()
+    const missingCookieResponse = await requestCallMe(db)
     const failedBackendResponse = await requestCallMeWithAccessToken()
 
     expect(await cookieResponse.json()).toStrictEqual({ data: { email: 'user@example.com', id: 'user-1' }, ok: true })
@@ -87,5 +118,10 @@ describe('BackendClient.callMe', () => {
     expect(await missingCookieResponse.json()).toMatchObject({ ok: false })
     expect(await failedBackendResponse.json()).toMatchObject({ ok: false })
     expect(mockFetch).toHaveBeenCalledTimes(3)
+    const firstRequestInput = mockFetch.mock.calls[0]?.[0]
+    const firstRequestUrl = firstRequestInput instanceof URL ? firstRequestInput.href : firstRequestInput
+    expect(firstRequestUrl).toBe('http://localhost:8789/api/v1/me')
+    const firstRequestInit = mockFetch.mock.calls[0]?.[1]
+    expect(firstRequestInit?.headers).toMatchObject({ authorization: 'Bearer stored-access-jwt' })
   })
 })

--- a/js/app/feed-platform-web/app/feature/api/client.ts
+++ b/js/app/feed-platform-web/app/feature/api/client.ts
@@ -1,9 +1,11 @@
 import type { TaggedErrorBaseType } from '@totto2727/fp/error'
-import { Context, Data, Effect, Layer, Predicate, Schema } from 'effect'
+import { Context, Data, DateTime, Effect, Layer, Predicate, Schema } from 'effect'
 import { HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import { getCookie } from 'hono/cookie'
 
 import { FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
+import { getAccessToken } from '#@/feature/auth/refresh-store.ts'
+import * as DB from '#@/feature/db/kysely.ts'
 import * as Env from '#@/feature/env.ts'
 import * as HonoContext from '#@/feature/share/lib/hono/context.ts'
 
@@ -51,20 +53,26 @@ const callBackendApi = (baseUrl: string, authorization: string) =>
     return { email: user.email, id }
   })
 
-const getAuthorization = (): string | null => {
-  const token = getCookie(HonoContext.get(), FEED_SESSION_COOKIE)
-  return Predicate.isNullish(token) ? null : `Bearer ${token}`
-}
-
 const callBackendApiWithAuthorization = (baseUrl: string, authorization: string | null) =>
   Predicate.isNullish(authorization)
     ? Effect.fail(new BackendError({ message: 'missing feed-session cookie' }))
     : callBackendApi(baseUrl, authorization).pipe(Effect.mapError((failure) => new BackendError({ error: failure })))
 
 const makeCallMe =
-  (baseUrl: string): BackendClientService['callMe'] =>
+  (baseUrl: string, db: DB.Instance): BackendClientService['callMe'] =>
   () =>
-    callBackendApiWithAuthorization(baseUrl, getAuthorization())
+    Effect.gen(function* () {
+      const sessionToken = getCookie(HonoContext.get(), FEED_SESSION_COOKIE)
+      if (Predicate.isNullish(sessionToken)) {
+        return yield* Effect.fail(new BackendError({ message: 'missing feed-session cookie' }))
+      }
+      const now = DateTime.toEpochMillis(yield* DateTime.now)
+      const accessToken = yield* Effect.promise(() => getAccessToken(db, sessionToken, now))
+      return yield* callBackendApiWithAuthorization(
+        baseUrl,
+        Predicate.isNullish(accessToken) ? null : `Bearer ${accessToken}`,
+      )
+    })
 
 const makeCallMeWithAccessToken =
   (baseUrl: string): BackendClientService['callMeWithAccessToken'] =>
@@ -75,8 +83,9 @@ export const liveLayer = Layer.effect(
   BackendClient,
   Effect.gen(function* () {
     const env = yield* Env.Service
+    const db = yield* DB.Service
     return {
-      callMe: makeCallMe(env.BACKEND_BASE_URL),
+      callMe: makeCallMe(env.BACKEND_BASE_URL, db),
       callMeWithAccessToken: makeCallMeWithAccessToken(env.BACKEND_BASE_URL),
     }
   }),

--- a/js/app/feed-platform-web/app/feature/api/client.ts
+++ b/js/app/feed-platform-web/app/feature/api/client.ts
@@ -10,8 +10,8 @@ import * as Env from '#@/feature/env.ts'
 import * as HonoContext from '#@/feature/share/lib/hono/context.ts'
 
 export interface UserDTO {
-  readonly id: string
   readonly email: string
+  readonly sub: string
 }
 
 export class BackendError extends Data.TaggedError('BackendError')<TaggedErrorBaseType> {}
@@ -25,8 +25,7 @@ export const BackendClient = Context.Service<BackendClientService>('BackendClien
 
 const UserResponse = Schema.Struct({
   email: Schema.String,
-  id: Schema.optional(Schema.String),
-  sub: Schema.optional(Schema.String),
+  sub: Schema.String,
 })
 
 // oxlint-disable-next-line rules/prefer-non-unknown-decode -- backend JSON response is an external boundary with unknown shape.
@@ -46,11 +45,7 @@ const callBackendApi = (baseUrl: string, authorization: string) =>
     const user = yield* decodeUserResponse(data).pipe(
       Effect.mapError((error) => new BackendError({ error, message: 'invalid response shape' })),
     )
-    const id = user.id ?? user.sub
-    if (Predicate.isNullish(id)) {
-      return yield* Effect.fail(new BackendError({ message: 'missing user id' }))
-    }
-    return { email: user.email, id }
+    return { email: user.email, sub: user.sub }
   })
 
 const callBackendApiWithAuthorization = (baseUrl: string, authorization: string | null) =>
@@ -92,6 +87,6 @@ export const liveLayer = Layer.effect(
 )
 
 export const mockLayer = Layer.succeed(BackendClient, {
-  callMe: () => Effect.succeed({ email: 'mock@example.com', id: 'mock-user' }),
-  callMeWithAccessToken: () => Effect.succeed({ email: 'mock@example.com', id: 'mock-user' }),
+  callMe: () => Effect.succeed({ email: 'mock@example.com', sub: 'mock-user' }),
+  callMeWithAccessToken: () => Effect.succeed({ email: 'mock@example.com', sub: 'mock-user' }),
 })

--- a/js/app/feed-platform-web/app/feature/api/client.ts
+++ b/js/app/feed-platform-web/app/feature/api/client.ts
@@ -23,7 +23,8 @@ export const BackendClient = Context.Service<BackendClientService>('BackendClien
 
 const UserResponse = Schema.Struct({
   email: Schema.String,
-  id: Schema.String,
+  id: Schema.optional(Schema.String),
+  sub: Schema.optional(Schema.String),
 })
 
 // oxlint-disable-next-line rules/prefer-non-unknown-decode -- backend JSON response is an external boundary with unknown shape.
@@ -40,9 +41,14 @@ const callBackendApi = (baseUrl: string, authorization: string) =>
       return yield* Effect.fail(new BackendError({ message: `HTTP ${response.status}` }))
     }
     const data: unknown = yield* response.json
-    return yield* decodeUserResponse(data).pipe(
+    const user = yield* decodeUserResponse(data).pipe(
       Effect.mapError((error) => new BackendError({ error, message: 'invalid response shape' })),
     )
+    const id = user.id ?? user.sub
+    if (Predicate.isNullish(id)) {
+      return yield* Effect.fail(new BackendError({ message: 'missing user id' }))
+    }
+    return { email: user.email, id }
   })
 
 const getAuthorization = (): string | null => {

--- a/js/app/feed-platform-web/app/feature/auth/callback.test.ts
+++ b/js/app/feed-platform-web/app/feature/auth/callback.test.ts
@@ -1,16 +1,19 @@
-import { Effect } from 'effect'
-import { FetchHttpClient } from 'effect/unstable/http'
+import { Effect, Layer } from 'effect'
+import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 import { Hono } from 'hono'
-import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+import { describe, expect, it } from 'vite-plus/test'
 
 import { FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
+import { getAccessToken, getRefreshToken } from '#@/feature/auth/refresh-store.ts'
 import { makeInMemory } from '#@/feature/db/kysely.ts'
+import type { Instance as DBInstance } from '#@/feature/db/kysely.ts'
 import type { Type as EnvType } from '#@/feature/env.ts'
 
 import { handleAuthCallback } from './callback.ts'
 
 const testEnv: EnvType = {
   BACKEND_BASE_URL: 'http://localhost:8789',
+  BACKEND_RESOURCE: 'feed-platform-backend',
   DATABASE_AUTH_TOKEN: '',
   DATABASE_URL: ':memory:',
   IDP_BASE_URL: 'https://idp.example.com',
@@ -18,19 +21,54 @@ const testEnv: EnvType = {
   OAUTH_CLIENT_SECRET: '',
 }
 
-const makeApp = () =>
-  new Hono().get('/auth/callback', (ctx) =>
-    Effect.runPromise(handleAuthCallback(ctx, testEnv, makeInMemory()).pipe(Effect.provide(FetchHttpClient.layer))),
+const makeHttpClientLayer = (response: Response) =>
+  Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) => Effect.succeed(HttpClientResponse.fromWeb(request, response))),
   )
+
+const makeIdToken = (nonce: string): string => `header.${btoa(JSON.stringify({ nonce }))}.signature`
+
+const validExpiresAt = 4_102_444_800_000
+
+const makeApp = (
+  db: DBInstance = makeInMemory(),
+  httpClientLayer = makeHttpClientLayer(
+    Response.json({ access_token: 'access-jwt-token', id_token: makeIdToken('mystate') }, { status: 200 }),
+  ),
+) =>
+  new Hono().get('/auth/callback', (ctx) =>
+    Effect.runPromise(handleAuthCallback(ctx, testEnv, db).pipe(Effect.provide(httpClientLayer))),
+  )
+
+const createRefreshSessionTable = async (db: DBInstance): Promise<void> => {
+  await db.schema
+    .createTable('oauth_refresh_session')
+    .addColumn('session_token', 'text', (column) => column.primaryKey().notNull())
+    .addColumn('access_token', 'text', (column) => column.notNull())
+    .addColumn('refresh_token', 'text', (column) => column.notNull())
+    .addColumn('expires_at', 'integer', (column) => column.notNull())
+    .execute()
+}
+
+const createNonceTable = async (db: DBInstance): Promise<void> => {
+  await db.schema
+    .createTable('oauth_nonce')
+    .addColumn('state', 'text', (column) => column.primaryKey().notNull())
+    .addColumn('nonce', 'text', (column) => column.notNull())
+    .addColumn('expires_at', 'integer', (column) => column.notNull())
+    .execute()
+}
+
+const prepareNonce = async (db: DBInstance): Promise<void> => {
+  await createNonceTable(db)
+  await db.insertInto('oauthNonce').values({ expiresAt: validExpiresAt, nonce: 'mystate', state: 'mystate' }).execute()
+}
 
 const makeCookieHeader = (pairs: Record<string, string>) =>
   Object.entries(pairs)
     .map(([k, v]) => `${k}=${v}`)
     .join('; ')
-
-afterEach(() => {
-  vi.restoreAllMocks()
-})
 
 describe('handleAuthCallback', () => {
   it('returns 403 when state mismatches', async () => {
@@ -42,23 +80,47 @@ describe('handleAuthCallback', () => {
   })
 
   it('redirects to /dashboard and sets feed-session on success', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(Response.json({ access_token: 'jwt-token-here' }, { status: 200 })),
-    )
-    const app = makeApp()
+    const db = makeInMemory()
+    await prepareNonce(db)
+    const app = makeApp(db)
     const res = await app.request('/auth/callback?code=authcode&state=mystate', {
       headers: { cookie: makeCookieHeader({ oauth_state: 'mystate', pkce_verifier: 'verifier123' }) },
     })
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe('/dashboard')
     const cookies = res.headers.getSetCookie()
-    expect(cookies.some((cookie) => cookie.startsWith(`${FEED_SESSION_COOKIE}=jwt-token-here`))).toBe(true)
+    expect(cookies.some((cookie) => cookie.startsWith(`${FEED_SESSION_COOKIE}=header.`))).toBe(true)
+  })
+
+  it('stores refresh token in DB without setting a browser refresh cookie', async () => {
+    const db = makeInMemory()
+    await prepareNonce(db)
+    await createRefreshSessionTable(db)
+    const app = makeApp(
+      db,
+      makeHttpClientLayer(
+        Response.json(
+          {
+            access_token: 'access-jwt-token',
+            id_token: makeIdToken('mystate'),
+            refresh_token: 'refresh-token-server-side',
+          },
+          { status: 200 },
+        ),
+      ),
+    )
+    const res = await app.request('/auth/callback?code=authcode&state=mystate', {
+      headers: { cookie: makeCookieHeader({ oauth_state: 'mystate', pkce_verifier: 'verifier123' }) },
+    })
+    expect(res.status).toBe(302)
+    const cookies = res.headers.getSetCookie()
+    expect(cookies.some((cookie) => cookie.startsWith('feed-refresh='))).toBe(false)
+    expect(await getAccessToken(db, makeIdToken('mystate'), 0)).toBe('access-jwt-token')
+    expect(await getRefreshToken(db, makeIdToken('mystate'), 0)).toBe('refresh-token-server-side')
   })
 
   it('returns 401 when token endpoint returns non-200', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 401 })))
-    const app = makeApp()
+    const app = makeApp(makeInMemory(), makeHttpClientLayer(new Response(null, { status: 401 })))
     const res = await app.request('/auth/callback?code=authcode&state=mystate', {
       headers: { cookie: makeCookieHeader({ oauth_state: 'mystate', pkce_verifier: 'verifier123' }) },
     })
@@ -66,8 +128,7 @@ describe('handleAuthCallback', () => {
   })
 
   it('returns 401 when access_token is missing from response', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({})))
-    const app = makeApp()
+    const app = makeApp(makeInMemory(), makeHttpClientLayer(Response.json({})))
     const res = await app.request('/auth/callback?code=authcode&state=mystate', {
       headers: { cookie: makeCookieHeader({ oauth_state: 'mystate', pkce_verifier: 'verifier123' }) },
     })

--- a/js/app/feed-platform-web/app/feature/auth/callback.ts
+++ b/js/app/feed-platform-web/app/feature/auth/callback.ts
@@ -11,7 +11,7 @@ import type * as Env from '#@/feature/env.ts'
 
 const TokenResponse = Schema.Struct({
   access_token: Schema.String,
-  id_token: Schema.optional(Schema.String),
+  id_token: Schema.String,
   refresh_token: Schema.optional(Schema.String),
 })
 
@@ -34,10 +34,9 @@ const exchangeToken = (idpBaseUrl: string, params: Record<string, string>) =>
     const response = yield* client.execute(request)
     if (response.status !== 200) {
       const text = yield* response.text
-      return { data: null, error: String.isNonEmpty(text) ? text : 'token exchange failed' }
+      return yield* Effect.fail(new Error(String.isNonEmpty(text) ? text : 'token exchange failed'))
     }
-    const data: unknown = yield* response.json
-    return { data, error: null }
+    return yield* response.json
   })
 
 const verifyNonce = (db: DBInstance, idToken: string, state: string) =>
@@ -91,24 +90,24 @@ export const handleAuthCallback = (
       bodyParams.client_secret = env.OAUTH_CLIENT_SECRET
     }
 
-    const rawTokenResult = yield* exchangeToken(env.IDP_BASE_URL, bodyParams).pipe(
-      Effect.orElseSucceed(() => ({ data: null, error: 'token exchange failed' })),
+    const resultOrResponse = yield* exchangeToken(env.IDP_BASE_URL, bodyParams).pipe(
+      Effect.flatMap(decodeTokenResponse),
+      Effect.match({
+        onFailure: (error) => new Response(`auth failed: ${globalThis.String(error)}`, { status: 401 }),
+        onSuccess: (tokenResponse) => tokenResponse,
+      }),
     )
-    if (Predicate.isNullish(rawTokenResult.data)) {
-      return new Response(`auth failed: ${rawTokenResult.error}`, { status: 401 })
-    }
-    const rawToken = rawTokenResult.data
-    const result = yield* decodeTokenResponse(rawToken).pipe(Effect.orElseSucceed(() => null))
 
-    if (Predicate.isNullish(result)) {
-      return new Response('auth failed', { status: 401 })
+    if (resultOrResponse instanceof Response) {
+      return resultOrResponse
     }
+    const result = resultOrResponse
     if (String.isEmpty(result.access_token)) {
       return new Response('auth failed', { status: 401 })
     }
 
     const idToken = result.id_token
-    if (Predicate.isNullish(idToken) || String.isEmpty(idToken)) {
+    if (String.isEmpty(idToken)) {
       return new Response('auth failed', { status: 401 })
     }
 

--- a/js/app/feed-platform-web/app/feature/auth/callback.ts
+++ b/js/app/feed-platform-web/app/feature/auth/callback.ts
@@ -1,5 +1,4 @@
 import { Effect, Predicate, Schema, String } from 'effect'
-import { HttpClient, HttpClientRequest, HttpBody } from 'effect/unstable/http'
 import type { Context } from 'hono'
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 
@@ -25,17 +24,22 @@ const decodeIdTokenPayload = Schema.decodeUnknownEffect(IdTokenPayload)
 
 const exchangeToken = (idpBaseUrl: string, params: Record<string, string>) =>
   Effect.gen(function* () {
-    const client = yield* HttpClient.HttpClient
     const formBody = new URLSearchParams(params).toString()
-    const request = HttpClientRequest.post(`${idpBaseUrl}/api/v1/auth/oauth2/token`, {
-      body: HttpBody.text(formBody, 'application/x-www-form-urlencoded'),
-    })
-    const response = yield* client.execute(request)
+    /* oxlint-disable rules/no-fetch -- Token exchange runs in a Worker request handler where native fetch is the platform boundary. */
+    const response = yield* Effect.promise(() =>
+      fetch(`${idpBaseUrl}/api/v1/auth/oauth2/token`, {
+        body: formBody,
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        method: 'POST',
+      }),
+    )
+    /* oxlint-enable rules/no-fetch */
     if (response.status !== 200) {
-      return yield* Effect.fail(new Error('token exchange failed'))
+      const text = yield* Effect.promise(() => response.text())
+      return { data: null, error: String.isNonEmpty(text) ? text : 'token exchange failed' }
     }
-    const data: unknown = yield* response.json
-    return data
+    const data: unknown = yield* Effect.promise(() => response.json())
+    return { data, error: null }
   })
 
 const verifyNonce = (db: DBInstance, idToken: string, state: string) =>
@@ -57,11 +61,7 @@ const verifyNonce = (db: DBInstance, idToken: string, state: string) =>
     return yield* Effect.promise(() => verifyAndDeleteNonce(db, state, decodedPayload.nonce))
   })
 
-export const handleAuthCallback = (
-  ctx: Context,
-  env: Env.Type,
-  db: DBInstance,
-): Effect.Effect<Response, never, HttpClient.HttpClient> =>
+export const handleAuthCallback = (ctx: Context, env: Env.Type, db: DBInstance): Effect.Effect<Response> =>
   Effect.gen(function* () {
     const code = ctx.req.query('code')
     const state = ctx.req.query('state')
@@ -88,10 +88,13 @@ export const handleAuthCallback = (
       bodyParams.client_secret = env.OAUTH_CLIENT_SECRET
     }
 
-    const rawToken = yield* exchangeToken(env.IDP_BASE_URL, bodyParams).pipe(Effect.orElseSucceed(() => null))
-    if (Predicate.isNullish(rawToken)) {
-      return new Response('auth failed', { status: 401 })
+    const rawTokenResult = yield* exchangeToken(env.IDP_BASE_URL, bodyParams).pipe(
+      Effect.orElseSucceed(() => ({ data: null, error: 'token exchange failed' })),
+    )
+    if (Predicate.isNullish(rawTokenResult.data)) {
+      return new Response(`auth failed: ${rawTokenResult.error}`, { status: 401 })
     }
+    const rawToken = rawTokenResult.data
     const result = yield* decodeTokenResponse(rawToken).pipe(Effect.orElseSucceed(() => null))
 
     if (Predicate.isNullish(result)) {
@@ -108,7 +111,11 @@ export const handleAuthCallback = (
       }
     }
 
-    setCookie(ctx, FEED_SESSION_COOKIE, result.access_token, { httpOnly: true, path: '/', sameSite: 'Lax' })
+    setCookie(ctx, FEED_SESSION_COOKIE, result.id_token ?? result.access_token, {
+      httpOnly: true,
+      path: '/',
+      sameSite: 'Lax',
+    })
     deleteCookie(ctx, 'pkce_verifier', { httpOnly: true, path: '/', sameSite: 'Lax' })
     deleteCookie(ctx, 'oauth_state', { httpOnly: true, path: '/', sameSite: 'Lax' })
 

--- a/js/app/feed-platform-web/app/feature/auth/callback.ts
+++ b/js/app/feed-platform-web/app/feature/auth/callback.ts
@@ -1,10 +1,11 @@
-import { Effect, Predicate, Schema, String } from 'effect'
+import { DateTime, Effect, Predicate, Schema, String } from 'effect'
 import { HttpBody, HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import type { Context } from 'hono'
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 
-import { FEED_REFRESH_COOKIE, FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
+import { FEED_SESSION_COOKIE } from '#@/feature/auth/constants.ts'
 import { verifyAndDeleteNonce } from '#@/feature/auth/nonce-store.ts'
+import { storeRefreshToken } from '#@/feature/auth/refresh-store.ts'
 import type { Instance as DBInstance } from '#@/feature/db/kysely.ts'
 import type * as Env from '#@/feature/env.ts'
 
@@ -84,6 +85,7 @@ export const handleAuthCallback = (
       code_verifier: verifier,
       grant_type: 'authorization_code',
       redirect_uri: redirectUri,
+      resource: env.BACKEND_RESOURCE,
     }
     if (String.isNonEmpty(env.OAUTH_CLIENT_SECRET)) {
       bodyParams.client_secret = env.OAUTH_CLIENT_SECRET
@@ -105,14 +107,20 @@ export const handleAuthCallback = (
       return new Response('auth failed', { status: 401 })
     }
 
-    if (!Predicate.isNullish(result.id_token) && Predicate.isNotNullish(state)) {
-      const valid = yield* verifyNonce(db, result.id_token, state)
+    const idToken = result.id_token
+    if (Predicate.isNullish(idToken) || String.isEmpty(idToken)) {
+      return new Response('auth failed', { status: 401 })
+    }
+
+    if (Predicate.isNotNullish(state)) {
+      const valid = yield* verifyNonce(db, idToken, state)
       if (!valid) {
         return new Response('nonce mismatch', { status: 403 })
       }
     }
 
-    setCookie(ctx, FEED_SESSION_COOKIE, result.id_token ?? result.access_token, {
+    const sessionToken = idToken
+    setCookie(ctx, FEED_SESSION_COOKIE, sessionToken, {
       httpOnly: true,
       path: '/',
       sameSite: 'Lax',
@@ -120,13 +128,10 @@ export const handleAuthCallback = (
     deleteCookie(ctx, 'pkce_verifier', { httpOnly: true, path: '/', sameSite: 'Lax' })
     deleteCookie(ctx, 'oauth_state', { httpOnly: true, path: '/', sameSite: 'Lax' })
 
-    if (!Predicate.isNullish(result.refresh_token) && String.isNonEmpty(result.refresh_token)) {
-      setCookie(ctx, FEED_REFRESH_COOKIE, result.refresh_token, {
-        httpOnly: true,
-        maxAge: 2_592_000,
-        path: '/',
-        sameSite: 'Lax',
-      })
+    const refreshToken = result.refresh_token
+    if (!Predicate.isNullish(refreshToken) && String.isNonEmpty(refreshToken)) {
+      const now = DateTime.toEpochMillis(yield* DateTime.now)
+      yield* Effect.promise(() => storeRefreshToken(db, sessionToken, refreshToken, result.access_token, now))
     }
 
     return ctx.redirect('/dashboard')

--- a/js/app/feed-platform-web/app/feature/auth/callback.ts
+++ b/js/app/feed-platform-web/app/feature/auth/callback.ts
@@ -1,4 +1,5 @@
 import { Effect, Predicate, Schema, String } from 'effect'
+import { HttpBody, HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import type { Context } from 'hono'
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 
@@ -24,21 +25,17 @@ const decodeIdTokenPayload = Schema.decodeUnknownEffect(IdTokenPayload)
 
 const exchangeToken = (idpBaseUrl: string, params: Record<string, string>) =>
   Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient
     const formBody = new URLSearchParams(params).toString()
-    /* oxlint-disable rules/no-fetch -- Token exchange runs in a Worker request handler where native fetch is the platform boundary. */
-    const response = yield* Effect.promise(() =>
-      fetch(`${idpBaseUrl}/api/v1/auth/oauth2/token`, {
-        body: formBody,
-        headers: { 'content-type': 'application/x-www-form-urlencoded' },
-        method: 'POST',
-      }),
-    )
-    /* oxlint-enable rules/no-fetch */
+    const request = HttpClientRequest.post(`${idpBaseUrl}/api/v1/auth/oauth2/token`, {
+      body: HttpBody.text(formBody, 'application/x-www-form-urlencoded'),
+    })
+    const response = yield* client.execute(request)
     if (response.status !== 200) {
-      const text = yield* Effect.promise(() => response.text())
+      const text = yield* response.text
       return { data: null, error: String.isNonEmpty(text) ? text : 'token exchange failed' }
     }
-    const data: unknown = yield* Effect.promise(() => response.json())
+    const data: unknown = yield* response.json
     return { data, error: null }
   })
 
@@ -61,7 +58,11 @@ const verifyNonce = (db: DBInstance, idToken: string, state: string) =>
     return yield* Effect.promise(() => verifyAndDeleteNonce(db, state, decodedPayload.nonce))
   })
 
-export const handleAuthCallback = (ctx: Context, env: Env.Type, db: DBInstance): Effect.Effect<Response> =>
+export const handleAuthCallback = (
+  ctx: Context,
+  env: Env.Type,
+  db: DBInstance,
+): Effect.Effect<Response, never, HttpClient.HttpClient> =>
   Effect.gen(function* () {
     const code = ctx.req.query('code')
     const state = ctx.req.query('state')

--- a/js/app/feed-platform-web/app/feature/auth/constants.ts
+++ b/js/app/feed-platform-web/app/feature/auth/constants.ts
@@ -1,7 +1,5 @@
 export const FEED_SESSION_COOKIE = 'feed-session'
 
-export const FEED_REFRESH_COOKIE = 'feed-refresh'
-
 export const OAUTH_BASE_PATH = '/api/v1/auth/oauth'
 
 export const OAUTH_CLIENT_ID = 'feed-platform-web'

--- a/js/app/feed-platform-web/app/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-web/app/feature/auth/middleware.test.ts
@@ -14,7 +14,7 @@ vi.mock('jose', () => ({
 const { authMiddleware } = await import('./middleware.ts')
 
 const makeApp = () =>
-  new Hono<{ Variables: { user: { id: string; email: string } | null } }>()
+  new Hono<{ Variables: { user: { email: string; sub: string } | null } }>()
     .use('*', runtimeMiddleware)
     .use('*', authMiddleware)
     .get('/test', (ctx) => ctx.json({ user: ctx.var.user }))
@@ -38,7 +38,7 @@ describe('authMiddleware', () => {
     const app = makeApp()
     const res = await app.request('/test', { headers: { cookie: `${FEED_SESSION_COOKIE}=valid.jwt.token` } })
     expect(res.status).toBe(200)
-    expect(await res.json()).toStrictEqual({ user: { email: 'test@example.com', id: 'user-123' } })
+    expect(await res.json()).toStrictEqual({ user: { email: 'test@example.com', sub: 'user-123' } })
   })
 
   it('sets user to null when JWT payload shape is invalid', async () => {

--- a/js/app/feed-platform-web/app/feature/auth/middleware.ts
+++ b/js/app/feed-platform-web/app/feature/auth/middleware.ts
@@ -1,5 +1,5 @@
 import type { AppJWTPayload } from 'auth-helper'
-import { Effect, Predicate, Result, Schema } from 'effect'
+import { Effect, Predicate, Schema } from 'effect'
 import { getCookie } from 'hono/cookie'
 import { createRemoteJWKSet, jwtVerify } from 'jose'
 
@@ -28,21 +28,20 @@ export const authMiddleware = factory.createMiddleware((ctx, next) =>
 
       const env = yield* AppEnv.Service
       const jwks = createRemoteJWKSet(new URL(`${env.IDP_BASE_URL}/api/v1/auth/jwks`))
-      const verified = yield* Effect.result(Effect.tryPromise(() => jwtVerify<AppJWTPayload>(token, jwks)))
-      if (Result.isFailure(verified)) {
-        console.warn('[auth] JWT verification failed:', String(verified.failure))
-        ctx.set('user', null)
-        yield* Effect.promise(() => next())
-        return
-      }
-
-      const decodedPayload = yield* Effect.result(decodeAuthUserPayload(verified.success.payload))
-      if (Result.isFailure(decodedPayload)) {
-        ctx.set('user', null)
-      } else {
-        const { email, sub } = decodedPayload.success
-        ctx.set('user', { email, id: sub })
-      }
+      const decodedPayload = yield* Effect.tryPromise({
+        catch: (cause) => new Error(String(cause)),
+        try: () => jwtVerify<AppJWTPayload>(token, jwks),
+      }).pipe(
+        Effect.flatMap(({ payload }) => decodeAuthUserPayload(payload)),
+        Effect.match({
+          onFailure: (failure) => {
+            console.warn('[auth] JWT verification failed:', String(failure))
+            return null
+          },
+          onSuccess: (payload) => payload,
+        }),
+      )
+      ctx.set('user', decodedPayload)
 
       yield* Effect.promise(() => next())
     }),

--- a/js/app/feed-platform-web/app/feature/auth/refresh-store.ts
+++ b/js/app/feed-platform-web/app/feature/auth/refresh-store.ts
@@ -1,0 +1,69 @@
+import { Predicate } from 'effect'
+
+import type { Instance } from '#@/feature/db/kysely.ts'
+
+const REFRESH_SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+export const deleteRefreshToken = async (db: Instance, sessionToken: string): Promise<void> => {
+  await db.deleteFrom('oauthRefreshSession').where('sessionToken', '=', sessionToken).execute()
+}
+
+export const getRefreshToken = async (db: Instance, sessionToken: string, now: number): Promise<string | null> => {
+  const row = await db
+    .selectFrom('oauthRefreshSession')
+    .select(['expiresAt', 'refreshToken'])
+    .where('sessionToken', '=', sessionToken)
+    .executeTakeFirst()
+  if (Predicate.isNullish(row)) {
+    return null
+  }
+  if (row.expiresAt < now) {
+    await deleteRefreshToken(db, sessionToken)
+    return null
+  }
+  return row.refreshToken
+}
+
+export const getAccessToken = async (db: Instance, sessionToken: string, now: number): Promise<string | null> => {
+  const row = await db
+    .selectFrom('oauthRefreshSession')
+    .select(['accessToken', 'expiresAt'])
+    .where('sessionToken', '=', sessionToken)
+    .executeTakeFirst()
+  if (Predicate.isNullish(row)) {
+    return null
+  }
+  if (row.expiresAt < now) {
+    await deleteRefreshToken(db, sessionToken)
+    return null
+  }
+  return row.accessToken
+}
+
+export const storeRefreshToken = async (
+  db: Instance,
+  sessionToken: string,
+  refreshToken: string,
+  accessToken: string,
+  now: number,
+): Promise<void> => {
+  await db
+    .insertInto('oauthRefreshSession')
+    .values({ accessToken, expiresAt: now + REFRESH_SESSION_TTL_MS, refreshToken, sessionToken })
+    .onConflict((oc) =>
+      oc.column('sessionToken').doUpdateSet({ accessToken, expiresAt: now + REFRESH_SESSION_TTL_MS, refreshToken }),
+    )
+    .execute()
+}
+
+export const replaceRefreshToken = async (
+  db: Instance,
+  previousSessionToken: string,
+  nextSessionToken: string,
+  refreshToken: string,
+  accessToken: string,
+  now: number,
+): Promise<void> => {
+  await db.deleteFrom('oauthRefreshSession').where('sessionToken', '=', previousSessionToken).execute()
+  await storeRefreshToken(db, nextSessionToken, refreshToken, accessToken, now)
+}

--- a/js/app/feed-platform-web/app/feature/env.ts
+++ b/js/app/feed-platform-web/app/feature/env.ts
@@ -34,5 +34,5 @@ export const devLayer = Layer.succeed(Service, {
   DATABASE_URL: 'http://127.0.0.1:8081',
   IDP_BASE_URL: 'http://localhost:8787',
   OAUTH_CLIENT_ID: 'feed-platform-web',
-  OAUTH_CLIENT_SECRET: 'dev-secret-pkce-not-used',
+  OAUTH_CLIENT_SECRET: 'dev-secret-do-not-use-in-prod',
 } satisfies Type as Type)

--- a/js/app/feed-platform-web/app/feature/env.ts
+++ b/js/app/feed-platform-web/app/feature/env.ts
@@ -4,6 +4,7 @@ import * as HonoContext from '#@/feature/share/lib/hono/context.ts'
 
 export interface Backend {
   BACKEND_BASE_URL: string
+  BACKEND_RESOURCE: string
 }
 
 export interface Database {
@@ -30,6 +31,7 @@ export const prodLayer = Layer.sync(Service, () => HonoContext.get().env)
 
 export const devLayer = Layer.succeed(Service, {
   BACKEND_BASE_URL: 'http://localhost:8788',
+  BACKEND_RESOURCE: 'feed-platform-backend',
   DATABASE_AUTH_TOKEN: '',
   DATABASE_URL: 'http://127.0.0.1:8081',
   IDP_BASE_URL: 'http://localhost:8787',

--- a/js/app/feed-platform-web/app/feature/runtime/hono.ts
+++ b/js/app/feed-platform-web/app/feature/runtime/hono.ts
@@ -8,8 +8,8 @@ export interface Variables {
 }
 
 export interface AuthUser {
-  readonly id: string
   readonly email: string
+  readonly sub: string
 }
 
 export const middleware = factory.createMiddleware(async (ctx, next) => {

--- a/js/app/feed-platform-web/db/schema.hcl
+++ b/js/app/feed-platform-web/db/schema.hcl
@@ -21,3 +21,28 @@ table "oauth_nonce" {
     columns = [column.state]
   }
 }
+
+table "oauth_refresh_session" {
+  schema = schema.main
+
+  column "session_token" {
+    type = text
+    null = false
+  }
+  column "refresh_token" {
+    type = text
+    null = false
+  }
+  column "access_token" {
+    type = text
+    null = false
+  }
+  column "expires_at" {
+    type = integer
+    null = false
+  }
+
+  primary_key {
+    columns = [column.session_token]
+  }
+}

--- a/js/app/identity-provider/AGENTS.md
+++ b/js/app/identity-provider/AGENTS.md
@@ -1,0 +1,20 @@
+# identity-provider
+
+## Project documentation
+
+- Auth flow, OAuth/OIDC compliance, and security hardening notes:
+  `docs/auth-flow.md`
+
+Use that document as the source of truth when changing IdP login, consent,
+OAuth token issuance, OIDC ID token/JWKS behavior, or local feed-platform auth
+integration.
+
+## Auth integration notes
+
+- The feed example in `docs/auth-flow.md` covers `feed-platform-web` as the
+  OAuth client and `feed-platform-backend` as the JWT-protected BFF.
+- Keep Better Auth OAuth model mappings in `app/feature/auth/better-auth.ts`
+  aligned with `db/schema.hcl`.
+- Local seeded client secrets are development-only. Do not copy the raw-secret
+  `storeClientSecret` behavior into production configuration without the
+  remediation described in `docs/auth-flow.md`.

--- a/js/app/identity-provider/README.md
+++ b/js/app/identity-provider/README.md
@@ -1,0 +1,17 @@
+# identity-provider
+
+`identity-provider` is the local Identity Provider for the feed platform. It
+provides Magic Link, Passkey, OAuth 2.0, and OpenID Connect flows through Better
+Auth.
+
+## Documentation
+
+- [Authentication flow and OAuth/OIDC status](docs/auth-flow.md)
+
+The linked document uses `feed-platform-web` and `feed-platform-backend` as the
+worked example for local authorization-code login, token exchange, backend JWT
+verification, and known security/compliance gaps.
+
+## Development
+
+Developer and agent-facing project notes live in [AGENTS.md](AGENTS.md).

--- a/js/app/identity-provider/app/app.tsx
+++ b/js/app/identity-provider/app/app.tsx
@@ -1,6 +1,7 @@
-import { Predicate } from 'effect'
+import { Predicate, String } from 'effect'
 import { remixRenderer } from 'hono-remix-middleware'
 import { contextStorage } from 'hono/context-storage'
+import { deleteCookie, getCookie } from 'hono/cookie'
 import { logger } from 'hono/logger'
 
 import { authMiddleware } from '#@/feature/auth/middleware.ts'
@@ -17,6 +18,27 @@ import { getSafeReturnTo } from '#@/ui/return-to.ts'
 
 const api = factory.createApp().all('/auth/*', (ctx) => ctx.var.auth.handler(ctx.req.raw))
 
+const LOGIN_RETURN_TO_COOKIE = 'login_return_to'
+
+const getStoredLoginReturnTo = (value: string | undefined): string | undefined => {
+  if (Predicate.isNullish(value)) {
+    return undefined
+  }
+  return getSafeReturnTo(decodeURIComponent(value))
+}
+
+const getLoginReturnTo = (url: string, rawReturnTo: string | undefined): string | undefined => {
+  const safeReturnTo = getSafeReturnTo(rawReturnTo)
+  if (Predicate.isNotNullish(safeReturnTo) && String.isNonEmpty(safeReturnTo)) {
+    return safeReturnTo
+  }
+  const parsedUrl = new URL(url)
+  if (parsedUrl.searchParams.has('client_id') && parsedUrl.searchParams.has('redirect_uri')) {
+    return `/api/v1/auth/oauth2/authorize${parsedUrl.search}`
+  }
+  return undefined
+}
+
 const appRoutes = factory
   .createApp()
   .get('/', (ctx) =>
@@ -27,8 +49,10 @@ const appRoutes = factory
     ),
   )
   .get('/login', (ctx) => {
-    const returnTo = ctx.req.query('return_to')
-    const safeReturnTo = getSafeReturnTo(returnTo)
+    const safeReturnTo = getLoginReturnTo(ctx.req.url, ctx.req.query('return_to'))
+    if (Predicate.isNullish(safeReturnTo) || String.isEmpty(safeReturnTo)) {
+      deleteCookie(ctx, LOGIN_RETURN_TO_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
+    }
     return ctx.render(
       <Document title='ログイン'>
         <LoginPage returnTo={safeReturnTo} />
@@ -59,16 +83,20 @@ const appRoutes = factory
     if (!session) {
       return ctx.redirect('/app/login?error=invalid_link')
     }
-    const returnTo = ctx.req.query('return_to')
-    return ctx.redirect(getSafeReturnTo(returnTo) ?? '/app/account')
+    const returnTo =
+      getSafeReturnTo(ctx.req.query('return_to')) ?? getStoredLoginReturnTo(getCookie(ctx, LOGIN_RETURN_TO_COOKIE))
+    deleteCookie(ctx, LOGIN_RETURN_TO_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
+    return ctx.redirect(returnTo ?? '/app/account')
   })
   .get('/auth/passkey/callback', async (ctx) => {
     const session = await ctx.var.auth.api.getSession({ headers: ctx.req.raw.headers })
     if (!session) {
       return ctx.redirect('/app/login')
     }
-    const returnTo = ctx.req.query('return_to')
-    return ctx.redirect(getSafeReturnTo(returnTo) ?? '/app/account')
+    const returnTo =
+      getSafeReturnTo(ctx.req.query('return_to')) ?? getStoredLoginReturnTo(getCookie(ctx, LOGIN_RETURN_TO_COOKIE))
+    deleteCookie(ctx, LOGIN_RETURN_TO_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
+    return ctx.redirect(returnTo ?? '/app/account')
   })
   .get('/register/passkey', async (ctx) => {
     const session = await ctx.var.auth.api.getSession({ headers: ctx.req.raw.headers })

--- a/js/app/identity-provider/app/feature/auth/better-auth.ts
+++ b/js/app/identity-provider/app/feature/auth/better-auth.ts
@@ -2,7 +2,7 @@ import { oauthProvider } from '@better-auth/oauth-provider'
 import { passkey } from '@better-auth/passkey'
 import { betterAuth } from 'better-auth'
 import { jwt, magicLink } from 'better-auth/plugins'
-import { Context, Effect, Layer } from 'effect'
+import { Context, Effect, Layer, Predicate } from 'effect'
 
 import * as DB from '#@/feature/db/kysely.ts'
 import * as EmailSender from '#@/feature/email/sender.ts'
@@ -41,6 +41,10 @@ const makeInstance = (db: DB.Instance, env: Env.Type, emailSender: EmailSender.E
       }),
       oauthProvider({
         consentPage: '/app/oauth/consent',
+        customAccessTokenClaims: ({ user }) => ({
+          ...(Predicate.isString(user?.email) ? { email: user.email } : {}),
+          token_use: 'access',
+        }),
         idTokenExpiresIn: 3600,
         loginPage: '/app/login',
         refreshTokenExpiresIn: 2_592_000,

--- a/js/app/identity-provider/app/feature/auth/better-auth.ts
+++ b/js/app/identity-provider/app/feature/auth/better-auth.ts
@@ -40,7 +40,6 @@ const makeInstance = (db: DB.Instance, env: Env.Type, emailSender: EmailSender.E
           ),
       }),
       oauthProvider({
-        cachedTrustedClients: new Set(['feed-platform-web']),
         consentPage: '/app/oauth/consent',
         idTokenExpiresIn: 3600,
         loginPage: '/app/login',
@@ -49,6 +48,7 @@ const makeInstance = (db: DB.Instance, env: Env.Type, emailSender: EmailSender.E
           oauthAccessToken: {
             fields: {
               scopes: 'scope',
+              token: 'access_token',
             },
             modelName: 'oauth_access_token',
           },
@@ -61,8 +61,18 @@ const makeInstance = (db: DB.Instance, env: Env.Type, emailSender: EmailSender.E
             },
             modelName: 'oauth_consent',
           },
+          oauthRefreshToken: {
+            fields: {
+              scopes: 'scope',
+            },
+            modelName: 'oauth_refresh_token',
+          },
         },
         scopes: ['openid', 'profile', 'email', 'offline_access'],
+        storeClientSecret: {
+          hash: (clientSecret) => Promise.resolve(clientSecret),
+          verify: (clientSecret, storedHash) => Promise.resolve(clientSecret === storedHash),
+        },
         validAudiences: env.OAUTH_VALID_AUDIENCES.split(','),
       }),
       jwt({

--- a/js/app/identity-provider/app/feature/env.ts
+++ b/js/app/identity-provider/app/feature/env.ts
@@ -35,6 +35,6 @@ export const devLayer = Layer.succeed(Service, {
   DATABASE_AUTH_TOKEN: '',
   DATABASE_URL: 'http://127.0.0.1:8080',
   MAIL_FROM_ADDRESS: 'auth@dev.example.com',
-  OAUTH_VALID_AUDIENCES: 'feed-platform-web,http://127.0.0.1:8789',
+  OAUTH_VALID_AUDIENCES: 'feed-platform-web,feed-platform-backend,http://127.0.0.1:8789',
   PASSKEY_RP_ID: 'localhost',
 } satisfies Type as Type)

--- a/js/app/identity-provider/app/ui/account.client.tsx
+++ b/js/app/identity-provider/app/ui/account.client.tsx
@@ -1,5 +1,5 @@
 import { Effect, String } from 'effect'
-import { FetchHttpClient, HttpClient, HttpClientRequest } from 'effect/unstable/http'
+import { FetchHttpClient, HttpBody, HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import { clientEntry, on } from 'remix/ui'
 import type { Handle, SerializableProps } from 'remix/ui'
 import { Button } from 'remix/ui/button'
@@ -23,7 +23,9 @@ export const LogoutButton = clientEntry(
                 })
 
                 const client = yield* HttpClient.HttpClient
-                const response = yield* client.execute(HttpClientRequest.post('/api/v1/auth/sign-out'))
+                const response = yield* client.execute(
+                  HttpClientRequest.post('/api/v1/auth/sign-out', { body: HttpBody.jsonUnsafe({}) }),
+                )
                 if (response.status !== 200) {
                   return yield* Effect.fail(new Error('ログアウトに失敗しました'))
                 }

--- a/js/app/identity-provider/app/ui/account.client.tsx
+++ b/js/app/identity-provider/app/ui/account.client.tsx
@@ -33,7 +33,6 @@ export const LogoutButton = clientEntry(
                 window.location.href = '/app/login'
                 return yield* Effect.void
               }).pipe(
-                // oxlint-disable-next-line promise/prefer-await-to-then -- This is Effect.catch, not Promise.catch.
                 Effect.catch(() =>
                   Effect.sync(() => {
                     state.error = 'ログアウトに失敗しました'

--- a/js/app/identity-provider/app/ui/login-passkey.client.tsx
+++ b/js/app/identity-provider/app/ui/login-passkey.client.tsx
@@ -96,7 +96,6 @@ export const PasskeyLoginButton = clientEntry(
                 window.location.href = withReturnTo('/app/auth/passkey/callback', handle.props.returnTo)
                 return yield* Effect.void
               }).pipe(
-                // oxlint-disable-next-line promise/prefer-await-to-then -- This is Effect.catch, not Promise.catch.
                 Effect.catch(() =>
                   Effect.sync(() => {
                     state.error = 'Passkey 認証に失敗しました'

--- a/js/app/identity-provider/app/ui/login.client.tsx
+++ b/js/app/identity-provider/app/ui/login.client.tsx
@@ -76,7 +76,6 @@ export const MagicLinkForm = clientEntry(
                 window.location.href = `/app/login/check-email?${params.toString()}`
                 return yield* Effect.void
               }).pipe(
-                // oxlint-disable-next-line promise/prefer-await-to-then -- This is Effect.catch, not Promise.catch.
                 Effect.catch(() =>
                   Effect.sync(() => {
                     state.error = 'マジックリンクの送信に失敗しました'

--- a/js/app/identity-provider/app/ui/login.client.tsx
+++ b/js/app/identity-provider/app/ui/login.client.tsx
@@ -4,8 +4,6 @@ import { clientEntry, css, on } from 'remix/ui'
 import type { Handle, SerializableProps } from 'remix/ui'
 import { Button } from 'remix/ui/button'
 
-import { withReturnTo } from '#@/ui/return-to.ts'
-
 const formStyle = css({
   display: 'flex',
   flexDirection: 'column',
@@ -46,15 +44,26 @@ export const MagicLinkForm = clientEntry(
                 state.submitting = true
                 void handle.update()
 
-                const callbackURL = withReturnTo('/app/auth/magic-link/callback', handle.props.returnTo)
+                const { returnTo } = handle.props
+                if (Predicate.isNotNullish(returnTo) && String.isNonEmpty(returnTo)) {
+                  yield* Effect.promise(() =>
+                    cookieStore.set({
+                      name: 'login_return_to',
+                      path: '/',
+                      sameSite: 'lax',
+                      value: encodeURIComponent(returnTo),
+                    }),
+                  )
+                }
+
                 const params = new URLSearchParams({ email })
-                if (Predicate.isNotNullish(handle.props.returnTo)) {
-                  params.set('return_to', handle.props.returnTo)
+                if (Predicate.isNotNullish(returnTo)) {
+                  params.set('return_to', returnTo)
                 }
 
                 const client = yield* HttpClient.HttpClient
                 const request = HttpClientRequest.post('/api/v1/auth/sign-in/magic-link', {
-                  body: HttpBody.jsonUnsafe({ callbackURL, email }),
+                  body: HttpBody.jsonUnsafe({ callbackURL: '/app/auth/magic-link/callback', email }),
                 })
                 const response = yield* client.execute(request)
                 if (response.status < 200 || response.status >= 300) {

--- a/js/app/identity-provider/app/ui/oauth-consent.client.tsx
+++ b/js/app/identity-provider/app/ui/oauth-consent.client.tsx
@@ -1,0 +1,89 @@
+import { Effect, Schema, String } from 'effect'
+import { FetchHttpClient, HttpBody, HttpClient, HttpClientRequest } from 'effect/unstable/http'
+import { clientEntry, css, on } from 'remix/ui'
+import type { Handle, SerializableProps } from 'remix/ui'
+import { Button } from 'remix/ui/button'
+
+const formStyle = css({
+  display: 'flex',
+  gap: '12px',
+})
+
+const ConsentResponse = Schema.Struct({ redirect: Schema.Literal(true), url: Schema.NonEmptyString })
+
+// oxlint-disable-next-line rules/prefer-non-unknown-decode -- OAuth consent response JSON is an external API boundary.
+const decodeConsentResponse = Schema.decodeUnknownEffect(ConsentResponse)
+
+export const OAuthConsentForm = clientEntry(
+  '/assets/app/ui/oauth-consent.client.tsx#OAuthConsentForm',
+  (handle: Handle<SerializableProps>) => {
+    const state = { error: '', submitting: false }
+
+    const submitConsent = (accept: boolean) =>
+      Effect.gen(function* () {
+        state.error = ''
+        state.submitting = true
+        void handle.update()
+
+        const oauthQuery = window.location.search.slice(1)
+        const client = yield* HttpClient.HttpClient
+        const response = yield* client.execute(
+          HttpClientRequest.post('/api/v1/auth/oauth2/consent', {
+            body: HttpBody.jsonUnsafe({ accept, oauth_query: oauthQuery }),
+          }),
+        )
+        if (response.status < 200 || response.status >= 300) {
+          const text = yield* response.text
+          return yield* Effect.fail(new Error(String.isNonEmpty(text) ? text : 'OAuth 認可に失敗しました'))
+        }
+
+        const result = yield* decodeConsentResponse(yield* response.json)
+        window.location.href = result.url
+        return yield* Effect.void
+      }).pipe(
+        // oxlint-disable-next-line promise/prefer-await-to-then -- This is Effect.catch, not Promise.catch.
+        Effect.catch(() =>
+          Effect.sync(() => {
+            state.error = 'OAuth 認可に失敗しました'
+            state.submitting = false
+            void handle.update()
+          }),
+        ),
+        Effect.provide(FetchHttpClient.layer),
+      )
+
+    return () => (
+      <form method='POST' mix={formStyle}>
+        <Button
+          type='submit'
+          name='action'
+          value='allow'
+          tone='primary'
+          disabled={state.submitting}
+          mix={on('click', (event) => {
+            event.preventDefault()
+            // oxlint-disable-next-line rules/no-effect-runtime-run -- Client event boundary executes one OAuth consent workflow Effect.
+            void Effect.runPromise(submitConsent(true))
+          })}
+        >
+          {state.submitting ? '処理中...' : '許可'}
+        </Button>
+        <Button
+          type='submit'
+          name='action'
+          value='deny'
+          tone='ghost'
+          disabled={state.submitting}
+          mix={on('click', (event) => {
+            event.preventDefault()
+            // oxlint-disable-next-line rules/no-effect-runtime-run -- Client event boundary executes one OAuth consent workflow Effect.
+            void Effect.runPromise(submitConsent(false))
+          })}
+        >
+          拒否
+        </Button>
+        {String.isNonEmpty(state.error) ? <p role='alert'>{state.error}</p> : null}
+      </form>
+    )
+  },
+)

--- a/js/app/identity-provider/app/ui/oauth-consent.client.tsx
+++ b/js/app/identity-provider/app/ui/oauth-consent.client.tsx
@@ -41,7 +41,6 @@ export const OAuthConsentForm = clientEntry(
         window.location.href = result.url
         return yield* Effect.void
       }).pipe(
-        // oxlint-disable-next-line promise/prefer-await-to-then -- This is Effect.catch, not Promise.catch.
         Effect.catch(() =>
           Effect.sync(() => {
             state.error = 'OAuth 認可に失敗しました'

--- a/js/app/identity-provider/app/ui/oauth-consent.tsx
+++ b/js/app/identity-provider/app/ui/oauth-consent.tsx
@@ -1,16 +1,12 @@
 import { css } from 'remix/ui'
 import type { Handle } from 'remix/ui'
-import { Button } from 'remix/ui/button'
+
+import { OAuthConsentForm } from '#@/ui/oauth-consent.client.tsx'
 
 const containerStyle = css({
   margin: '40px auto',
   maxWidth: '480px',
   padding: '0 16px',
-})
-
-const formStyle = css({
-  display: 'flex',
-  gap: '12px',
 })
 
 interface ConsentPageProps {
@@ -32,17 +28,7 @@ export const OAuthConsentPage = (handle: Handle<ConsentPageProps>) => () => (
       ))}
     </ul>
     <p>リダイレクト先: {handle.props.redirectUri}</p>
-    <form action='/api/v1/auth/oauth2/confirm-consent' method='POST' mix={formStyle}>
-      <input type='hidden' name='clientId' value={handle.props.clientId} />
-      <input type='hidden' name='redirectUri' value={handle.props.redirectUri} />
-      <input type='hidden' name='state' value={handle.props.state} />
-      <Button type='submit' name='action' value='allow' tone='primary'>
-        許可
-      </Button>
-      <Button type='submit' name='action' value='deny' tone='ghost'>
-        拒否
-      </Button>
-    </form>
+    <OAuthConsentForm />
   </main>
 )
 

--- a/js/app/identity-provider/app/ui/register-passkey.client.tsx
+++ b/js/app/identity-provider/app/ui/register-passkey.client.tsx
@@ -122,7 +122,6 @@ export const PasskeyRegisterButton = clientEntry(
                 window.location.href = withReturnTo('/app/auth/passkey/callback', handle.props.returnTo)
                 return yield* Effect.void
               }).pipe(
-                // oxlint-disable-next-line promise/prefer-await-to-then -- This is Effect.catch, not Promise.catch.
                 Effect.catch(() =>
                   Effect.sync(() => {
                     state.error = 'Passkey 登録に失敗しました'

--- a/js/app/identity-provider/db/schema.hcl
+++ b/js/app/identity-provider/db/schema.hcl
@@ -339,11 +339,23 @@ table "oauth_access_token" {
     type = text
     null = false
   }
+  column "session_id" {
+    type = text
+    null = true
+  }
   column "user_id" {
     type = text
     null = false
   }
   column "scope" {
+    type = text
+    null = true
+  }
+  column "reference_id" {
+    type = text
+    null = true
+  }
+  column "refresh_id" {
     type = text
     null = true
   }
@@ -357,7 +369,7 @@ table "oauth_access_token" {
   }
   column "updated_at" {
     type = text
-    null = false
+    null = true
   }
 
   primary_key {
@@ -365,6 +377,71 @@ table "oauth_access_token" {
   }
 
   foreign_key "oauth_access_token_user_id_fk" {
+    columns     = [column.user_id]
+    ref_columns = [table.user.column.id]
+    on_delete   = CASCADE
+  }
+}
+
+table "oauth_refresh_token" {
+  schema = schema.main
+
+  column "id" {
+    type = text
+    null = false
+  }
+  column "token" {
+    type = text
+    null = false
+  }
+  column "client_id" {
+    type = text
+    null = false
+  }
+  column "session_id" {
+    type = text
+    null = true
+  }
+  column "user_id" {
+    type = text
+    null = false
+  }
+  column "reference_id" {
+    type = text
+    null = true
+  }
+  column "expires_at" {
+    type = text
+    null = false
+  }
+  column "created_at" {
+    type = text
+    null = false
+  }
+  column "revoked" {
+    type = text
+    null = true
+  }
+  column "auth_time" {
+    type = text
+    null = true
+  }
+  column "scope" {
+    type = text
+    null = false
+  }
+
+  primary_key {
+    columns = [column.id]
+  }
+
+  foreign_key "oauth_refresh_token_session_id_fk" {
+    columns     = [column.session_id]
+    ref_columns = [table.session.column.id]
+    on_delete   = SET_NULL
+  }
+
+  foreign_key "oauth_refresh_token_user_id_fk" {
     columns     = [column.user_id]
     ref_columns = [table.user.column.id]
     on_delete   = CASCADE

--- a/js/app/identity-provider/docs/auth-flow.md
+++ b/js/app/identity-provider/docs/auth-flow.md
@@ -1,0 +1,462 @@
+# Authentication Flow
+
+This document describes the Identity Provider authentication flow and uses
+`feed-platform-web` plus `feed-platform-backend` as the concrete relying-party
+example. It also records the OAuth 2.0, OpenID Connect, and security
+best-practice status of the current implementation.
+
+## Scope
+
+The Identity Provider is implemented with Better Auth and exposes its auth API
+under `/api/v1/auth`. It currently provides:
+
+- Magic Link login.
+- Passkey login and registration.
+- OAuth 2.0 Authorization Code flow for `feed-platform-web`.
+- OIDC ID tokens signed by the Better Auth JWT/JWKS plugin.
+- Refresh tokens for the `offline_access` scope.
+
+The feed example consists of:
+
+- `identity-provider` on `http://localhost:8787` for Better Auth endpoints and
+  IdP UI pages.
+- `feed-platform-web` on `http://127.0.0.1:8789` as the OAuth client and browser
+  app.
+- `feed-platform-backend` on `http://127.0.0.1:8788` as the BFF API protected by
+  IdP-issued JWTs.
+
+## Local feed OAuth flow
+
+### 1. Login starts in feed-platform-web
+
+`GET /login` in `feed-platform-web` generates:
+
+- `state`, stored in the `oauth_state` HTTP-only cookie.
+- PKCE `code_verifier`, stored in the `pkce_verifier` HTTP-only cookie.
+- `nonce`, stored in the feed web database and later checked against the ID
+  token.
+- PKCE `code_challenge` using S256.
+
+The browser is redirected to:
+
+```text
+http://localhost:8787/api/v1/auth/oauth2/authorize
+```
+
+with `response_type=code`, `client_id=feed-platform-web`,
+`redirect_uri=http://127.0.0.1:8789/auth/callback`, `scope=openid profile email
+offline_access`, `state`, `nonce`, `code_challenge`, and
+`code_challenge_method=S256`.
+
+### 2. Identity Provider login
+
+If the user is not signed in, Better Auth redirects to the configured login page:
+
+```text
+/app/login
+```
+
+The IdP login page recognizes OAuth authorization parameters in the current URL
+and converts them into a safe return target:
+
+```text
+/api/v1/auth/oauth2/authorize?...original OAuth query...
+```
+
+For Magic Link login, this return target is stored in a `login_return_to` cookie.
+This avoids passing a nested OAuth authorization URL through Better Auth's Magic
+Link `callbackURL` validation. After the Magic Link callback validates the IdP
+session, the IdP deletes `login_return_to` and redirects back to the original
+OAuth authorize request.
+
+### 3. Consent page
+
+Better Auth redirects to the configured consent page:
+
+```text
+/app/oauth/consent
+```
+
+The consent screen displays `client_id`, `scope`, and `redirect_uri`. The client
+entry `oauth-consent.client.tsx` submits the decision to:
+
+```text
+POST /api/v1/auth/oauth2/consent
+```
+
+with JSON:
+
+```json
+{
+  "accept": true,
+  "oauth_query": "...signed OAuth query from window.location.search..."
+}
+```
+
+Better Auth requires `oauth_query` so it can verify the signed authorization
+request and reconstruct provider state. When consent is accepted, Better Auth
+returns a JSON object containing `redirect: true` and the final callback URL.
+The browser is then sent to `feed-platform-web` with an authorization code.
+
+### 4. Authorization callback and token exchange
+
+`feed-platform-web` handles:
+
+```text
+GET /auth/callback
+```
+
+It validates that the returned `state` matches the `oauth_state` cookie, then
+exchanges the authorization code at:
+
+```text
+POST http://localhost:8787/api/v1/auth/oauth2/token
+```
+
+with form-encoded `grant_type=authorization_code`, `client_id`,
+`client_secret`, `code`, `code_verifier`, and `redirect_uri`.
+
+The token response is decoded as:
+
+- `access_token`: opaque Better Auth OAuth access token.
+- `id_token`: OIDC JWT when `openid` is requested.
+- `refresh_token`: opaque refresh token when `offline_access` is granted.
+
+`feed-platform-web` verifies the `nonce` claim in the ID token against its stored
+nonce. It stores the ID token, not the opaque access token, in the
+`feed-session` HTTP-only cookie because the feed web and backend middleware
+verify JWTs through the IdP JWKS endpoint. `feed-refresh` stores the refresh
+token.
+
+### 5. Dashboard and backend call
+
+`feed-platform-web` auth middleware verifies the `feed-session` signature against:
+
+```text
+http://localhost:8787/api/v1/auth/jwks
+```
+
+The current web middleware does not validate issuer or audience. The backend
+does validate those claims, so the backend is the stricter JWT enforcement point
+in the feed example.
+
+The dashboard calls `feed-platform-backend`:
+
+```text
+GET http://localhost:8788/api/v1/me
+Authorization: Bearer <feed-session ID token>
+```
+
+`feed-platform-backend` verifies:
+
+- `alg=ES256`.
+- `aud=feed-platform-web`.
+- `iss=http://localhost:8787/api/v1/auth`.
+- signature through `http://localhost:8787/api/v1/auth/jwks`.
+- required `sub` and `email` claims.
+
+The backend returns the JWT-derived user payload. `feed-platform-web` accepts
+either `{ id, email }` or `{ sub, email }` and renders the dashboard.
+
+### 6. Refresh
+
+If the backend call fails and `feed-refresh` exists, `feed-platform-web` attempts
+`grant_type=refresh_token` at the IdP token endpoint. The refreshed ID token is
+stored back in `feed-session` when present, otherwise the access token is used as
+a fallback.
+
+### 7. Logout
+
+`GET /logout` in `feed-platform-web` clears `feed-session` and `feed-refresh`.
+It also attempts to call Better Auth sign-out with an empty JSON body to satisfy
+the endpoint content-type contract.
+
+Current logout is a local best-effort operation. It is not a complete OIDC
+RP-Initiated Logout or OAuth token revocation flow.
+
+## OAuth 2.0 and OIDC compliance status
+
+The references used for this status are OAuth 2.0 Authorization Framework
+(RFC 6749), PKCE (RFC 7636), OAuth 2.0 Security Best Current Practice
+(RFC 9700), OAuth token revocation (RFC 7009), OAuth discovery metadata
+(RFC 8414), JSON Web Token (RFC 7519), JSON Web Key (RFC 7517), OpenID Connect
+Core 1.0, and the OWASP OAuth2 Cheat Sheet.
+
+### Implemented or mostly compliant
+
+| Area                      | Status                     | Evidence                                                                                  |
+| ------------------------- | -------------------------- | ----------------------------------------------------------------------------------------- |
+| Authorization Code flow   | Implemented                | Feed web uses `/oauth2/authorize`, receives `code`, and exchanges it at `/oauth2/token`.  |
+| PKCE                      | Implemented                | Feed web generates a verifier and S256 challenge; the callback sends `code_verifier`.     |
+| `state` CSRF binding      | Implemented                | Feed web stores `oauth_state` in an HTTP-only cookie and rejects callback state mismatch. |
+| OIDC `nonce`              | Implemented                | Feed web stores a nonce and verifies the ID token nonce before accepting the login.       |
+| Exact redirect URI        | Implemented for local feed | Seeded client redirect URI is `http://127.0.0.1:8789/auth/callback`.                      |
+| ID token signing and JWKS | Implemented                | IdP uses Better Auth `jwt` with ES256 and exposes `/api/v1/auth/jwks`.                    |
+| Audience validation       | Implemented                | Backend verifies `aud=feed-platform-web`; IdP has `validAudiences`.                       |
+| Issuer validation         | Implemented                | Backend verifies issuer `http://localhost:8787/api/v1/auth`.                              |
+| Refresh token table       | Implemented                | `oauth_refresh_token` table exists and maps `scopes` to `scope`.                          |
+| Consent endpoint          | Implemented                | Consent screen calls `/oauth2/consent` with Better Auth `oauth_query`.                    |
+
+### Non-compliant, incomplete, or local-only behavior
+
+#### Raw local client secret storage
+
+Current behavior:
+
+- `identity-provider` configures `storeClientSecret` with identity `hash` and
+  equality `verify`.
+- The local seed stores the raw dev secret.
+
+Why this is a problem:
+
+- OAuth clients with `client_secret` are confidential clients. A stored raw
+  secret increases blast radius if the IdP database is disclosed.
+- This is acceptable only as a deterministic local-development exception.
+
+Fix:
+
+- In production, remove the identity `storeClientSecret` override and store
+  Better Auth's default hashed secret value.
+- Alternatively use a custom KMS-backed encrypted storage strategy with
+  rotation.
+- Document the one-time migration that hashes existing stored client secrets.
+
+#### HTTP localhost origins
+
+Current behavior:
+
+- Local IdP runs on `http://localhost:8787`.
+- Feed web runs on `http://127.0.0.1:8789`.
+
+Why this is a problem:
+
+- OAuth/OIDC production deployments must use HTTPS. Plain HTTP is only suitable
+  for local loopback development.
+- `localhost` and `127.0.0.1` are not interchangeable in redirect validation,
+  cookie scoping, or issuer strings.
+
+Fix:
+
+- Production origins must be HTTPS and stable.
+- Keep redirect URIs exact and environment-specific.
+- Avoid mixing `localhost` and `127.0.0.1` except where the local topology
+  explicitly requires separate cookie scopes.
+
+#### Consent information is minimal
+
+Current behavior:
+
+- Consent shows `client_id`, requested scopes, and redirect URI.
+
+Why this is incomplete:
+
+- OIDC consent should be understandable to users. `client_id` alone is not a
+  friendly application identity.
+- Users are not told what each scope permits, how long access lasts, or whether
+  refresh/offline access is being granted.
+
+Fix:
+
+- Resolve and display registered client name, owner/contact, and client URI.
+- Explain each requested scope in product language.
+- Highlight `offline_access` separately because it grants refresh-token based
+  access.
+
+#### No persisted consent review or revocation UI
+
+Current behavior:
+
+- Consent can be recorded by Better Auth, but there is no user-facing page to
+  review or revoke existing grants.
+
+Why this is incomplete:
+
+- Security best practices expect users or administrators to revoke application
+  access without deleting the whole account.
+
+Fix:
+
+- Add an IdP account page section listing `oauth_consent`, access tokens, and
+  refresh tokens by client.
+- Provide a revoke action using token/consent deletion or Better Auth revoke
+  endpoints where applicable.
+
+#### Logout is not OIDC RP-Initiated Logout
+
+Current behavior:
+
+- Feed web clears its cookies and attempts Better Auth sign-out.
+- It does not perform standards-based RP-Initiated Logout.
+- It does not revoke the OAuth refresh token.
+
+Why this is incomplete:
+
+- Clearing local cookies does not necessarily invalidate server-side refresh
+  tokens or all relying-party sessions.
+
+Fix:
+
+- Implement token revocation for `feed-refresh` using RFC 7009-compatible revoke
+  behavior if the provider exposes it.
+- Add OIDC RP-Initiated Logout support when Better Auth configuration and client
+  metadata support `end_session_endpoint` and `post_logout_redirect_uri`.
+- Ensure logout does not send an ID token in a cookie named as an access-token
+  session to the wrong endpoint.
+
+#### Access token is opaque but feed uses ID token as session
+
+Current behavior:
+
+- Better Auth returns an opaque OAuth access token.
+- Feed web stores the ID token in `feed-session` because the BFF verifies JWTs.
+
+Why this is a design mismatch:
+
+- ID tokens are intended to authenticate the user to the client, while access
+  tokens authorize API access. Using an ID token as a bearer token for a backend
+  API conflates token purposes.
+
+Fix:
+
+- Prefer one of these designs:
+  1. Configure or issue JWT access tokens with an API audience and have the BFF
+     verify those access tokens.
+  2. Keep opaque access tokens and make the BFF call the IdP introspection
+     endpoint.
+  3. Treat feed web as a BFF session holder and have the backend trust only a
+     separate server-to-server session/token minted by feed web.
+- Do not use ID tokens as API bearer tokens in production.
+
+#### Feed web JWT validation is weaker than backend validation
+
+Current behavior:
+
+- `feed-platform-web` middleware verifies JWT signatures with the IdP JWKS.
+- It does not pass expected `issuer`, `audience`, or `algorithms` to `jwtVerify`.
+- `feed-platform-backend` does validate issuer, audience, and ES256.
+
+Why this is incomplete:
+
+- A relying party should reject tokens from the wrong issuer, for the wrong
+  audience, or with an unexpected algorithm before treating the user as signed
+  in.
+
+Fix:
+
+- Update `feed-platform-web` auth middleware to verify `issuer`, `audience`, and
+  `algorithms: ['ES256']`, matching backend validation.
+- Keep the backend validation as the API authorization enforcement point.
+
+#### Refresh-token storage and rotation policy is not documented in code
+
+Current behavior:
+
+- Better Auth stores refresh tokens in `oauth_refresh_token`.
+- Feed web stores the current refresh token in an HTTP-only cookie.
+
+Why this needs follow-up:
+
+- Refresh tokens are long-lived and high-value.
+- The implementation should clearly enforce rotation, replay detection, expiry,
+  and revocation.
+
+Fix:
+
+- Confirm Better Auth refresh-token family invalidation and rotation settings for
+  the deployed version.
+- Add tests for refresh replay and revoked refresh-token rejection.
+- Consider storing refresh tokens server-side rather than directly in browser
+  cookies for production.
+
+#### CSRF and origin policy around sign-out and consent need explicit tests
+
+Current behavior:
+
+- Better Auth validates signed `oauth_query` for consent.
+- Feed web and IdP cookies are `HttpOnly` and `SameSite=Lax` where relevant.
+- There are no explicit tests proving malicious cross-site POSTs cannot mutate
+  consent or sign-out state.
+
+Why this is incomplete:
+
+- OAuth state protects the authorization callback. It does not automatically
+  protect every state-changing endpoint.
+
+Fix:
+
+- Add tests for untrusted-origin POSTs to Better Auth state-changing endpoints.
+- Configure `trustedOrigins` explicitly for production origins.
+- Add CSRF tokens for custom state-changing UI endpoints if they are introduced
+  outside Better Auth.
+
+#### Discovery metadata warning remains
+
+Current behavior:
+
+- Better Auth logs a warning requesting
+  `/.well-known/oauth-authorization-server/api/v1/auth`.
+
+Why this is incomplete:
+
+- OAuth/OIDC clients use discovery metadata for issuer, JWKS URI, token endpoint,
+  supported algorithms, and logout/revocation capabilities.
+
+Fix:
+
+- Expose and test OAuth Authorization Server Metadata and OIDC configuration
+  endpoints for the deployed issuer.
+- Silence warnings only after the metadata endpoints are intentionally served and
+  verified.
+
+#### Database schema drift from Better Auth is a recurring risk
+
+Current behavior:
+
+- The IdP schema manually maps Better Auth OAuth models and fields.
+- Recent runtime verification found missing `oauth_refresh_token`, missing access
+  token columns, and an incompatible `updated_at` constraint.
+
+Why this is a problem:
+
+- Manual schema drift causes runtime token issuance failures that type checks do
+  not catch.
+
+Fix:
+
+- Add a schema compatibility test that runs an authorization-code token exchange
+  against the local database.
+- Track Better Auth OAuth provider schema changes on dependency updates.
+- Prefer generated migrations from the provider schema when available.
+
+## Production hardening checklist
+
+Before using this flow beyond local development:
+
+1. Use HTTPS-only origins and exact registered redirect URIs.
+2. Store client secrets hashed or encrypted; do not use the local identity
+   secret verifier.
+3. Use access tokens, not ID tokens, for backend API authorization.
+4. Validate issuer, audience, and allowed algorithms in every JWT-consuming
+   relying party, including `feed-platform-web` middleware.
+5. Implement or validate token revocation for refresh tokens.
+6. Add consent review and revocation UI.
+7. Serve OAuth/OIDC discovery metadata and test issuer/JWKS consistency.
+8. Add end-to-end tests for authorization code, PKCE, nonce, refresh, revocation,
+   and logout.
+9. Add negative tests for invalid state, invalid nonce, invalid redirect URI,
+   invalid client secret, replayed authorization code, and untrusted origins.
+10. Keep local DB schema migrations in sync with Better Auth model names and field
+    mappings.
+
+## Key implementation files
+
+- IdP Better Auth config: `app/feature/auth/better-auth.ts`
+- IdP app routes: `app/app.tsx`
+- IdP consent UI: `app/ui/oauth-consent.tsx`
+- IdP consent client entry: `app/ui/oauth-consent.client.tsx`
+- IdP OAuth schema: `db/schema.hcl`
+- Feed OAuth client helpers: `../../feed-platform-web/app/feature/auth/oauth-client.ts`
+- Feed callback: `../../feed-platform-web/app/feature/auth/callback.ts`
+- Feed auth middleware: `../../feed-platform-web/app/feature/auth/middleware.ts`
+- Feed backend client: `../../feed-platform-web/app/feature/api/client.ts`
+- Backend JWT verifier: `../../feed-platform-backend/src/feature/auth/jwt.ts`

--- a/js/app/identity-provider/docs/auth-flow.md
+++ b/js/app/identity-provider/docs/auth-flow.md
@@ -25,6 +25,42 @@ The feed example consists of:
 - `feed-platform-backend` on `http://127.0.0.1:8788` as the BFF API protected by
   IdP-issued JWTs.
 
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant Web as feed-platform-web
+  participant IdP as identity-provider
+  participant BetterAuth as Better Auth OAuth/OIDC
+  participant Backend as feed-platform-backend
+
+  User->>Web: GET /login
+  Web-->>User: Set oauth_state and pkce_verifier cookies; redirect to /oauth2/authorize
+  User->>IdP: GET /api/v1/auth/oauth2/authorize?state&nonce&code_challenge
+  IdP->>BetterAuth: Validate OAuth client, redirect URI, scope, state, PKCE challenge
+  BetterAuth-->>User: Redirect to /app/login when no IdP session exists
+  User->>IdP: Complete Magic Link or Passkey login
+  IdP-->>User: Restore login_return_to and redirect to original authorize URL
+  User->>IdP: GET /api/v1/auth/oauth2/authorize?...original query...
+  BetterAuth-->>User: Redirect to /app/oauth/consent
+  User->>IdP: POST /api/v1/auth/oauth2/consent with accept and oauth_query
+  IdP->>BetterAuth: Verify signed oauth_query and record consent
+  BetterAuth-->>User: Redirect to feed /auth/callback?code&state
+  User->>Web: GET /auth/callback?code&state
+  Web->>Web: Verify oauth_state cookie and load pkce_verifier
+  Web->>BetterAuth: POST /oauth2/token with code, client credentials, PKCE verifier
+  BetterAuth-->>Web: access_token, id_token, optional refresh_token
+  Web->>Web: Verify ID token nonce and set feed-session/feed-refresh cookies
+  Web-->>User: Redirect to /dashboard
+  User->>Web: GET /dashboard
+  Web->>Backend: GET /api/v1/me with Authorization: Bearer feed-session token
+  Backend->>IdP: Fetch JWKS when needed
+  Backend-->>Web: JWT-derived user payload or 401
+  Web-->>User: Render dashboard or unauthenticated state
+```
+
 ## Local feed OAuth flow
 
 ### 1. Login starts in feed-platform-web

--- a/js/app/identity-provider/docs/auth-flow.md
+++ b/js/app/identity-provider/docs/auth-flow.md
@@ -199,17 +199,18 @@ Authorization: Bearer <JWT access token>
   JWTs.
 - required `sub` and `email` claims.
 
-The backend returns the JWT-derived user payload. `feed-platform-web` accepts
-either `{ id, email }` or `{ sub, email }` and renders the dashboard.
+The backend returns the JWT-derived `sub` and `email` payload. `feed-platform-web`
+uses `sub` as the OIDC subject and does not fall back to an application `id`.
 
 ### 6. Refresh
 
 If the backend call fails and a server-side refresh token exists for the current
 `feed-session`, `feed-platform-web` attempts `grant_type=refresh_token` at the
-IdP token endpoint with `resource=feed-platform-backend`. The refreshed ID token
-is stored back in `feed-session` when present. The refreshed JWT access token and
-refreshed or previous refresh token remain server-side, then feed web retries the
-backend call with the refreshed access token.
+IdP token endpoint with `resource=feed-platform-backend`. The refresh response
+must include a refreshed ID token for `feed-session` and a refreshed JWT access
+token for the backend. The refreshed or previous refresh token remains
+server-side, then feed web retries the backend call with the refreshed access
+token.
 
 ### 7. Logout
 

--- a/js/app/identity-provider/docs/auth-flow.md
+++ b/js/app/identity-provider/docs/auth-flow.md
@@ -14,6 +14,8 @@ under `/api/v1/auth`. It currently provides:
 - Passkey login and registration.
 - OAuth 2.0 Authorization Code flow for `feed-platform-web`.
 - OIDC ID tokens signed by the Better Auth JWT/JWKS plugin.
+- JWT access tokens for API calls when the token request includes a valid
+  `resource` audience.
 - Refresh tokens for the `offline_access` scope.
 
 The feed example consists of:
@@ -50,12 +52,13 @@ sequenceDiagram
   BetterAuth-->>User: Redirect to feed /auth/callback?code&state
   User->>Web: GET /auth/callback?code&state
   Web->>Web: Verify oauth_state cookie and load pkce_verifier
-  Web->>BetterAuth: POST /oauth2/token with code, client credentials, PKCE verifier
-  BetterAuth-->>Web: access_token, id_token, optional refresh_token
-  Web->>Web: Verify ID token nonce and set feed-session/feed-refresh cookies
+  Web->>BetterAuth: POST /oauth2/token with code, client credentials, PKCE verifier, resource=feed-platform-backend
+  BetterAuth-->>Web: JWT access_token, id_token, optional refresh_token
+  Web->>Web: Verify ID token nonce; store ID token cookie plus access/refresh tokens server-side
   Web-->>User: Redirect to /dashboard
   User->>Web: GET /dashboard
-  Web->>Backend: GET /api/v1/me with Authorization: Bearer feed-session token
+  Web->>Web: Look up JWT access token by feed-session ID token
+  Web->>Backend: GET /api/v1/me with Authorization: Bearer JWT access_token
   Backend->>IdP: Fetch JWKS when needed
   Backend-->>Web: JWT-derived user payload or 401
   Web-->>User: Render dashboard or unauthenticated state
@@ -150,19 +153,21 @@ POST http://localhost:8787/api/v1/auth/oauth2/token
 ```
 
 with form-encoded `grant_type=authorization_code`, `client_id`,
-`client_secret`, `code`, `code_verifier`, and `redirect_uri`.
+`client_secret`, `code`, `code_verifier`, `redirect_uri`, and
+`resource=feed-platform-backend`.
 
 The token response is decoded as:
 
-- `access_token`: opaque Better Auth OAuth access token.
+- `access_token`: JWT OAuth access token for the `feed-platform-backend`
+  resource.
 - `id_token`: OIDC JWT when `openid` is requested.
 - `refresh_token`: opaque refresh token when `offline_access` is granted.
 
 `feed-platform-web` verifies the `nonce` claim in the ID token against its stored
-nonce. It stores the ID token, not the opaque access token, in the
-`feed-session` HTTP-only cookie because the feed web and backend middleware
-verify JWTs through the IdP JWKS endpoint. `feed-refresh` stores the refresh
-token.
+nonce. It stores the ID token in the `feed-session` HTTP-only cookie for the web
+login session only. The JWT access token and refresh token are stored
+server-side in `oauth_refresh_session` keyed by the current `feed-session` token;
+neither token is sent to the browser.
 
 ### 5. Dashboard and backend call
 
@@ -176,19 +181,22 @@ The current web middleware does not validate issuer or audience. The backend
 does validate those claims, so the backend is the stricter JWT enforcement point
 in the feed example.
 
-The dashboard calls `feed-platform-backend`:
+Before calling the backend, feed web looks up the server-side access token for
+the current `feed-session`. The dashboard then calls `feed-platform-backend`:
 
 ```text
 GET http://localhost:8788/api/v1/me
-Authorization: Bearer <feed-session ID token>
+Authorization: Bearer <JWT access token>
 ```
 
 `feed-platform-backend` verifies:
 
 - `alg=ES256`.
-- `aud=feed-platform-web`.
+- `aud=feed-platform-backend`.
 - `iss=http://localhost:8787/api/v1/auth`.
 - signature through `http://localhost:8787/api/v1/auth/jwks`.
+- `token_use=access`, rejecting ID tokens even when they are otherwise valid
+  JWTs.
 - required `sub` and `email` claims.
 
 The backend returns the JWT-derived user payload. `feed-platform-web` accepts
@@ -196,16 +204,19 @@ either `{ id, email }` or `{ sub, email }` and renders the dashboard.
 
 ### 6. Refresh
 
-If the backend call fails and `feed-refresh` exists, `feed-platform-web` attempts
-`grant_type=refresh_token` at the IdP token endpoint. The refreshed ID token is
-stored back in `feed-session` when present, otherwise the access token is used as
-a fallback.
+If the backend call fails and a server-side refresh token exists for the current
+`feed-session`, `feed-platform-web` attempts `grant_type=refresh_token` at the
+IdP token endpoint with `resource=feed-platform-backend`. The refreshed ID token
+is stored back in `feed-session` when present. The refreshed JWT access token and
+refreshed or previous refresh token remain server-side, then feed web retries the
+backend call with the refreshed access token.
 
 ### 7. Logout
 
-`GET /logout` in `feed-platform-web` clears `feed-session` and `feed-refresh`.
-It also attempts to call Better Auth sign-out with an empty JSON body to satisfy
-the endpoint content-type contract.
+`GET /logout` in `feed-platform-web` clears `feed-session`, deletes the
+server-side refresh session for that browser session, and attempts to call Better
+Auth sign-out with an empty JSON body to satisfy the endpoint content-type
+contract.
 
 Current logout is a local best-effort operation. It is not a complete OIDC
 RP-Initiated Logout or OAuth token revocation flow.
@@ -220,18 +231,19 @@ Core 1.0, and the OWASP OAuth2 Cheat Sheet.
 
 ### Implemented or mostly compliant
 
-| Area                      | Status                     | Evidence                                                                                  |
-| ------------------------- | -------------------------- | ----------------------------------------------------------------------------------------- |
-| Authorization Code flow   | Implemented                | Feed web uses `/oauth2/authorize`, receives `code`, and exchanges it at `/oauth2/token`.  |
-| PKCE                      | Implemented                | Feed web generates a verifier and S256 challenge; the callback sends `code_verifier`.     |
-| `state` CSRF binding      | Implemented                | Feed web stores `oauth_state` in an HTTP-only cookie and rejects callback state mismatch. |
-| OIDC `nonce`              | Implemented                | Feed web stores a nonce and verifies the ID token nonce before accepting the login.       |
-| Exact redirect URI        | Implemented for local feed | Seeded client redirect URI is `http://127.0.0.1:8789/auth/callback`.                      |
-| ID token signing and JWKS | Implemented                | IdP uses Better Auth `jwt` with ES256 and exposes `/api/v1/auth/jwks`.                    |
-| Audience validation       | Implemented                | Backend verifies `aud=feed-platform-web`; IdP has `validAudiences`.                       |
-| Issuer validation         | Implemented                | Backend verifies issuer `http://localhost:8787/api/v1/auth`.                              |
-| Refresh token table       | Implemented                | `oauth_refresh_token` table exists and maps `scopes` to `scope`.                          |
-| Consent endpoint          | Implemented                | Consent screen calls `/oauth2/consent` with Better Auth `oauth_query`.                    |
+| Area                      | Status                     | Evidence                                                                                               |
+| ------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Authorization Code flow   | Implemented                | Feed web uses `/oauth2/authorize`, receives `code`, and exchanges it at `/oauth2/token`.               |
+| PKCE                      | Implemented                | Feed web generates a verifier and S256 challenge; the callback sends `code_verifier`.                  |
+| `state` CSRF binding      | Implemented                | Feed web stores `oauth_state` in an HTTP-only cookie and rejects callback state mismatch.              |
+| OIDC `nonce`              | Implemented                | Feed web stores a nonce and verifies the ID token nonce before accepting the login.                    |
+| Exact redirect URI        | Implemented for local feed | Seeded client redirect URI is `http://127.0.0.1:8789/auth/callback`.                                   |
+| ID token signing and JWKS | Implemented                | IdP uses Better Auth `jwt` with ES256 and exposes `/api/v1/auth/jwks`.                                 |
+| JWT access token boundary | Implemented                | Feed web requests `resource=feed-platform-backend`; backend rejects tokens without `token_use=access`. |
+| Audience validation       | Implemented                | Backend verifies `aud=feed-platform-backend`; IdP has `validAudiences`.                                |
+| Issuer validation         | Implemented                | Backend verifies issuer `http://localhost:8787/api/v1/auth`.                                           |
+| Refresh token table       | Implemented                | `oauth_refresh_token` table exists and maps `scopes` to `scope`.                                       |
+| Consent endpoint          | Implemented                | Consent screen calls `/oauth2/consent` with Better Auth `oauth_query`.                                 |
 
 ### Non-compliant, incomplete, or local-only behavior
 
@@ -332,36 +344,44 @@ Why this is incomplete:
 
 Fix:
 
-- Implement token revocation for `feed-refresh` using RFC 7009-compatible revoke
-  behavior if the provider exposes it.
+- Implement token revocation for server-side feed refresh sessions using
+  RFC 7009-compatible revoke behavior if the provider exposes it.
 - Add OIDC RP-Initiated Logout support when Better Auth configuration and client
   metadata support `end_session_endpoint` and `post_logout_redirect_uri`.
 - Ensure logout does not send an ID token in a cookie named as an access-token
   session to the wrong endpoint.
 
-#### Access token is opaque but feed uses ID token as session
+#### Backend access token purpose is separated from web session identity
 
 Current behavior:
 
-- Better Auth returns an opaque OAuth access token.
-- Feed web stores the ID token in `feed-session` because the BFF verifies JWTs.
+- Feed web requests a JWT access token by sending
+  `resource=feed-platform-backend` to the token endpoint.
+- The IdP includes `aud=feed-platform-backend`, `azp=feed-platform-web`, and
+  `token_use=access` in the access token.
+- Feed web stores the ID token in `feed-session` only for the web login session.
+- Feed web stores the JWT access token server-side and sends that token, not the
+  ID token, to `feed-platform-backend`.
+- The backend verifies issuer, audience, ES256 signature, required user claims,
+  and `token_use=access`.
 
-Why this is a design mismatch:
+Why this matters:
 
 - ID tokens are intended to authenticate the user to the client, while access
-  tokens authorize API access. Using an ID token as a bearer token for a backend
-  API conflates token purposes.
+  tokens authorize API access. A backend that accepts ID tokens as bearer tokens
+  conflates token purposes and can accidentally accept tokens minted for a
+  different relying party.
+- Requiring a resource-specific JWT access token keeps the BFF authorization
+  boundary aligned with OAuth token purpose and audience semantics.
 
-Fix:
+Remaining hardening:
 
-- Prefer one of these designs:
-  1. Configure or issue JWT access tokens with an API audience and have the BFF
-     verify those access tokens.
-  2. Keep opaque access tokens and make the BFF call the IdP introspection
-     endpoint.
-  3. Treat feed web as a BFF session holder and have the backend trust only a
-     separate server-to-server session/token minted by feed web.
-- Do not use ID tokens as API bearer tokens in production.
+- Keep the ID-token rejection test in `feed-platform-backend` whenever changing
+  JWT claims or token exchange behavior.
+- If the IdP ever returns opaque access tokens for this flow, replace backend JWT
+  verification with RFC 7662-style introspection or a server-to-server token
+  minted specifically for the backend.
+- Do not send `feed-session` ID tokens to backend APIs.
 
 #### Feed web JWT validation is weaker than backend validation
 
@@ -387,8 +407,9 @@ Fix:
 
 Current behavior:
 
-- Better Auth stores refresh tokens in `oauth_refresh_token`.
-- Feed web stores the current refresh token in an HTTP-only cookie.
+- Better Auth stores provider-side refresh tokens in `oauth_refresh_token`.
+- Feed web stores the client refresh token server-side in `oauth_refresh_session`
+  keyed by the current `feed-session` token.
 
 Why this needs follow-up:
 
@@ -401,8 +422,8 @@ Fix:
 - Confirm Better Auth refresh-token family invalidation and rotation settings for
   the deployed version.
 - Add tests for refresh replay and revoked refresh-token rejection.
-- Consider storing refresh tokens server-side rather than directly in browser
-  cookies for production.
+- Add explicit refresh-token revocation and replay tests for the
+  `oauth_refresh_session` store.
 
 #### CSRF and origin policy around sign-out and consent need explicit tests
 
@@ -471,7 +492,8 @@ Before using this flow beyond local development:
 1. Use HTTPS-only origins and exact registered redirect URIs.
 2. Store client secrets hashed or encrypted; do not use the local identity
    secret verifier.
-3. Use access tokens, not ID tokens, for backend API authorization.
+3. Keep backend API authorization on resource-specific access tokens; never send
+   ID tokens as backend bearer tokens.
 4. Validate issuer, audience, and allowed algorithms in every JWT-consuming
    relying party, including `feed-platform-web` middleware.
 5. Implement or validate token revocation for refresh tokens.

--- a/js/package/auth-helper/src/jwt-payload.ts
+++ b/js/package/auth-helper/src/jwt-payload.ts
@@ -1,6 +1,8 @@
 export interface AppJWTPayload {
   readonly sub: string
   readonly email: string
+  readonly token_use: 'access'
+  readonly scope?: string
   readonly iat?: number
   readonly exp?: number
 }

--- a/js/package/vite-plugin-remix/src/client/boot.ts
+++ b/js/package/vite-plugin-remix/src/client/boot.ts
@@ -1,4 +1,5 @@
-import { Predicate, String } from 'effect'
+import { Effect, Predicate, String } from 'effect'
+import { FetchHttpClient, HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import { run } from 'remix/ui'
 import type { ImportGlobFunction } from 'vite'
 
@@ -45,16 +46,20 @@ export const boot = ({ components }: BootOptions): ReturnType<typeof run> =>
       return await exported
     },
     async resolveFrame(src: string, signal?: AbortSignal, target?: string) {
-      const headers = new Headers({ accept: 'text/html' })
+      const headers: Record<string, string> = { accept: 'text/html' }
       if (Predicate.isNotNullish(target) && String.isNonEmpty(target)) {
-        headers.set('x-remix-target', target)
+        headers['x-remix-target'] = target
       }
-      // oxlint-disable-next-line rules/no-fetch -- client-side framework loader runs before any Effect runtime is bootstrapped
-      const response = await fetch(src, {
-        credentials: 'same-origin',
-        headers,
-        signal,
-      })
-      return await (response.body ?? response.text())
+      const program = Effect.gen(function* () {
+        if (signal?.aborted === true) {
+          return ''
+        }
+        const client = yield* HttpClient.HttpClient
+        const request = HttpClientRequest.get(src, { headers })
+        const response = yield* client.execute(request)
+        return yield* response.text
+      }).pipe(Effect.provide(FetchHttpClient.layer))
+      // oxlint-disable-next-line rules/no-effect-runtime-run -- Remix frame resolver callback is a client-side framework boundary.
+      return await Effect.runPromise(program)
     },
   })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
       'jsx-no-new-function-as-prop': 'allow',
       'no-nodejs-modules': 'allow',
       'number-literal-case': 'allow',
+      'promise/prefer-await-to-then': 'allow',
       'typescript/promise-function-async': 'allow',
     },
   },


### PR DESCRIPTION
## Summary
- preserve IdP OAuth return targets across magic-link login
- submit Better Auth OAuth consent with signed oauth_query
- align local IdP OAuth token tables and feed web token handling
- verify IdP-issued JWTs in the backend BFF

## Verification
- vp run js:check
- vp run js:test
- Playwright: login via magic link reaches feed dashboard
- Playwright: logout clears feed session