### PR TITLE
fix(identity-provider): align better auth schema mappings

### DIFF
--- a/js/app/feed-platform-web/app/app.tsx
+++ b/js/app/feed-platform-web/app/app.tsx
@@ -50,16 +50,6 @@ const refreshTokens = (idpBaseUrl: string, params: Record<string, string>) =>
     return yield* decodeTokenResponse(data)
   })
 
-const logoutFromIdp = (idpBaseUrl: string, sessionCookieValue: string) =>
-  Effect.gen(function* () {
-    const client = yield* HttpClient.HttpClient
-    const request = HttpClientRequest.post(`${idpBaseUrl}/api/v1/auth/sign-out`, {
-      body: HttpBody.jsonUnsafe({}),
-      headers: { Cookie: `${FEED_SESSION_COOKIE}=${sessionCookieValue}` },
-    })
-    yield* client.execute(request)
-  })
-
 const app: Hono<Env> = new Hono<Env>()
   .use(logger())
   .use(contextStorage())
@@ -222,11 +212,11 @@ const app: Hono<Env> = new Hono<Env>()
         const db = yield* DBService
         const token = getCookie(ctx, FEED_SESSION_COOKIE)
         if (!Predicate.isNullish(token)) {
-          yield* logoutFromIdp(env.IDP_BASE_URL, token).pipe(Effect.ignore)
           yield* Effect.promise(() => deleteRefreshToken(db, token))
         }
         deleteCookie(ctx, FEED_SESSION_COOKIE, { httpOnly: true, path: '/', sameSite: 'Lax' })
-        return ctx.redirect('/login')
+        const { origin } = new URL(ctx.req.url)
+        return ctx.redirect(`${env.IDP_BASE_URL}/app/logout?return_to=${encodeURIComponent(`${origin}/login`)}`)
       }),
     ),
   )

--- a/js/app/identity-provider/app/app.tsx
+++ b/js/app/identity-provider/app/app.tsx
@@ -39,6 +39,18 @@ const getLoginReturnTo = (url: string, rawReturnTo: string | undefined): string 
   return undefined
 }
 
+const getSafeLogoutReturnTo = (value: string | undefined): string | undefined => {
+  if (Predicate.isNullish(value)) {
+    return undefined
+  }
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' && url.hostname === '127.0.0.1' && url.port === '8789' ? value : undefined
+  } catch {
+    return getSafeReturnTo(value)
+  }
+}
+
 const appRoutes = factory
   .createApp()
   .get('/', (ctx) =>
@@ -58,6 +70,11 @@ const appRoutes = factory
         <LoginPage returnTo={safeReturnTo} />
       </Document>,
     )
