### PR TITLE
chore(c-plugin): bump version to 0.6.0

### DIFF
--- a/js/app/c-plugin/package.json
+++ b/js/app/c-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totto2727/c-plugin",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump @totto2727/c-plugin version from 0.5.0 to 0.6.0 following the lock-file-based target discovery and searchTopDir feature additions.