+  })
+  .get('/logout', (ctx) => {
+    deleteCookie(ctx, 'better-auth.session_token', { httpOnly: true, path: '/', sameSite: 'Lax' })
+    const returnTo = getSafeLogoutReturnTo(ctx.req.query('return_to'))
+    return ctx.redirect(returnTo ?? '/app/login')
   })
   .get('/login/passkey', (ctx) => {
     const returnTo = ctx.req.query('return_to')

--- a/js/app/identity-provider/app/feature/auth/better-auth.ts
+++ b/js/app/identity-provider/app/feature/auth/better-auth.ts
@@ -2,49 +2,14 @@ import { oauthProvider } from '@better-auth/oauth-provider'
 import { passkey } from '@better-auth/passkey'
 import { betterAuth } from 'better-auth'
 import { jwt, magicLink } from 'better-auth/plugins'
-import type { Jwk } from 'better-auth/plugins'
 import { Context, Effect, Layer, Predicate } from 'effect'
 
-import * as DB from '#@/feature/db/kysely.ts'
+import * as BetterAuthDB from '#@/feature/db/better-auth-kysely.ts'
 import * as EmailSender from '#@/feature/email/sender.ts'
 import * as Env from '#@/feature/env.ts'
 import * as HonoContext from '#@/feature/share/lib/hono/context.ts'
 
-const toJwk = (row: DB.Type.Jwks): Jwk => ({
-  // oxlint-disable-next-line rules/no-js-date -- Better Auth JWT adapter boundary requires JavaScript Date objects.
-  createdAt: new Date(row.createdAt),
-  // oxlint-disable-next-line rules/no-js-date -- Better Auth JWT adapter boundary requires JavaScript Date objects.
-  ...(Predicate.isNotNullish(row.expiresAt) ? { expiresAt: new Date(row.expiresAt) } : {}),
-  id: row.id,
-  privateKey: row.privateKey,
-  publicKey: row.publicKey,
-})
-
-const makeJwksAdapter = (db: DB.Instance) => ({
-  createJwk: async (data: Omit<Jwk, 'id'>): Promise<Jwk> => {
-    const jwk: Jwk = {
-      ...data,
-      id: crypto.randomUUID(),
-    }
-    await db
-      .insertInto('jwks')
-      .values({
-        createdAt: jwk.createdAt.toISOString(),
-        expiresAt: jwk.expiresAt?.toISOString() ?? null,
-        id: jwk.id,
-        privateKey: jwk.privateKey,
-        publicKey: jwk.publicKey,
-      })
-      .execute()
-    return jwk
-  },
-  getJwks: async (): Promise<Jwk[]> => {
-    const rows = await db.selectFrom('jwks').selectAll().execute()
-    return rows.map(toJwk)
-  },
-})
-
-const makeInstance = (db: DB.Instance, env: Env.Type, emailSender: EmailSender.EmailSender, origin: string) =>
+const makeInstance = (db: BetterAuthDB.Instance, env: Env.Type, emailSender: EmailSender.EmailSender, origin: string) =>
   betterAuth({
     account: {
       fields: {
@@ -198,7 +163,6 @@ const makeInstance = (db: DB.Instance, env: Env.Type, emailSender: EmailSender.E
         validAudiences: env.OAUTH_VALID_AUDIENCES.split(','),
       }),
       jwt({
-        adapter: makeJwksAdapter(db),
         jwks: { keyPairConfig: { alg: 'ES256' } },
         schema: {
           jwks: {
@@ -261,7 +225,7 @@ export const Service = Context.Service<Instance>('@app/identity-provider/feature
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
-    const db = yield* DB.Service
+    const db = yield* BetterAuthDB.Service
     const env = yield* Env.Service
     const emailSender = yield* EmailSender.Service
     const { origin } = new URL(HonoContext.get().req.url)

--- a/js/app/identity-provider/app/feature/auth/better-auth.ts
+++ b/js/app/identity-provider/app/feature/auth/better-auth.ts
@@ -2,6 +2,7 @@ import { oauthProvider } from '@better-auth/oauth-provider'
 import { passkey } from '@better-auth/passkey'
 import { betterAuth } from 'better-auth'
 import { jwt, magicLink } from 'better-auth/plugins'
+import type { Jwk } from 'better-auth/plugins'
 import { Context, Effect, Layer, Predicate } from 'effect'
 
 import * as DB from '#@/feature/db/kysely.ts'
@@ -9,9 +10,58 @@ import * as EmailSender from '#@/feature/email/sender.ts'
 import * as Env from '#@/feature/env.ts'
 import * as HonoContext from '#@/feature/share/lib/hono/context.ts'
 
+const toJwk = (row: DB.Type.Jwks): Jwk => ({
+  // oxlint-disable-next-line rules/no-js-date -- Better Auth JWT adapter boundary requires JavaScript Date objects.
+  createdAt: new Date(row.createdAt),
+  // oxlint-disable-next-line rules/no-js-date -- Better Auth JWT adapter boundary requires JavaScript Date objects.
+  ...(Predicate.isNotNullish(row.expiresAt) ? { expiresAt: new Date(row.expiresAt) } : {}),
+  id: row.id,
+  privateKey: row.privateKey,
+  publicKey: row.publicKey,
+})
+
+const makeJwksAdapter = (db: DB.Instance) => ({
+  createJwk: async (data: Omit<Jwk, 'id'>): Promise<Jwk> => {
+    const jwk: Jwk = {
+      ...data,
+      id: crypto.randomUUID(),
+    }
+    await db
+      .insertInto('jwks')
+      .values({
+        createdAt: jwk.createdAt.toISOString(),
+        expiresAt: jwk.expiresAt?.toISOString() ?? null,
+        id: jwk.id,
+        privateKey: jwk.privateKey,
+        publicKey: jwk.publicKey,
+      })
+      .execute()
+    return jwk
+  },
+  getJwks: async (): Promise<Jwk[]> => {
+    const rows = await db.selectFrom('jwks').selectAll().execute()
+    return rows.map(toJwk)
+  },
+})
+
 const makeInstance = (db: DB.Instance, env: Env.Type, emailSender: EmailSender.EmailSender, origin: string) =>
   betterAuth({
     account: {
+      fields: {
+        accessToken: 'access_token',
+        accessTokenExpiresAt: 'access_token_expires_at',
+        accountId: 'account_id',
+        createdAt: 'created_at',
+        id: 'id',
+        idToken: 'id_token',
+        password: 'password',
+        providerId: 'provider_id',
+        refreshToken: 'refresh_token',
+        refreshTokenExpiresAt: 'refresh_token_expires_at',
+        scope: 'scope',
+        updatedAt: 'updated_at',
+        userId: 'user_id',
+      },
       modelName: 'account',
     },
     basePath: '/api/v1/auth',
@@ -24,6 +74,18 @@ const makeInstance = (db: DB.Instance, env: Env.Type, emailSender: EmailSender.E
         rpName: 'identity-provider',
         schema: {
           passkey: {
+            fields: {
+              aaguid: 'aaguid',
+              backedUp: 'backed_up',
+              counter: 'counter',
+              createdAt: 'created_at',
+              credentialID: 'credential_id',
+              deviceType: 'device_type',
+              name: 'name',
+              publicKey: 'public_key',
+              transports: 'transports',
+              userId: 'user_id',
+            },
             modelName: 'passkey',
           },
         },
@@ -51,23 +113,79 @@ const makeInstance = (db: DB.Instance, env: Env.Type, emailSender: EmailSender.E
         schema: {
           oauthAccessToken: {
             fields: {
+              clientId: 'client_id',
+              createdAt: 'created_at',
+              expiresAt: 'expires_at',
+              id: 'id',
+              referenceId: 'reference_id',
+              refreshId: 'refresh_id',
               scopes: 'scope',
+              sessionId: 'session_id',
               token: 'access_token',
+              userId: 'user_id',
             },
             modelName: 'oauth_access_token',
           },
           oauthClient: {
+            fields: {
+              clientId: 'client_id',
+              clientSecret: 'client_secret',
+              contacts: 'contacts',
+              createdAt: 'created_at',
+              disabled: 'disabled',
+              enableEndSession: 'enable_end_session',
+              grantTypes: 'grant_types',
+              icon: 'icon',
+              id: 'id',
+              metadata: 'metadata',
+              name: 'name',
+              policy: 'policy',
+              postLogoutRedirectUris: 'post_logout_redirect_uris',
+              public: 'public',
+              redirectUris: 'redirect_uris',
+              referenceId: 'reference_id',
+              requirePKCE: 'require_pkce',
+              responseTypes: 'response_types',
+              scopes: 'scopes',
+              skipConsent: 'skip_consent',
+              softwareId: 'software_id',
+              softwareStatement: 'software_statement',
+              softwareVersion: 'software_version',
+              subjectType: 'subject_type',
+              tokenEndpointAuthMethod: 'token_endpoint_auth_method',
+              tos: 'tos',
+              type: 'type',
+              updatedAt: 'updated_at',
+              uri: 'uri',
+              userId: 'user_id',
+            },
             modelName: 'oauth_application',
           },
           oauthConsent: {
             fields: {
+              clientId: 'client_id',
+              createdAt: 'created_at',
+              id: 'id',
+              referenceId: 'reference_id',
               scopes: 'scope',
+              updatedAt: 'updated_at',
+              userId: 'user_id',
             },
             modelName: 'oauth_consent',
           },
           oauthRefreshToken: {
             fields: {
+              authTime: 'auth_time',
+              clientId: 'client_id',
+              createdAt: 'created_at',
+              expiresAt: 'expires_at',
+              id: 'id',
+              referenceId: 'reference_id',
+              revoked: 'revoked',
               scopes: 'scope',
+              sessionId: 'session_id',
+              token: 'token',
+              userId: 'user_id',
             },
             modelName: 'oauth_refresh_token',
           },
@@ -80,13 +198,16 @@ const makeInstance = (db: DB.Instance, env: Env.Type, emailSender: EmailSender.E
         validAudiences: env.OAUTH_VALID_AUDIENCES.split(','),
       }),
       jwt({
+        adapter: makeJwksAdapter(db),
         jwks: { keyPairConfig: { alg: 'ES256' } },
         schema: {
           jwks: {
             fields: {
-              createdAt: 'createdAt',
-              privateKey: 'privateKey',
-              publicKey: 'publicKey',
+              createdAt: 'created_at',
+              expiresAt: 'expires_at',
+              id: 'id',
+              privateKey: 'private_key',
+              publicKey: 'public_key',
             },
             modelName: 'jwks',
           },
@@ -95,13 +216,40 @@ const makeInstance = (db: DB.Instance, env: Env.Type, emailSender: EmailSender.E
     ],
     secret: env.BETTER_AUTH_SECRET,
     session: {
+      fields: {
+        createdAt: 'created_at',
+        expiresAt: 'expires_at',
+        id: 'id',
+        ipAddress: 'ip_address',
+        token: 'token',
+        updatedAt: 'updated_at',
+        userAgent: 'user_agent',
+        userId: 'user_id',
+      },
       modelName: 'session',
       storeSessionInDatabase: true,
     },
     user: {
+      fields: {
+        createdAt: 'created_at',
+        email: 'email',
+        emailVerified: 'email_verified',
+        id: 'id',
+        image: 'image',
+        name: 'name',
+        updatedAt: 'updated_at',
+      },
       modelName: 'user',
     },
     verification: {
+      fields: {
+        createdAt: 'created_at',
+        expiresAt: 'expires_at',
+        id: 'id',
+        identifier: 'identifier',
+        updatedAt: 'updated_at',
+        value: 'value',
+      },
       modelName: 'verification',
     },
   })

--- a/js/app/identity-provider/app/feature/db/better-auth-kysely.ts
+++ b/js/app/identity-provider/app/feature/db/better-auth-kysely.ts
@@ -1,0 +1,36 @@
+import { LibsqlDialect } from '@libsql/kysely-libsql'
+import { Context, Effect, Layer } from 'effect'
+import { Kysely } from 'kysely'
+
+import * as Env from '#@/feature/env.ts'
+
+type RawDatabase = Record<string, Record<string, unknown>>
+
+export type Instance = Kysely<RawDatabase>
+
+export const makeInMemory = (): Instance =>
+  new Kysely({
+    dialect: new LibsqlDialect({
+      url: ':memory:',
+    }),
+  })
+
+export const makeRemote = (env: Env.Database): Instance =>
+  new Kysely({
+    dialect: new LibsqlDialect({
+      authToken: env.DATABASE_AUTH_TOKEN,
+      url: env.DATABASE_URL,
+    }),
+  })
+
+export const Service = Context.Service<Instance>('@app/identity-provider/feature/db/better-auth-kysely/Service')
+
+export const inMemoryLayer = Layer.sync(Service, () => makeInMemory())
+
+export const remoteLayer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const env = yield* Env.Service
+    return makeRemote(env)
+  }),
+)

--- a/js/app/identity-provider/app/feature/db/kysely.test.ts
+++ b/js/app/identity-provider/app/feature/db/kysely.test.ts
@@ -1,6 +1,7 @@
 import { Effect } from 'effect'
 import { describe, expect, test } from 'vite-plus/test'
 
+import * as BetterAuthDB from './better-auth-kysely.ts'
 import * as DB from './kysely.ts'
 
 describe('Kysely LibSQL service', () => {
@@ -16,5 +17,18 @@ describe('Kysely LibSQL service', () => {
     expect(sql).toContain('"created_at"')
     expect(sql).toContain('from "user"')
     expect(sql).not.toContain('createdAt')
+  })
+
+  test('Better Auth inMemoryLayer builds a raw Kysely instance without CamelCasePlugin', async () => {
+    const program = Effect.gen(function* () {
+      const db = yield* BetterAuthDB.Service
+      return db.selectFrom('jwks').select('public_key').compile().sql
+    })
+
+    const sql = await Effect.runPromise(Effect.provide(program, BetterAuthDB.inMemoryLayer))
+
+    expect(sql).toContain('"public_key"')
+    expect(sql).toContain('from "jwks"')
+    expect(sql).not.toContain('publicKey')
   })
 })

--- a/js/app/identity-provider/app/feature/runtime/server.ts
+++ b/js/app/identity-provider/app/feature/runtime/server.ts
@@ -2,6 +2,7 @@ import { Layer, ManagedRuntime } from 'effect'
 import { dynamicLoggerLayer, Env as RuntimeEnv, makeDisposableRuntime } from 'effect-hono'
 
 import * as BetterAuth from '../auth/better-auth.ts'
+import * as BetterAuthDB from '../db/better-auth-kysely.ts'
 import * as DB from '../db/kysely.ts'
 import * as EmailCloudflare from '../email/cloudflare.ts'
 import * as EmailMock from '../email/mock.ts'
@@ -10,6 +11,7 @@ import * as Env from '../env.ts'
 const makeProdRuntime = () =>
   ManagedRuntime.make(
     BetterAuth.layer.pipe(
+      Layer.provideMerge(BetterAuthDB.remoteLayer),
       Layer.provideMerge(DB.remoteLayer),
       Layer.provideMerge(EmailCloudflare.layer),
       Layer.provideMerge(dynamicLoggerLayer),
@@ -21,6 +23,7 @@ const makeProdRuntime = () =>
 const makeDevRuntime = () =>
   ManagedRuntime.make(
     BetterAuth.layer.pipe(
+      Layer.provideMerge(BetterAuthDB.remoteLayer),
       Layer.provideMerge(DB.remoteLayer),
       Layer.provideMerge(EmailMock.layer),
       Layer.provideMerge(dynamicLoggerLayer),

--- a/js/app/identity-provider/db/schema.hcl
+++ b/js/app/identity-provider/db/schema.hcl
@@ -36,6 +36,11 @@ table "user" {
   primary_key {
     columns = [column.id]
   }
+
+  index "user_email_unique" {
+    unique  = true
+    columns = [column.email]
+  }
 }
 
 table "session" {
@@ -76,6 +81,11 @@ table "session" {
 
   primary_key {
     columns = [column.id]
+  }
+
+  index "session_token_unique" {
+    unique  = true
+    columns = [column.token]
   }
 
   foreign_key "session_user_id_fk" {
@@ -204,7 +214,7 @@ table "passkey" {
     type = text
     null = false
   }
-  column "credential_i_d" {
+  column "credential_id" {
     type = text
     null = false
   }
@@ -232,13 +242,16 @@ table "passkey" {
     type = text
     null = false
   }
-  column "updated_at" {
-    type = text
-    null = false
-  }
-
   primary_key {
     columns = [column.id]
+  }
+
+  index "passkey_credential_id_index" {
+    columns = [column.credential_id]
+  }
+
+  index "passkey_user_id_index" {
+    columns = [column.user_id]
   }
 
   foreign_key "passkey_user_id_fk" {
@@ -267,6 +280,10 @@ table "jwks" {
     type = text
     null = false
   }
+  column "expires_at" {
+    type = text
+    null = true
+  }
 
   primary_key {
     columns = [column.id]
@@ -282,7 +299,7 @@ table "oauth_application" {
   }
   column "name" {
     type = text
-    null = false
+    null = true
   }
   column "client_id" {
     type = text
@@ -290,33 +307,126 @@ table "oauth_application" {
   }
   column "client_secret" {
     type = text
-    null = false
+    null = true
+  }
+  column "disabled" {
+    type = integer
+    null = true
+  }
+  column "skip_consent" {
+    type = integer
+    null = true
+  }
+  column "enable_end_session" {
+    type = integer
+    null = true
+  }
+  column "subject_type" {
+    type = text
+    null = true
+  }
+  column "scopes" {
+    type = text
+    null = true
   }
   column "redirect_uris" {
     type = text
     null = false
   }
+  column "uri" {
+    type = text
+    null = true
+  }
+  column "icon" {
+    type = text
+    null = true
+  }
+  column "contacts" {
+    type = text
+    null = true
+  }
+  column "tos" {
+    type = text
+    null = true
+  }
+  column "policy" {
+    type = text
+    null = true
+  }
+  column "software_id" {
+    type = text
+    null = true
+  }
+  column "software_version" {
+    type = text
+    null = true
+  }
+  column "software_statement" {
+    type = text
+    null = true
+  }
+  column "post_logout_redirect_uris" {
+    type = text
+    null = true
+  }
+  column "token_endpoint_auth_method" {
+    type = text
+    null = true
+  }
+  column "grant_types" {
+    type = text
+    null = true
+  }
+  column "response_types" {
+    type = text
+    null = true
+  }
+  column "public" {
+    type = integer
+    null = true
+  }
+  column "type" {
+    type = text
+    null = true
+  }
+  column "require_pkce" {
+    type = integer
+    null = true
+  }
+  column "reference_id" {
+    type = text
+    null = true
+  }
+  column "metadata" {
+    type = text
+    null = true
+  }
   column "user_id" {
     type = text
-    null = false
+    null = true
   }
   column "created_at" {
     type = text
-    null = false
+    null = true
   }
   column "updated_at" {
     type = text
-    null = false
+    null = true
   }
 
   primary_key {
     columns = [column.id]
   }
 
+  index "oauth_application_client_id_unique" {
+    unique  = true
+    columns = [column.client_id]
+  }
+
   foreign_key "oauth_application_user_id_fk" {
     columns     = [column.user_id]
     ref_columns = [table.user.column.id]
-    on_delete   = CASCADE
+    on_delete   = SET_NULL
   }
 }
 
@@ -331,10 +441,6 @@ table "oauth_access_token" {
     type = text
     null = false
   }
-  column "refresh_token" {
-    type = text
-    null = true
-  }
   column "client_id" {
     type = text
     null = false
@@ -345,11 +451,11 @@ table "oauth_access_token" {
   }
   column "user_id" {
     type = text
-    null = false
+    null = true
   }
   column "scope" {
     type = text
-    null = true
+    null = false
   }
   column "reference_id" {
     type = text
@@ -376,10 +482,49 @@ table "oauth_access_token" {
     columns = [column.id]
   }
 
+  index "oauth_access_token_access_token_unique" {
+    unique  = true
+    columns = [column.access_token]
+  }
+
+  index "oauth_access_token_client_id_index" {
+    columns = [column.client_id]
+  }
+
+  index "oauth_access_token_session_id_index" {
+    columns = [column.session_id]
+  }
+
+  index "oauth_access_token_user_id_index" {
+    columns = [column.user_id]
+  }
+
+  index "oauth_access_token_refresh_id_index" {
+    columns = [column.refresh_id]
+  }
+
+  foreign_key "oauth_access_token_client_id_fk" {
+    columns     = [column.client_id]
+    ref_columns = [table.oauth_application.column.client_id]
+    on_delete   = CASCADE
+  }
+
+  foreign_key "oauth_access_token_session_id_fk" {
+    columns     = [column.session_id]
+    ref_columns = [table.session.column.id]
+    on_delete   = SET_NULL
+  }
+
   foreign_key "oauth_access_token_user_id_fk" {
     columns     = [column.user_id]
     ref_columns = [table.user.column.id]
-    on_delete   = CASCADE
+    on_delete   = SET_NULL
+  }
+
+  foreign_key "oauth_access_token_refresh_id_fk" {
+    columns     = [column.refresh_id]
+    ref_columns = [table.oauth_refresh_token.column.id]
+    on_delete   = SET_NULL
   }
 }
 
@@ -435,6 +580,29 @@ table "oauth_refresh_token" {
     columns = [column.id]
   }
 
+  index "oauth_refresh_token_token_unique" {
+    unique  = true
+    columns = [column.token]
+  }
+
+  index "oauth_refresh_token_client_id_index" {
+    columns = [column.client_id]
+  }
+
+  index "oauth_refresh_token_session_id_index" {
+    columns = [column.session_id]
+  }
+
+  index "oauth_refresh_token_user_id_index" {
+    columns = [column.user_id]
+  }
+
+  foreign_key "oauth_refresh_token_client_id_fk" {
+    columns     = [column.client_id]
+    ref_columns = [table.oauth_application.column.client_id]
+    on_delete   = CASCADE
+  }
+
   foreign_key "oauth_refresh_token_session_id_fk" {
     columns     = [column.session_id]
     ref_columns = [table.session.column.id]
@@ -457,13 +625,17 @@ table "oauth_consent" {
   }
   column "user_id" {
     type = text
-    null = false
+    null = true
   }
   column "client_id" {
     type = text
     null = false
   }
   column "scope" {
+    type = text
+    null = false
+  }
+  column "reference_id" {
     type = text
     null = true
   }
@@ -480,9 +652,23 @@ table "oauth_consent" {
     columns = [column.id]
   }
 
+  index "oauth_consent_client_id_index" {
+    columns = [column.client_id]
+  }
+
+  index "oauth_consent_user_id_index" {
+    columns = [column.user_id]
+  }
+
+  foreign_key "oauth_consent_client_id_fk" {
+    columns     = [column.client_id]
+    ref_columns = [table.oauth_application.column.client_id]
+    on_delete   = CASCADE
+  }
+
   foreign_key "oauth_consent_user_id_fk" {
     columns     = [column.user_id]
     ref_columns = [table.user.column.id]
-    on_delete   = CASCADE
+    on_delete   = SET_NULL
   }
 }

--- a/js/app/identity-provider/docs/auth-flow.md
+++ b/js/app/identity-provider/docs/auth-flow.md
@@ -39,7 +39,7 @@ sequenceDiagram
   participant Backend as feed-platform-backend
 
   User->>Web: GET /login
-  Web-->>User: Set oauth_state and pkce_verifier cookies; redirect to /oauth2/authorize
+  Web-->>User: Set oauth_state and pkce_verifier cookies, then redirect to /oauth2/authorize
   User->>IdP: GET /api/v1/auth/oauth2/authorize?state&nonce&code_challenge
   IdP->>BetterAuth: Validate OAuth client, redirect URI, scope, state, PKCE challenge
   BetterAuth-->>User: Redirect to /app/login when no IdP session exists
@@ -54,7 +54,7 @@ sequenceDiagram
   Web->>Web: Verify oauth_state cookie and load pkce_verifier
   Web->>BetterAuth: POST /oauth2/token with code, client credentials, PKCE verifier, resource=feed-platform-backend
   BetterAuth-->>Web: JWT access_token, id_token, optional refresh_token
-  Web->>Web: Verify ID token nonce; store ID token cookie plus access/refresh tokens server-side
+  Web->>Web: Verify ID token nonce, then store ID token cookie plus access/refresh tokens server-side
   Web-->>User: Redirect to /dashboard
   User->>Web: GET /dashboard
   Web->>Web: Look up JWT access token by feed-session ID token


### PR DESCRIPTION
…eware, and protected /api/v1/me endpoint

- JwtService (Effect Service) with jose remote JWKS + ES256, audience and issuer enforcement
- authMiddleware extracts Bearer token, verifies via JwtService, exposes payload as c.var.user
- jwt-payload re-exports AppJWTPayload from auth-helper (canonical source)
- /api/v1/me protected endpoint returns the verified JWT payload
- Tests cover happy path, missing/invalid Bearer, missing email claim, optional iat/exp