### PR TITLE
SymphonyのバックエンドをOpenCodeに差し替える。

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -3,6 +3,7 @@
   "packages": [
     "go@latest",
     "deno@latest",
+    "elixir@latest",
     "pnpm@latest",
     "just@latest",
     "turso-cli@latest",

--- a/devbox.lock
+++ b/devbox.lock
@@ -49,6 +49,55 @@
         }
       }
     },
+    "elixir@latest": {
+      "last_modified": "2024-12-27T03:08:00Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/7cc0bff31a3a705d3ac4fdceb030a17239412210#elixir",
+      "source": "devbox-search",
+      "version": "1.18.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hdd9x34p0gplcl1bramq80lqi76xrd87-elixir-1.18.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hdd9x34p0gplcl1bramq80lqi76xrd87-elixir-1.18.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/a4g29icpil9b1hsniqspz5k110h4df8v-elixir-1.18.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/a4g29icpil9b1hsniqspz5k110h4df8v-elixir-1.18.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/b3h6f36zd4gjivb76lvvs6a9bi1mq9q8-elixir-1.18.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/b3h6f36zd4gjivb76lvvs6a9bi1mq9q8-elixir-1.18.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3zd200bq28mv3pdbii7rijzmb0gmhhs3-elixir-1.18.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3zd200bq28mv3pdbii7rijzmb0gmhhs3-elixir-1.18.1"
+        }
+      }
+    },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
       "last_modified": "2026-06-23T00:43:55Z",
       "resolved": "github:NixOS/nixpkgs/89570f24e97e614aa34aa9ab1c927b6578a43775?lastModified=1782175435"

--- a/elixir/opencode_client/lib/opencode_client/event_stream.ex
+++ b/elixir/opencode_client/lib/opencode_client/event_stream.ex
@@ -29,6 +29,10 @@ defmodule OpencodeClient.EventStream do
     {:ok, stream_from_mailbox(ref, task, timeout)}
   end
 
+  @doc false
+  @spec decode_frame_for_test(map()) :: event()
+  def decode_frame_for_test(frame), do: decode_frame(frame)
+
   defp request_stream(owner, ref, opts) do
     req =
       Req.new(
@@ -62,9 +66,11 @@ defmodule OpencodeClient.EventStream do
   end
 
   defp decode_frame(%{event: event, data: data, id: id, retry: retry}) do
+    decoded_data = decode_data(data)
+
     %{
-      type: event,
-      data: decode_data(data),
+      type: event || event_type(decoded_data),
+      data: decoded_data,
       id: id,
       retry: retry
     }
@@ -79,4 +85,9 @@ defmodule OpencodeClient.EventStream do
     end
   end
 
+  defp event_type(%{"type" => type}) when is_binary(type), do: type
+  defp event_type(%{type: type}) when is_binary(type), do: type
+  defp event_type(%{"payload" => payload}) when is_map(payload), do: event_type(payload)
+  defp event_type(%{payload: payload}) when is_map(payload), do: event_type(payload)
+  defp event_type(_data), do: nil
 end

--- a/elixir/opencode_client/test/opencode_client_test.exs
+++ b/elixir/opencode_client/test/opencode_client_test.exs
@@ -25,5 +25,19 @@ defmodule OpencodeClientTest do
 
       assert %{event: "session.idle", data: ~s({"type":"session.idle"})} = frame
     end
+
+    test "normalizes SSE event type from JSON payload when event name is omitted" do
+      frame = %{
+        event: nil,
+        data: ~s({"type":"session.idle","properties":{"sessionID":"ses_test"}}),
+        id: nil,
+        retry: nil
+      }
+
+      assert %{
+               type: "session.idle",
+               data: %{"properties" => %{"sessionID" => "ses_test"}}
+             } = OpencodeClient.EventStream.decode_frame_for_test(frame)
+    end
   end
 end

--- a/elixir/opencode_client/test/opencode_client_test.exs
+++ b/elixir/opencode_client/test/opencode_client_test.exs
@@ -3,7 +3,8 @@ defmodule OpencodeClientTest do
 
   describe "generated OpenAPI client" do
     test "exports generated session operations" do
-      assert {:module, OpencodeClient.Generated.Session} = Code.ensure_loaded(OpencodeClient.Generated.Session)
+      assert {:module, OpencodeClient.Generated.Session} =
+               Code.ensure_loaded(OpencodeClient.Generated.Session)
 
       assert function_exported?(OpencodeClient.Generated.Session, :session_create, 2)
       assert function_exported?(OpencodeClient.Generated.Session, :session_prompt_async, 3)
@@ -17,11 +18,13 @@ defmodule OpencodeClientTest do
     end
 
     test "provides SSE event stream backed by ReqServerSentEvents" do
-      assert {:module, OpencodeClient.EventStream} = Code.ensure_loaded(OpencodeClient.EventStream)
+      assert {:module, OpencodeClient.EventStream} =
+               Code.ensure_loaded(OpencodeClient.EventStream)
 
       assert function_exported?(OpencodeClient.EventStream, :stream, 1)
 
-      frame = ReqServerSentEvents.Frame.parse(~s(event: session.idle\ndata: {"type":"session.idle"}))
+      frame =
+        ReqServerSentEvents.Frame.parse(~s(event: session.idle\ndata: {"type":"session.idle"}))
 
       assert %{event: "session.idle", data: ~s({"type":"session.idle"})} = frame
     end

--- a/elixir/symphony_elixir/AGENTS.md
+++ b/elixir/symphony_elixir/AGENTS.md
@@ -7,7 +7,7 @@
 
 # Symphony Elixir
 
-This directory contains the Elixir agent orchestration service that polls Linear, creates per-issue workspaces, and runs Codex in app-server mode.
+This directory contains the Elixir agent orchestration service that polls Linear, creates per-issue workspaces, and runs OpenCode through the in-repo `opencode_client`.
 
 ## Environment
 
@@ -25,7 +25,7 @@ This directory contains the Elixir agent orchestration service that polls Linear
     change where practical so the spec stays current.
 - Prefer adding config access through `SymphonyElixir.Config` instead of ad-hoc env reads.
 - Workspace safety is critical:
-  - Never run Codex turn cwd in source repo.
+  - Never run agent turns in the source repo.
   - Workspaces must stay under configured workspace root.
 - Orchestrator behavior is stateful and concurrency-sensitive; preserve retry, reconciliation, and cleanup semantics.
 - Follow `docs/logging.md` for logging conventions and required issue/session context fields.

--- a/elixir/symphony_elixir/README.md
+++ b/elixir/symphony_elixir/README.md
@@ -24,10 +24,9 @@ This project is a port of the original [OpenAI Symphony](https://github.com/open
 
 1. Polls Linear for candidate work
 2. Creates a workspace per issue
-3. Launches Codex in [App Server mode](https://developers.openai.com/codex/app-server/) inside the
-   workspace
-4. Sends a workflow prompt to Codex
-5. Keeps Codex working on the issue until the work is done
+3. Starts or connects to an OpenCode HTTP server
+4. Creates an OpenCode session for the issue workspace and sends the workflow prompt
+5. Keeps OpenCode working on the issue until the work is done
 
 During app-server sessions, Symphony also serves a client-side `linear_graphql` tool so that repo
 skills can make raw Linear GraphQL calls.
@@ -35,7 +34,7 @@ skills can make raw Linear GraphQL calls.
 If a claimed issue moves to a terminal state (`Done`, `Closed`, `Cancelled`, or `Duplicate`),
 Symphony stops the active agent for that issue and cleans up matching workspaces.
 
-If Codex reports that operator input, approval, or MCP elicitation is required, Symphony keeps the
+If OpenCode reports that operator input or permission is required, Symphony keeps the
 issue claimed and exposes it as blocked in the runtime state, JSON API, and dashboard. Blocked
 entries are in memory only; restarting the orchestrator clears that blocked map, so any still-active
 Linear issue can become a dispatch candidate again after restart.
@@ -95,7 +94,7 @@ Optional flags:
 - `--port` also starts the Phoenix observability service (default: disabled)
 
 The `WORKFLOW.md` file uses YAML front matter for configuration, plus a Markdown body used as the
-Codex session prompt.
+agent session prompt.
 
 Minimal example:
 
@@ -112,8 +111,6 @@ hooks:
 agent:
   max_concurrent_agents: 10
   max_turns: 20
-codex:
-  command: codex app-server
 ---
 
 You are working on a Linear issue {{ issue.identifier }}.
@@ -124,22 +121,17 @@ Title: {{ issue.title }} Body: {{ issue.description }}
 Notes:
 
 - If a value is missing, defaults are used.
+- By default Symphony starts `opencode serve` through `opencode_client`. Set `OPENCODE_BASE_URL`
+  to connect to an already-running OpenCode server instead.
+- Set `OPENCODE_AUTH_USER` and `OPENCODE_AUTH_PASS` when the target OpenCode server requires
+  HTTP basic auth.
 - `tracker.required_labels` is optional. When set, an issue must have every
   configured label to dispatch or continue running. Label matching ignores
   case and surrounding whitespace. A blank configured label matches no issue.
-- Safer Codex defaults are used when policy fields are omitted:
-  - `codex.approval_policy` defaults to `{"reject":{"sandbox_approval":true,"rules":true,"mcp_elicitations":true}}`
-  - `codex.thread_sandbox` defaults to `workspace-write`
-  - `codex.turn_sandbox_policy` defaults to a `workspaceWrite` policy rooted at the current issue workspace
-- Supported `codex.approval_policy` values depend on the targeted Codex app-server version. In the current local Codex schema, string values include `untrusted`, `on-failure`, `on-request`, and `never`, and object-form `reject` is also supported.
-- Supported `codex.thread_sandbox` values: `read-only`, `workspace-write`, `danger-full-access`.
-- When `codex.turn_sandbox_policy` is set explicitly, Symphony passes the map through to Codex
-  unchanged. Compatibility then depends on the targeted Codex app-server version rather than local
-  Symphony validation.
-- Workflows that run package managers or other commands that resolve external hosts should set
-  `networkAccess: true` in `codex.turn_sandbox_policy`; otherwise DNS/network access may be denied
-  by the Codex turn sandbox.
-- `agent.max_turns` caps how many back-to-back Codex turns Symphony will run in a single agent
+- The historical `codex.*` config section is still parsed for compatibility. The active OpenCode
+  backend currently uses `codex.turn_timeout_ms` as the turn timeout; the old Codex command,
+  approval, and sandbox fields are not used by normal dispatch.
+- `agent.max_turns` caps how many back-to-back OpenCode turns Symphony will run in a single agent
   invocation when a turn completes normally but the issue is still in an active state. Default: `20`.
 - If the Markdown body is blank, Symphony uses a default prompt template that includes the issue
   identifier, title, and body.
@@ -149,9 +141,7 @@ Notes:
   the project dependencies in `hooks.after_create` before invoking `mise` later from other hooks.
 - `tracker.api_key` reads from `LINEAR_API_KEY` when unset or when value is `$LINEAR_API_KEY`.
 - For path values, `~` is expanded to the home directory.
-- For env-backed path values, use `$VAR`. `workspace.root` resolves `$VAR` before path handling,
-  while `codex.command` stays a shell command string and any `$VAR` expansion there happens in the
-  launched shell.
+- For env-backed path values, use `$VAR`. `workspace.root` resolves `$VAR` before path handling.
 
 ```yaml
 tracker:
@@ -161,8 +151,6 @@ workspace:
 hooks:
   after_create: |
     git clone --depth 1 "$SOURCE_REPO_URL" .
-codex:
-  command: '$CODEX_BIN --config ''model="gpt-5.5"'' app-server'
 ```
 
 - If `WORKFLOW.md` is missing or has invalid YAML at startup, Symphony does not boot.
@@ -186,7 +174,7 @@ The observability UI now runs on a minimal Phoenix stack:
 - `lib/`: application code and Mix tasks
 - `test/`: ExUnit coverage for runtime behavior
 - `WORKFLOW.md`: in-repo workflow contract used by local runs
-- `../.codex/`: repository-local Codex skills and setup helpers
+- `../.codex/`: repository-local agent skills and setup helpers
 
 ## Testing
 
@@ -195,7 +183,7 @@ make all
 ```
 
 Run the real external end-to-end test only when you want Symphony to create disposable Linear
-resources and launch a real `codex app-server` session:
+resources and launch a real OpenCode session:
 
 ```bash
 cd elixir
@@ -215,15 +203,15 @@ Optional environment variables:
 
 If `SYMPHONY_LIVE_SSH_WORKER_HOSTS` is unset, the SSH scenario uses `docker compose` to start two
 disposable SSH workers on `localhost:<port>`. The live test generates a temporary SSH keypair,
-mounts the host `~/.codex/auth.json` into each worker, verifies that Symphony can talk to them
-over real SSH, then runs the same orchestration flow against those worker addresses. This keeps
-the transport representative without depending on long-lived external machines.
+verifies that Symphony can talk to them over real SSH, then runs the same orchestration flow
+against those worker addresses. This keeps the transport representative without depending on
+long-lived external machines.
 
 Set `SYMPHONY_LIVE_SSH_WORKER_HOSTS` if you want `make e2e` to target real SSH hosts instead.
 
 The live test creates a temporary Linear project and issue, writes a temporary `WORKFLOW.md`, runs
-a real agent turn, verifies the workspace side effect, requires Codex to comment on and close the
-Linear issue, then marks the project completed so the run remains visible in Linear.
+a real agent turn, verifies the workspace side effect, requires the agent to comment on and close
+the Linear issue, then marks the project completed so the run remains visible in Linear.
 
 ## FAQ
 
@@ -235,8 +223,8 @@ actively running subagents, which is very useful during development.
 
 ### What's the easiest way to set this up for my own codebase?
 
-Launch `codex` in your repo, give it the URL to the Symphony repo, and ask it to set things up for
-you.
+Launch your coding agent in your repo, give it the URL to the Symphony repo, and ask it to set
+things up for you.
 
 ## License
 

--- a/elixir/symphony_elixir/docs/SPEC.md
+++ b/elixir/symphony_elixir/docs/SPEC.md
@@ -11,6 +11,11 @@ Status: Draft v1 (language-agnostic)
 
 Purpose: Define a service that orchestrates coding agents to get project work done.
 
+Implementation note: this repository's current Elixir implementation dispatches normal agent runs
+through OpenCode using the in-repository `opencode_client`. Sections that discuss the Codex
+app-server protocol describe the original/legacy integration contract and compatibility vocabulary
+until this language-neutral specification is fully revised.
+
 ## Normative Language
 
 The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and

--- a/elixir/symphony_elixir/docs/logging.md
+++ b/elixir/symphony_elixir/docs/logging.md
@@ -1,6 +1,6 @@
 # Logging Best Practices
 
-This guide defines logging conventions for Symphony so Codex can diagnose failures quickly.
+This guide defines logging conventions for Symphony so agent runtime failures can be diagnosed quickly.
 
 ## Goals
 
@@ -15,9 +15,9 @@ When logging issue-related work, include both identifiers:
 - `issue_id`: Linear internal UUID (stable foreign key).
 - `issue_identifier`: human ticket key (for example `MT-620`).
 
-When logging Codex execution lifecycle events, include:
+When logging OpenCode execution lifecycle events, include:
 
-- `session_id`: combined Codex thread/turn identifier.
+- `session_id`: OpenCode session identifier.
 
 ## Message Design
 
@@ -30,11 +30,15 @@ When logging Codex execution lifecycle events, include:
 
 - `AgentRunner`: log start/completion/failure with issue context, plus `session_id` when known.
 - `Orchestrator`: log dispatch, retry, terminal/non-active transitions, and worker exits with issue context. Include `session_id` whenever running-entry data has it.
-- `Codex.AppServer`: log session start/completion/error with issue context and `session_id`.
+- `Opencode.AppServer`: log session start/completion/error with issue context and `session_id`.
 
 ## Checklist For New Logs
 
 - Is this event tied to a Linear issue? Include `issue_id` and `issue_identifier`.
-- Is this event tied to a Codex session? Include `session_id`.
+- Is this event tied to an OpenCode session? Include `session_id`.
 - Is the failure reason present and concise?
 - Is the message format consistent with existing lifecycle logs?
+
+Some status payload keys and pubsub tuples still use `codex` in their names for compatibility with
+existing dashboard consumers. Treat those names as compatibility vocabulary, not as evidence that
+normal dispatch uses the legacy Codex backend.

--- a/elixir/symphony_elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/agent_runner.ex
@@ -32,9 +32,12 @@ defmodule SymphonyElixir.AgentRunner do
   @spec run(map(), pid() | nil, keyword()) :: :ok | no_return()
   def run(issue, update_recipient \\ nil, opts \\ []) do
     # The orchestrator owns host retries so one worker lifetime never hops machines.
-    worker_host = selected_worker_host(Keyword.get(opts, :worker_host), Config.settings!().worker.ssh_hosts)
+    worker_host =
+      selected_worker_host(Keyword.get(opts, :worker_host), Config.settings!().worker.ssh_hosts)
 
-    Logger.info("Starting agent run for #{issue_context(issue)} worker_host=#{worker_host_for_log(worker_host)}")
+    Logger.info(
+      "Starting agent run for #{issue_context(issue)} worker_host=#{worker_host_for_log(worker_host)}"
+    )
 
     case run_on_worker_host(issue, update_recipient, opts, worker_host) do
       :ok ->
@@ -47,7 +50,9 @@ defmodule SymphonyElixir.AgentRunner do
   end
 
   defp run_on_worker_host(issue, update_recipient, opts, worker_host) do
-    Logger.info("Starting worker attempt for #{issue_context(issue)} worker_host=#{worker_host_for_log(worker_host)}")
+    Logger.info(
+      "Starting worker attempt for #{issue_context(issue)} worker_host=#{worker_host_for_log(worker_host)}"
+    )
 
     case Workspace.create_for_issue(issue, worker_host) do
       {:ok, workspace} ->
@@ -98,12 +103,24 @@ defmodule SymphonyElixir.AgentRunner do
 
   defp run_opencode_turns(workspace, issue, update_recipient, opts, worker_host) do
     max_turns = Keyword.get(opts, :max_turns, Config.settings!().agent.max_turns)
-    issue_state_fetcher = Keyword.get(opts, :issue_state_fetcher, &Tracker.fetch_issue_states_by_ids/1)
+
+    issue_state_fetcher =
+      Keyword.get(opts, :issue_state_fetcher, &Tracker.fetch_issue_states_by_ids/1)
+
     app_server_opts = app_server_opts(opts, worker_host, issue)
 
     with {:ok, session} <- AppServer.start_session(workspace, app_server_opts) do
       try do
-        do_run_opencode_turns(session, workspace, issue, update_recipient, opts, issue_state_fetcher, 1, max_turns)
+        do_run_opencode_turns(
+          session,
+          workspace,
+          issue,
+          update_recipient,
+          opts,
+          issue_state_fetcher,
+          1,
+          max_turns
+        )
       after
         AppServer.stop_session(session)
       end
@@ -131,11 +148,15 @@ defmodule SymphonyElixir.AgentRunner do
                on_message: opencode_message_handler(update_recipient, issue)
              )
            ) do
-      Logger.info("Completed agent run for #{issue_context(issue)} session_id=#{turn_session[:session_id]} workspace=#{workspace} turn=#{turn_number}/#{max_turns}")
+      Logger.info(
+        "Completed agent run for #{issue_context(issue)} session_id=#{turn_session[:session_id]} workspace=#{workspace} turn=#{turn_number}/#{max_turns}"
+      )
 
       case continue_with_issue?(issue, issue_state_fetcher) do
         {:continue, refreshed_issue} when turn_number < max_turns ->
-          Logger.info("Continuing agent run for #{issue_context(refreshed_issue)} after normal turn completion turn=#{turn_number}/#{max_turns}")
+          Logger.info(
+            "Continuing agent run for #{issue_context(refreshed_issue)} after normal turn completion turn=#{turn_number}/#{max_turns}"
+          )
 
           do_run_opencode_turns(
             app_session,
@@ -149,7 +170,9 @@ defmodule SymphonyElixir.AgentRunner do
           )
 
         {:continue, refreshed_issue} ->
-          Logger.info("Reached agent.max_turns for #{issue_context(refreshed_issue)} with issue still active; returning control to orchestrator")
+          Logger.info(
+            "Reached agent.max_turns for #{issue_context(refreshed_issue)} with issue still active; returning control to orchestrator"
+          )
 
           :ok
 
@@ -176,7 +199,8 @@ defmodule SymphonyElixir.AgentRunner do
     """
   end
 
-  defp continue_with_issue?(%Issue{id: issue_id} = issue, issue_state_fetcher) when is_binary(issue_id) do
+  defp continue_with_issue?(%Issue{id: issue_id} = issue, issue_state_fetcher)
+       when is_binary(issue_id) do
     case issue_state_fetcher.([issue_id]) do
       {:ok, [%Issue{} = refreshed_issue | _]} ->
         if active_issue_state?(refreshed_issue.state) and issue_routable?(refreshed_issue) do

--- a/elixir/symphony_elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/agent_runner.ex
@@ -1,13 +1,25 @@
 defmodule SymphonyElixir.AgentRunner do
   @moduledoc """
-  Executes a single Linear issue in its workspace with Codex.
+  Executes a single Linear issue in its workspace with OpenCode.
   """
 
   require Logger
-  alias SymphonyElixir.Codex.AppServer
+  alias SymphonyElixir.Opencode.AppServer
   alias SymphonyElixir.{Config, Linear.Issue, PromptBuilder, Tracker, Workspace}
 
   @type worker_host :: String.t() | nil
+  @opencode_app_server_opts [
+    :auth,
+    :base_url,
+    :client_opts,
+    :event_stream,
+    :receive_timeout,
+    :server_config,
+    :server_module,
+    :server_opts,
+    :session_api,
+    :turn_timeout_ms
+  ]
 
   @doc false
   @spec continue_with_issue_for_test(Issue.t(), ([String.t()] -> term())) ::
@@ -18,13 +30,13 @@ defmodule SymphonyElixir.AgentRunner do
   end
 
   @spec run(map(), pid() | nil, keyword()) :: :ok | no_return()
-  def run(issue, codex_update_recipient \\ nil, opts \\ []) do
+  def run(issue, update_recipient \\ nil, opts \\ []) do
     # The orchestrator owns host retries so one worker lifetime never hops machines.
     worker_host = selected_worker_host(Keyword.get(opts, :worker_host), Config.settings!().worker.ssh_hosts)
 
     Logger.info("Starting agent run for #{issue_context(issue)} worker_host=#{worker_host_for_log(worker_host)}")
 
-    case run_on_worker_host(issue, codex_update_recipient, opts, worker_host) do
+    case run_on_worker_host(issue, update_recipient, opts, worker_host) do
       :ok ->
         :ok
 
@@ -34,16 +46,16 @@ defmodule SymphonyElixir.AgentRunner do
     end
   end
 
-  defp run_on_worker_host(issue, codex_update_recipient, opts, worker_host) do
+  defp run_on_worker_host(issue, update_recipient, opts, worker_host) do
     Logger.info("Starting worker attempt for #{issue_context(issue)} worker_host=#{worker_host_for_log(worker_host)}")
 
     case Workspace.create_for_issue(issue, worker_host) do
       {:ok, workspace} ->
-        send_worker_runtime_info(codex_update_recipient, issue, worker_host, workspace)
+        send_worker_runtime_info(update_recipient, issue, worker_host, workspace)
 
         try do
           with :ok <- Workspace.run_before_run_hook(workspace, issue, worker_host) do
-            run_codex_turns(workspace, issue, codex_update_recipient, opts, worker_host)
+            run_opencode_turns(workspace, issue, update_recipient, opts, worker_host)
           end
         after
           Workspace.run_after_run_hook(workspace, issue, worker_host)
@@ -54,19 +66,19 @@ defmodule SymphonyElixir.AgentRunner do
     end
   end
 
-  defp codex_message_handler(recipient, issue) do
+  defp opencode_message_handler(recipient, issue) do
     fn message ->
-      send_codex_update(recipient, issue, message)
+      send_agent_update(recipient, issue, message)
     end
   end
 
-  defp send_codex_update(recipient, %Issue{id: issue_id}, message)
+  defp send_agent_update(recipient, %Issue{id: issue_id}, message)
        when is_binary(issue_id) and is_pid(recipient) do
     send(recipient, {:codex_worker_update, issue_id, message})
     :ok
   end
 
-  defp send_codex_update(_recipient, _issue, _message), do: :ok
+  defp send_agent_update(_recipient, _issue, _message), do: :ok
 
   defp send_worker_runtime_info(recipient, %Issue{id: issue_id}, worker_host, workspace)
        when is_binary(issue_id) and is_pid(recipient) and is_binary(workspace) do
@@ -84,20 +96,30 @@ defmodule SymphonyElixir.AgentRunner do
 
   defp send_worker_runtime_info(_recipient, _issue, _worker_host, _workspace), do: :ok
 
-  defp run_codex_turns(workspace, issue, codex_update_recipient, opts, worker_host) do
+  defp run_opencode_turns(workspace, issue, update_recipient, opts, worker_host) do
     max_turns = Keyword.get(opts, :max_turns, Config.settings!().agent.max_turns)
     issue_state_fetcher = Keyword.get(opts, :issue_state_fetcher, &Tracker.fetch_issue_states_by_ids/1)
+    app_server_opts = app_server_opts(opts, worker_host, issue)
 
-    with {:ok, session} <- AppServer.start_session(workspace, worker_host: worker_host) do
+    with {:ok, session} <- AppServer.start_session(workspace, app_server_opts) do
       try do
-        do_run_codex_turns(session, workspace, issue, codex_update_recipient, opts, issue_state_fetcher, 1, max_turns)
+        do_run_opencode_turns(session, workspace, issue, update_recipient, opts, issue_state_fetcher, 1, max_turns)
       after
         AppServer.stop_session(session)
       end
     end
   end
 
-  defp do_run_codex_turns(app_session, workspace, issue, codex_update_recipient, opts, issue_state_fetcher, turn_number, max_turns) do
+  defp do_run_opencode_turns(
+         app_session,
+         workspace,
+         issue,
+         update_recipient,
+         opts,
+         issue_state_fetcher,
+         turn_number,
+         max_turns
+       ) do
     prompt = build_turn_prompt(issue, opts, turn_number, max_turns)
 
     with {:ok, turn_session} <-
@@ -105,7 +127,9 @@ defmodule SymphonyElixir.AgentRunner do
              app_session,
              prompt,
              issue,
-             on_message: codex_message_handler(codex_update_recipient, issue)
+             app_server_turn_opts(opts,
+               on_message: opencode_message_handler(update_recipient, issue)
+             )
            ) do
       Logger.info("Completed agent run for #{issue_context(issue)} session_id=#{turn_session[:session_id]} workspace=#{workspace} turn=#{turn_number}/#{max_turns}")
 
@@ -113,11 +137,11 @@ defmodule SymphonyElixir.AgentRunner do
         {:continue, refreshed_issue} when turn_number < max_turns ->
           Logger.info("Continuing agent run for #{issue_context(refreshed_issue)} after normal turn completion turn=#{turn_number}/#{max_turns}")
 
-          do_run_codex_turns(
+          do_run_opencode_turns(
             app_session,
             workspace,
             refreshed_issue,
-            codex_update_recipient,
+            update_recipient,
             opts,
             issue_state_fetcher,
             turn_number + 1,
@@ -144,7 +168,7 @@ defmodule SymphonyElixir.AgentRunner do
     """
     Continuation guidance:
 
-    - The previous Codex turn completed normally, but the Linear issue is still in an active state.
+    - The previous OpenCode turn completed normally, but the Linear issue is still in an active state.
     - This is continuation turn ##{turn_number} of #{max_turns} for the current agent run.
     - Resume from the current workspace and workpad state instead of restarting from scratch.
     - The original task instructions and prior turn context are already present in this thread, so do not restate them before acting.
@@ -183,6 +207,26 @@ defmodule SymphonyElixir.AgentRunner do
   defp issue_routable?(%Issue{} = issue) do
     Issue.routable?(issue, Config.settings!().tracker.required_labels)
   end
+
+  defp app_server_opts(opts, worker_host, issue) do
+    opts
+    |> Keyword.take(@opencode_app_server_opts)
+    |> Keyword.put(:worker_host, worker_host)
+    |> Keyword.put_new(:title, issue_title(issue))
+  end
+
+  defp app_server_turn_opts(opts, extra_opts) do
+    opts
+    |> Keyword.take(@opencode_app_server_opts)
+    |> Keyword.merge(extra_opts)
+  end
+
+  defp issue_title(%Issue{identifier: identifier, title: title})
+       when is_binary(identifier) and is_binary(title) do
+    "#{identifier}: #{title}"
+  end
+
+  defp issue_title(_issue), do: "Symphony agent run"
 
   defp selected_worker_host(nil, []), do: nil
 

--- a/elixir/symphony_elixir/lib/symphony_elixir/opencode/agent_runner.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/opencode/agent_runner.ex
@@ -7,12 +7,9 @@ defmodule SymphonyElixir.Opencode.AgentRunner do
   @moduledoc """
   Executes a single Linear issue in its workspace using the OpenCode HTTP server.
 
-  This module mirrors `SymphonyElixir.AgentRunner` but replaces the Codex app-server
-  subprocess with HTTP calls to a running `opencode serve` instance via
-  `SymphonyElixir.Opencode.AppServer`.
-
-  The orchestrator can select this runner instead of the Codex-backed one by setting
-  the `OPENCODE_BASE_URL` environment variable (or passing `base_url` in opts).
+  `SymphonyElixir.AgentRunner` is now the canonical OpenCode-backed runner.
+  This module remains as a compatibility runner around the same OpenCode app-server
+  integration vocabulary.
   """
 
   require Logger

--- a/elixir/symphony_elixir/lib/symphony_elixir/opencode/agent_runner.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/opencode/agent_runner.ex
@@ -35,7 +35,9 @@ defmodule SymphonyElixir.Opencode.AgentRunner do
 
       {:error, reason} ->
         Logger.error("OpenCode agent run failed for #{issue_context(issue)}: #{inspect(reason)}")
-        raise RuntimeError, "OpenCode agent run failed for #{issue_context(issue)}: #{inspect(reason)}"
+
+        raise RuntimeError,
+              "OpenCode agent run failed for #{issue_context(issue)}: #{inspect(reason)}"
     end
   end
 
@@ -91,11 +93,23 @@ defmodule SymphonyElixir.Opencode.AgentRunner do
 
   defp run_opencode_turns(workspace, issue, codex_update_recipient, opts) do
     max_turns = Keyword.get(opts, :max_turns, Config.settings!().agent.max_turns)
-    issue_state_fetcher = Keyword.get(opts, :issue_state_fetcher, &Tracker.fetch_issue_states_by_ids/1)
 
-    with {:ok, session} <- AppServer.start_session(workspace, title: "#{issue.identifier}: #{issue.title}") do
+    issue_state_fetcher =
+      Keyword.get(opts, :issue_state_fetcher, &Tracker.fetch_issue_states_by_ids/1)
+
+    with {:ok, session} <-
+           AppServer.start_session(workspace, title: "#{issue.identifier}: #{issue.title}") do
       try do
-        do_run_opencode_turns(session, workspace, issue, codex_update_recipient, opts, issue_state_fetcher, 1, max_turns)
+        do_run_opencode_turns(
+          session,
+          workspace,
+          issue,
+          codex_update_recipient,
+          opts,
+          issue_state_fetcher,
+          1,
+          max_turns
+        )
       after
         AppServer.stop_session(session)
       end
@@ -121,11 +135,15 @@ defmodule SymphonyElixir.Opencode.AgentRunner do
              issue,
              on_message: codex_message_handler(codex_update_recipient, issue)
            ) do
-      Logger.info("Completed OpenCode agent run for #{issue_context(issue)} session_id=#{turn_session[:session_id]} workspace=#{workspace} turn=#{turn_number}/#{max_turns}")
+      Logger.info(
+        "Completed OpenCode agent run for #{issue_context(issue)} session_id=#{turn_session[:session_id]} workspace=#{workspace} turn=#{turn_number}/#{max_turns}"
+      )
 
       case continue_with_issue?(issue, issue_state_fetcher) do
         {:continue, refreshed_issue} when turn_number < max_turns ->
-          Logger.info("Continuing OpenCode agent run for #{issue_context(refreshed_issue)} after normal turn completion turn=#{turn_number}/#{max_turns}")
+          Logger.info(
+            "Continuing OpenCode agent run for #{issue_context(refreshed_issue)} after normal turn completion turn=#{turn_number}/#{max_turns}"
+          )
 
           do_run_opencode_turns(
             app_session,
@@ -139,7 +157,10 @@ defmodule SymphonyElixir.Opencode.AgentRunner do
           )
 
         {:continue, refreshed_issue} ->
-          Logger.info("Reached agent.max_turns for #{issue_context(refreshed_issue)} with issue still active; returning control to orchestrator")
+          Logger.info(
+            "Reached agent.max_turns for #{issue_context(refreshed_issue)} with issue still active; returning control to orchestrator"
+          )
+
           :ok
 
         {:done, _refreshed_issue} ->
@@ -165,7 +186,8 @@ defmodule SymphonyElixir.Opencode.AgentRunner do
     """
   end
 
-  defp continue_with_issue?(%Issue{id: issue_id} = issue, issue_state_fetcher) when is_binary(issue_id) do
+  defp continue_with_issue?(%Issue{id: issue_id} = issue, issue_state_fetcher)
+       when is_binary(issue_id) do
     case issue_state_fetcher.([issue_id]) do
       {:ok, [%Issue{} = refreshed_issue | _]} ->
         if active_issue_state?(refreshed_issue.state) and issue_routable?(refreshed_issue) do

--- a/elixir/symphony_elixir/lib/symphony_elixir/opencode/app_server.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/opencode/app_server.ex
@@ -94,16 +94,36 @@ defmodule SymphonyElixir.Opencode.AppServer do
     try do
       case session_api.session_prompt_async(session_id, body, client) do
         :ok ->
-          Logger.info("OpenCode prompt accepted for #{issue_context(issue)} session_id=#{session_id} workspace=#{workspace}")
+          Logger.info(
+            "OpenCode prompt accepted for #{issue_context(issue)} session_id=#{session_id} workspace=#{workspace}"
+          )
 
           case await_turn_completion(session_id, on_message, session.metadata, timeout_ms, issue) do
             {:ok, result} ->
-              Logger.info("OpenCode session completed for #{issue_context(issue)} session_id=#{session_id}")
-              {:ok, %{result: result, session_id: session_id, thread_id: session_id, turn_id: session_id}}
+              Logger.info(
+                "OpenCode session completed for #{issue_context(issue)} session_id=#{session_id}"
+              )
+
+              {:ok,
+               %{
+                 result: result,
+                 session_id: session_id,
+                 thread_id: session_id,
+                 turn_id: session_id
+               }}
 
             {:error, reason} ->
-              Logger.warning("OpenCode session ended with error for #{issue_context(issue)} session_id=#{session_id}: #{inspect(reason)}")
-              emit_message(on_message, :turn_ended_with_error, %{session_id: session_id, reason: reason}, session.metadata)
+              Logger.warning(
+                "OpenCode session ended with error for #{issue_context(issue)} session_id=#{session_id}: #{inspect(reason)}"
+              )
+
+              emit_message(
+                on_message,
+                :turn_ended_with_error,
+                %{session_id: session_id, reason: reason},
+                session.metadata
+              )
+
               {:error, reason}
           end
 
@@ -129,12 +149,18 @@ defmodule SymphonyElixir.Opencode.AppServer do
           :ok
 
         {:error, reason} ->
-          Logger.warning("OpenCode session delete failed for session_id=#{session_id}: #{inspect(reason)}")
+          Logger.warning(
+            "OpenCode session delete failed for session_id=#{session_id}: #{inspect(reason)}"
+          )
+
           :ok
       end
     catch
       kind, reason ->
-        Logger.warning("OpenCode session delete raised for session_id=#{session_id}: #{inspect({kind, reason})}")
+        Logger.warning(
+          "OpenCode session delete raised for session_id=#{session_id}: #{inspect({kind, reason})}"
+        )
+
         :ok
     after
       stop_connection_server(session)
@@ -315,7 +341,8 @@ defmodule SymphonyElixir.Opencode.AppServer do
           {:error, {:invalid_workspace_cwd, :symlink_escape, expanded_workspace, canonical_root}}
 
         true ->
-          {:error, {:invalid_workspace_cwd, :outside_workspace_root, canonical_workspace, canonical_root}}
+          {:error,
+           {:invalid_workspace_cwd, :outside_workspace_root, canonical_workspace, canonical_root}}
       end
     else
       {:error, {:path_canonicalize_failed, path, reason}} ->
@@ -389,7 +416,9 @@ defmodule SymphonyElixir.Opencode.AppServer do
         type = event_type(event)
         data = event_data(event)
 
-        Logger.debug("OpenCode SSE event for #{issue_context(issue)} session_id=#{session_id} type=#{inspect(type)}")
+        Logger.debug(
+          "OpenCode SSE event for #{issue_context(issue)} session_id=#{session_id} type=#{inspect(type)}"
+        )
 
         handle_sse_event(session_id, type, data, on_message, metadata, deadline, issue)
 
@@ -401,38 +430,64 @@ defmodule SymphonyElixir.Opencode.AppServer do
     end
   end
 
-  defp handle_sse_event(session_id, "session.idle", data, on_message, metadata, _deadline, _issue) do
+  defp handle_sse_event(session_id, "session.idle", data, on_message, metadata, deadline, issue) do
     if event_for_session?(data, session_id) do
       emit_message(on_message, :turn_completed, %{session_id: session_id}, metadata)
       {:ok, :turn_completed}
     else
-      {:error, {:unexpected_session_idle, data}}
+      continue_after_notification(
+        session_id,
+        "session.idle",
+        data,
+        on_message,
+        metadata,
+        deadline,
+        issue
+      )
     end
   end
 
-  defp handle_sse_event(session_id, "session.error", data, on_message, metadata, _deadline, _issue) do
+  defp handle_sse_event(session_id, "session.error", data, on_message, metadata, deadline, issue) do
     if event_for_session?(data, session_id) do
       error = event_error(data)
       emit_message(on_message, :turn_failed, %{session_id: session_id, error: error}, metadata)
       {:error, {:session_error, error}}
     else
-      {:error, {:unexpected_session_error, data}}
+      continue_after_notification(
+        session_id,
+        "session.error",
+        data,
+        on_message,
+        metadata,
+        deadline,
+        issue
+      )
     end
   end
 
-  defp handle_sse_event(session_id, type, data, on_message, metadata, _deadline, _issue)
+  defp handle_sse_event(session_id, type, data, on_message, metadata, deadline, issue)
        when type in ["permission.asked", "question.asked"] do
     if event_for_session?(data, session_id) do
       reason = {:interactive_input_required, type, data}
-      emit_message(on_message, :turn_input_required, %{session_id: session_id, reason: reason}, metadata)
+
+      emit_message(
+        on_message,
+        :turn_input_required,
+        %{session_id: session_id, reason: reason},
+        metadata
+      )
+
       {:error, reason}
     else
-      emit_message(on_message, :notification, %{type: type, payload: data}, metadata)
-      {:error, {:unexpected_interactive_event, type, data}}
+      continue_after_notification(session_id, type, data, on_message, metadata, deadline, issue)
     end
   end
 
   defp handle_sse_event(session_id, type, data, on_message, metadata, deadline, issue) do
+    continue_after_notification(session_id, type, data, on_message, metadata, deadline, issue)
+  end
+
+  defp continue_after_notification(session_id, type, data, on_message, metadata, deadline, issue) do
     emit_message(on_message, :notification, %{type: type, payload: data}, metadata)
     now = System.monotonic_time(:millisecond)
 
@@ -484,7 +539,12 @@ defmodule SymphonyElixir.Opencode.AppServer do
   end
 
   defp emit_message(on_message, event, details, metadata) when is_function(on_message, 1) do
-    message = metadata |> Map.merge(details) |> Map.put(:event, event) |> Map.put(:timestamp, DateTime.utc_now())
+    message =
+      metadata
+      |> Map.merge(details)
+      |> Map.put(:event, event)
+      |> Map.put(:timestamp, DateTime.utc_now())
+
     on_message.(message)
   end
 

--- a/elixir/symphony_elixir/lib/symphony_elixir/opencode/app_server.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/opencode/app_server.ex
@@ -5,12 +5,11 @@
 
 defmodule SymphonyElixir.Opencode.AppServer do
   @moduledoc """
-  HTTP-based client for the OpenCode server, mirroring the Codex.AppServer interface.
+  HTTP-based client for the OpenCode server.
 
-  Instead of spawning a codex app-server subprocess over stdio, this module talks to
-  a running `opencode serve` instance via HTTP.  Session lifecycle maps as follows:
+  Session lifecycle maps as follows:
 
-    * `start_session/2` -> POST /session
+    * `start_session/2` -> start or connect to `opencode serve`, then POST /session
     * `run_turn/4`      -> POST /session/{id}/prompt_async + GET /event (SSE)
     * `stop_session/1`  -> DELETE /session/{id}
 
@@ -21,16 +20,20 @@ defmodule SymphonyElixir.Opencode.AppServer do
 
   require Logger
 
-  alias SymphonyElixir.{Config, Linear.Issue}
+  alias SymphonyElixir.{Config, Linear.Issue, PathSafety}
   alias OpencodeClient.EventStream
+  alias OpencodeClient.Server
   alias OpencodeClient.Generated.Session
 
-  @default_base_url "http://localhost:4096"
   @default_turn_timeout_ms 3_600_000
 
   @type session :: %{
           client: keyword(),
+          event_stream: module(),
           session_id: String.t(),
+          session_api: module(),
+          server: GenServer.server() | nil,
+          server_module: module(),
           workspace: Path.t(),
           metadata: map()
         }
@@ -48,38 +51,29 @@ defmodule SymphonyElixir.Opencode.AppServer do
 
   @spec start_session(Path.t(), keyword()) :: {:ok, session()} | {:error, term()}
   def start_session(workspace, opts \\ []) do
-    client = build_client(opts)
-    title = Keyword.get(opts, :title, "Symphony agent run")
-    body = %{title: title, directory: workspace}
+    worker_host = Keyword.get(opts, :worker_host)
 
-    case Session.session_create(body, client) do
-      {:ok, body_json} when is_map(body_json) ->
-        session_id = get_field(body_json, :id)
-
-        if is_binary(session_id) and session_id != "" do
-          {:ok,
-           %{
-             client: client,
-             session_id: session_id,
-             workspace: workspace,
-             metadata: %{opencode_session_id: session_id}
-           }}
-        else
-          {:error, {:invalid_session_response, body_json}}
-        end
-
-      {:ok, body} ->
-        {:error, {:session_create_failed, body}}
-
-      {:error, reason} ->
-        {:error, {:session_create_error, reason}}
+    with {:ok, expanded_workspace} <- validate_workspace_cwd(workspace, worker_host),
+         {:ok, connection} <- start_connection(opts, worker_host) do
+      create_session(expanded_workspace, opts, connection)
     end
   end
 
   @spec run_turn(session(), String.t(), map(), keyword()) :: {:ok, map()} | {:error, term()}
-  def run_turn(%{client: client, session_id: session_id, workspace: workspace} = session, prompt, issue, opts \\ []) do
+  def run_turn(
+        %{
+          client: client,
+          event_stream: event_stream,
+          session_api: session_api,
+          session_id: session_id,
+          workspace: workspace
+        } = session,
+        prompt,
+        issue,
+        opts \\ []
+      ) do
     on_message = Keyword.get(opts, :on_message, &default_on_message/1)
-    timeout_ms = turn_timeout_ms()
+    timeout_ms = turn_timeout_ms(opts)
 
     emit_message(
       on_message,
@@ -95,82 +89,286 @@ defmodule SymphonyElixir.Opencode.AppServer do
     body = %{parts: [%{type: "text", text: prompt}]}
 
     parent = self()
-    sse_pid = spawn_link(fn -> sse_listener(client, session_id, parent) end)
+    sse_pid = spawn_link(fn -> sse_listener(event_stream, client, parent) end)
 
-    case Session.session_prompt_async(session_id, body, client) do
-      :ok ->
-        Logger.info("OpenCode prompt accepted for #{issue_context(issue)} session_id=#{session_id} workspace=#{workspace}")
+    try do
+      case session_api.session_prompt_async(session_id, body, client) do
+        :ok ->
+          Logger.info("OpenCode prompt accepted for #{issue_context(issue)} session_id=#{session_id} workspace=#{workspace}")
 
-        case await_turn_completion(session_id, on_message, session.metadata, timeout_ms, issue) do
-          {:ok, result} ->
-            Logger.info("OpenCode session completed for #{issue_context(issue)} session_id=#{session_id}")
-            {:ok, %{result: result, session_id: session_id, thread_id: session_id, turn_id: session_id}}
+          case await_turn_completion(session_id, on_message, session.metadata, timeout_ms, issue) do
+            {:ok, result} ->
+              Logger.info("OpenCode session completed for #{issue_context(issue)} session_id=#{session_id}")
+              {:ok, %{result: result, session_id: session_id, thread_id: session_id, turn_id: session_id}}
 
-          {:error, reason} ->
-            Logger.warning("OpenCode session ended with error for #{issue_context(issue)} session_id=#{session_id}: #{inspect(reason)}")
-            emit_message(on_message, :turn_ended_with_error, %{session_id: session_id, reason: reason}, session.metadata)
-            {:error, reason}
-        end
+            {:error, reason} ->
+              Logger.warning("OpenCode session ended with error for #{issue_context(issue)} session_id=#{session_id}: #{inspect(reason)}")
+              emit_message(on_message, :turn_ended_with_error, %{session_id: session_id, reason: reason}, session.metadata)
+              {:error, reason}
+          end
 
-      {:ok, body} ->
-        stop_sse_listener(sse_pid)
-        {:error, {:prompt_async_failed, body}}
+        {:ok, body} ->
+          {:error, {:prompt_async_failed, body}}
 
-      {:error, reason} ->
-        stop_sse_listener(sse_pid)
-        {:error, {:prompt_async_error, reason}}
+        {:error, reason} ->
+          {:error, {:prompt_async_error, reason}}
+      end
+    after
+      stop_sse_listener(sse_pid)
     end
   end
 
   @spec stop_session(session()) :: :ok
-  def stop_session(%{client: client, session_id: session_id}) do
-    case Session.session_delete(session_id, client) do
-      {:ok, _} ->
-        :ok
+  def stop_session(%{client: client, session_api: session_api, session_id: session_id} = session) do
+    try do
+      case session_api.session_delete(session_id, client) do
+        {:ok, _} ->
+          :ok
 
-      :ok ->
-        :ok
+        :ok ->
+          :ok
 
-      {:error, reason} ->
-        Logger.warning("OpenCode session delete failed for session_id=#{session_id}: #{inspect(reason)}")
+        {:error, reason} ->
+          Logger.warning("OpenCode session delete failed for session_id=#{session_id}: #{inspect(reason)}")
+          :ok
+      end
+    catch
+      kind, reason ->
+        Logger.warning("OpenCode session delete raised for session_id=#{session_id}: #{inspect({kind, reason})}")
         :ok
+    after
+      stop_connection_server(session)
     end
   end
 
-  defp build_client(opts) do
-    base_url =
-      Keyword.get(opts, :base_url) ||
-        System.get_env("OPENCODE_BASE_URL") ||
-        @default_base_url
+  defp create_session(workspace, opts, %{client: client} = connection) do
+    session_api = Keyword.get(opts, :session_api, Session)
+    event_stream = Keyword.get(opts, :event_stream, EventStream)
+    title = Keyword.get(opts, :title, "Symphony agent run")
+    body = %{title: title, directory: workspace}
 
-    auth =
-      case {System.get_env("OPENCODE_AUTH_USER"), System.get_env("OPENCODE_AUTH_PASS")} do
-        {user, pass} when is_binary(user) and is_binary(pass) -> {:basic, user, pass}
-        _ -> nil
+    case session_api.session_create(body, client) do
+      {:ok, body_json} when is_map(body_json) ->
+        case get_field(body_json, :id) do
+          session_id when is_binary(session_id) and session_id != "" ->
+            {:ok,
+             %{
+               client: client,
+               event_stream: event_stream,
+               session_api: session_api,
+               session_id: session_id,
+               server: connection.server,
+               server_module: connection.server_module,
+               workspace: workspace,
+               metadata: session_metadata(session_id, client, connection)
+             }}
+
+          _ ->
+            stop_connection_server(connection)
+            {:error, {:invalid_session_response, body_json}}
+        end
+
+      {:ok, body} ->
+        stop_connection_server(connection)
+        {:error, {:session_create_failed, body}}
+
+      {:error, reason} ->
+        stop_connection_server(connection)
+        {:error, {:session_create_error, reason}}
+    end
+  end
+
+  defp start_connection(opts, worker_host) do
+    base_url = explicit_base_url(opts)
+
+    cond do
+      is_binary(base_url) ->
+        {:ok,
+         %{
+           client: build_client(opts, base_url),
+           server: nil,
+           server_module: Keyword.get(opts, :server_module, Server),
+           worker_host: worker_host
+         }}
+
+      is_binary(worker_host) ->
+        {:error, {:opencode_remote_worker_requires_base_url, worker_host}}
+
+      true ->
+        start_local_server(opts)
+    end
+  end
+
+  defp start_local_server(opts) do
+    server_module = Keyword.get(opts, :server_module, Server)
+
+    case server_module.start(server_opts(opts)) do
+      {:ok, server} ->
+        case server_module.url(server) do
+          base_url when is_binary(base_url) ->
+            {:ok,
+             %{
+               client: build_client(opts, base_url),
+               server: server,
+               server_module: server_module,
+               worker_host: nil
+             }}
+
+          {:error, reason} ->
+            stop_server(server_module, server)
+            {:error, {:opencode_server_url_failed, reason}}
+
+          other ->
+            stop_server(server_module, server)
+            {:error, {:opencode_server_url_failed, other}}
+        end
+
+      {:error, reason} ->
+        {:error, {:opencode_server_start_failed, reason}}
+    end
+  end
+
+  defp explicit_base_url(opts) do
+    opts
+    |> Keyword.get(:base_url, System.get_env("OPENCODE_BASE_URL"))
+    |> case do
+      url when is_binary(url) ->
+        url = String.trim(url)
+        if url == "", do: nil, else: url
+
+      _ ->
+        nil
+    end
+  end
+
+  defp build_client(opts, base_url) do
+    client_opts = Keyword.get(opts, :client_opts, [])
+    auth = Keyword.get(opts, :auth, Keyword.get(client_opts, :auth, env_auth()))
+
+    client_opts
+    |> Keyword.put(:base_url, base_url)
+    |> Keyword.put(:auth, auth)
+  end
+
+  defp env_auth do
+    case {System.get_env("OPENCODE_AUTH_USER"), System.get_env("OPENCODE_AUTH_PASS")} do
+      {user, pass} when is_binary(user) and is_binary(pass) -> {:basic, user, pass}
+      _ -> nil
+    end
+  end
+
+  defp server_opts(opts) do
+    opts
+    |> Keyword.get(:server_opts, [])
+    |> Keyword.put_new(:config, Keyword.get(opts, :server_config, %{}))
+  end
+
+  defp session_metadata(session_id, client, connection) do
+    %{
+      opencode_base_url: Keyword.get(client, :base_url),
+      opencode_session_id: session_id
+    }
+    |> maybe_put(:worker_host, connection.worker_host)
+    |> maybe_put(:opencode_server_pid, server_pid(connection.server))
+  end
+
+  defp server_pid(nil), do: nil
+
+  defp server_pid(server) when is_pid(server), do: inspect(server)
+
+  defp server_pid(_server), do: nil
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp stop_connection_server(%{server: nil}), do: :ok
+
+  defp stop_connection_server(%{server: server, server_module: server_module}) do
+    stop_server(server_module, server)
+  end
+
+  defp stop_server(server_module, server) do
+    server_module.stop(server)
+  catch
+    kind, reason ->
+      Logger.warning("OpenCode server stop failed: #{inspect({kind, reason})}")
+      :ok
+  end
+
+  defp validate_workspace_cwd(workspace, nil) when is_binary(workspace) do
+    expanded_workspace = Path.expand(workspace)
+    expanded_root = Path.expand(Config.settings!().workspace.root)
+    expanded_root_prefix = expanded_root <> "/"
+
+    with {:ok, canonical_workspace} <- PathSafety.canonicalize(expanded_workspace),
+         {:ok, canonical_root} <- PathSafety.canonicalize(expanded_root) do
+      canonical_root_prefix = canonical_root <> "/"
+
+      cond do
+        canonical_workspace == canonical_root ->
+          {:error, {:invalid_workspace_cwd, :workspace_root, canonical_workspace}}
+
+        String.starts_with?(canonical_workspace <> "/", canonical_root_prefix) ->
+          {:ok, canonical_workspace}
+
+        String.starts_with?(expanded_workspace <> "/", expanded_root_prefix) ->
+          {:error, {:invalid_workspace_cwd, :symlink_escape, expanded_workspace, canonical_root}}
+
+        true ->
+          {:error, {:invalid_workspace_cwd, :outside_workspace_root, canonical_workspace, canonical_root}}
       end
+    else
+      {:error, {:path_canonicalize_failed, path, reason}} ->
+        {:error, {:invalid_workspace_cwd, :path_unreadable, path, reason}}
+    end
+  end
 
-    [base_url: base_url, auth: auth]
+  defp validate_workspace_cwd(workspace, worker_host)
+       when is_binary(workspace) and is_binary(worker_host) do
+    cond do
+      String.trim(workspace) == "" ->
+        {:error, {:invalid_workspace_cwd, :empty_remote_workspace, worker_host}}
+
+      String.contains?(workspace, ["\n", "\r", <<0>>]) ->
+        {:error, {:invalid_workspace_cwd, :invalid_remote_workspace, worker_host, workspace}}
+
+      true ->
+        {:ok, workspace}
+    end
   end
 
   defp get_field(map, field) when is_map(map) do
     Map.get(map, field) || Map.get(map, Atom.to_string(field))
   end
 
-  defp turn_timeout_ms do
-    case Config.settings() do
-      {:ok, settings} -> settings.codex.turn_timeout_ms
-      _ -> @default_turn_timeout_ms
+  defp turn_timeout_ms(opts) do
+    case Keyword.get(opts, :turn_timeout_ms) do
+      timeout_ms when is_integer(timeout_ms) and timeout_ms > 0 ->
+        timeout_ms
+
+      _ ->
+        case Config.settings() do
+          {:ok, settings} -> settings.codex.turn_timeout_ms
+          _ -> @default_turn_timeout_ms
+        end
     end
   end
 
-  defp sse_listener(client, _session_id, parent) do
-    {:ok, stream} = EventStream.stream(client)
+  defp sse_listener(event_stream, client, parent) do
+    case event_stream.stream(client) do
+      {:ok, stream} ->
+        stream
+        |> Stream.each(fn event ->
+          send(parent, {:sse_event, event})
+        end)
+        |> Stream.run()
 
-    stream
-    |> Stream.each(fn event ->
-      send(parent, {:sse_event, event})
-    end)
-    |> Stream.run()
+      {:error, reason} ->
+        send(parent, {:sse_error, reason})
+
+      other ->
+        send(parent, {:sse_error, {:invalid_stream_response, other}})
+    end
   catch
     kind, reason ->
       send(parent, {:sse_error, {kind, reason}})
@@ -187,32 +385,13 @@ defmodule SymphonyElixir.Opencode.AppServer do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
 
     receive do
-      {:sse_event, %{type: "session.idle", data: %{"properties" => %{"sessionID" => ^session_id}}}} ->
-        emit_message(on_message, :turn_completed, %{session_id: session_id}, metadata)
-        {:ok, :turn_completed}
+      {:sse_event, event} ->
+        type = event_type(event)
+        data = event_data(event)
 
-      {:sse_event, %{type: "session.idle", data: %{"sessionID" => ^session_id}}} ->
-        emit_message(on_message, :turn_completed, %{session_id: session_id}, metadata)
-        {:ok, :turn_completed}
+        Logger.debug("OpenCode SSE event for #{issue_context(issue)} session_id=#{session_id} type=#{inspect(type)}")
 
-      {:sse_event, %{type: "session.error", data: %{"properties" => %{"sessionID" => ^session_id, "error" => error}}}} ->
-        emit_message(on_message, :turn_failed, %{session_id: session_id, error: error}, metadata)
-        {:error, {:session_error, error}}
-
-      {:sse_event, %{type: "session.error", data: %{"sessionID" => ^session_id}}} ->
-        emit_message(on_message, :turn_failed, %{session_id: session_id}, metadata)
-        {:error, {:session_error, :unknown}}
-
-      {:sse_event, %{type: type, data: data}} ->
-        Logger.debug("OpenCode SSE event for #{issue_context(issue)} session_id=#{session_id} type=#{type}")
-        emit_message(on_message, :notification, %{type: type, payload: data}, metadata)
-        now = System.monotonic_time(:millisecond)
-
-        if now >= deadline do
-          {:error, :turn_timeout}
-        else
-          await_turn_completion(session_id, on_message, metadata, deadline - now, issue)
-        end
+        handle_sse_event(session_id, type, data, on_message, metadata, deadline, issue)
 
       {:sse_error, reason} ->
         {:error, {:sse_stream_error, reason}}
@@ -220,6 +399,88 @@ defmodule SymphonyElixir.Opencode.AppServer do
       timeout_ms ->
         {:error, :turn_timeout}
     end
+  end
+
+  defp handle_sse_event(session_id, "session.idle", data, on_message, metadata, _deadline, _issue) do
+    if event_for_session?(data, session_id) do
+      emit_message(on_message, :turn_completed, %{session_id: session_id}, metadata)
+      {:ok, :turn_completed}
+    else
+      {:error, {:unexpected_session_idle, data}}
+    end
+  end
+
+  defp handle_sse_event(session_id, "session.error", data, on_message, metadata, _deadline, _issue) do
+    if event_for_session?(data, session_id) do
+      error = event_error(data)
+      emit_message(on_message, :turn_failed, %{session_id: session_id, error: error}, metadata)
+      {:error, {:session_error, error}}
+    else
+      {:error, {:unexpected_session_error, data}}
+    end
+  end
+
+  defp handle_sse_event(session_id, type, data, on_message, metadata, _deadline, _issue)
+       when type in ["permission.asked", "question.asked"] do
+    if event_for_session?(data, session_id) do
+      reason = {:interactive_input_required, type, data}
+      emit_message(on_message, :turn_input_required, %{session_id: session_id, reason: reason}, metadata)
+      {:error, reason}
+    else
+      emit_message(on_message, :notification, %{type: type, payload: data}, metadata)
+      {:error, {:unexpected_interactive_event, type, data}}
+    end
+  end
+
+  defp handle_sse_event(session_id, type, data, on_message, metadata, deadline, issue) do
+    emit_message(on_message, :notification, %{type: type, payload: data}, metadata)
+    now = System.monotonic_time(:millisecond)
+
+    if now >= deadline do
+      {:error, :turn_timeout}
+    else
+      await_turn_completion(session_id, on_message, metadata, deadline - now, issue)
+    end
+  end
+
+  defp event_type(%{type: type}) when is_binary(type), do: type
+  defp event_type(%{"type" => type}) when is_binary(type), do: type
+  defp event_type(%{data: data}), do: event_type(data)
+  defp event_type(%{"data" => data}), do: event_type(data)
+  defp event_type(event), do: find_nested_field(event, [:type, "type"])
+
+  defp event_data(%{data: data}), do: data
+  defp event_data(%{"data" => data}), do: data
+  defp event_data(event), do: event
+
+  defp event_for_session?(data, session_id) do
+    case find_nested_field(data, [:sessionID, "sessionID", :session_id, "session_id"]) do
+      nil -> false
+      ^session_id -> true
+      _ -> false
+    end
+  end
+
+  defp event_error(data) do
+    find_nested_field(data, [:error, "error"]) || :unknown
+  end
+
+  defp find_nested_field(nil, _keys), do: nil
+
+  defp find_nested_field(data, keys) when is_map(data) do
+    Enum.find_value(keys, &Map.get(data, &1)) ||
+      data
+      |> nested_maps()
+      |> Enum.find_value(&find_nested_field(&1, keys))
+  end
+
+  defp find_nested_field(_data, _keys), do: nil
+
+  defp nested_maps(data) when is_map(data) do
+    data
+    |> Map.take([:payload, "payload", :properties, "properties"])
+    |> Map.values()
+    |> Enum.filter(&is_map/1)
   end
 
   defp emit_message(on_message, event, details, metadata) when is_function(on_message, 1) do

--- a/elixir/symphony_elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/orchestrator.ex
@@ -132,7 +132,9 @@ defmodule SymphonyElixir.Orchestrator do
 
         state = handle_agent_down(reason, state, issue_id, running_entry, session_id)
 
-        Logger.info("Agent task finished for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}")
+        Logger.info(
+          "Agent task finished for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}"
+        )
 
         notify_dashboard()
         {:noreply, state}
@@ -201,7 +203,9 @@ defmodule SymphonyElixir.Orchestrator do
     if input_required_blocker?(running_entry) do
       block_input_required_agent_down(state, issue_id, running_entry, session_id, :normal)
     else
-      Logger.info("Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling active-state continuation check")
+      Logger.info(
+        "Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling active-state continuation check"
+      )
 
       state
       |> complete_issue(issue_id)
@@ -226,13 +230,17 @@ defmodule SymphonyElixir.Orchestrator do
   defp block_input_required_agent_down(state, issue_id, running_entry, session_id, reason) do
     error = blocker_error(running_entry, "agent exited: #{inspect(reason)}")
 
-    Logger.warning("Agent task blocked for issue_id=#{issue_id} issue_identifier=#{running_entry.identifier} session_id=#{session_id}: #{error}")
+    Logger.warning(
+      "Agent task blocked for issue_id=#{issue_id} issue_identifier=#{running_entry.identifier} session_id=#{session_id}: #{error}"
+    )
 
     block_issue_from_entry(state, issue_id, running_entry, error)
   end
 
   defp retry_agent_down(state, issue_id, running_entry, session_id, reason) do
-    Logger.warning("Agent task exited for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}; scheduling retry")
+    Logger.warning(
+      "Agent task exited for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}; scheduling retry"
+    )
 
     next_attempt = next_retry_attempt_from_running(running_entry)
 
@@ -317,7 +325,9 @@ defmodule SymphonyElixir.Orchestrator do
           |> reconcile_missing_running_issue_ids(running_ids, issues)
 
         {:error, reason} ->
-          Logger.debug("Failed to refresh running issue states: #{inspect(reason)}; keeping active workers")
+          Logger.debug(
+            "Failed to refresh running issue states: #{inspect(reason)}; keeping active workers"
+          )
 
           state
       end
@@ -341,7 +351,9 @@ defmodule SymphonyElixir.Orchestrator do
           |> reconcile_missing_blocked_issue_ids(blocked_ids, issues)
 
         {:error, reason} ->
-          Logger.debug("Failed to refresh blocked issue states: #{inspect(reason)}; keeping blocked issues")
+          Logger.debug(
+            "Failed to refresh blocked issue states: #{inspect(reason)}; keeping blocked issues"
+          )
 
           state
       end
@@ -365,11 +377,25 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   @doc false
-  @spec handle_retry_issue_lookup_for_test(Issue.t(), term(), String.t(), non_neg_integer(), map()) ::
+  @spec handle_retry_issue_lookup_for_test(
+          Issue.t(),
+          term(),
+          String.t(),
+          non_neg_integer(),
+          map()
+        ) ::
           term()
-  def handle_retry_issue_lookup_for_test(%Issue{} = issue, %State{} = state, issue_id, attempt, metadata)
+  def handle_retry_issue_lookup_for_test(
+        %Issue{} = issue,
+        %State{} = state,
+        issue_id,
+        attempt,
+        metadata
+      )
       when is_binary(issue_id) and is_integer(attempt) and attempt >= 0 and is_map(metadata) do
-    {:noreply, updated_state} = handle_retry_issue_lookup(issue, state, issue_id, attempt, metadata)
+    {:noreply, updated_state} =
+      handle_retry_issue_lookup(issue, state, issue_id, attempt, metadata)
+
     updated_state
   end
 
@@ -394,7 +420,8 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   @doc false
-  @spec select_worker_host_for_test(term(), String.t() | nil) :: String.t() | nil | :no_worker_capacity
+  @spec select_worker_host_for_test(term(), String.t() | nil) ::
+          String.t() | nil | :no_worker_capacity
   def select_worker_host_for_test(%State{} = state, preferred_worker_host) do
     select_worker_host(state, preferred_worker_host)
   end
@@ -413,12 +440,16 @@ defmodule SymphonyElixir.Orchestrator do
   defp reconcile_issue_state(%Issue{} = issue, state, active_states, terminal_states) do
     cond do
       terminal_issue_state?(issue.state, terminal_states) ->
-        Logger.info("Issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; stopping active agent")
+        Logger.info(
+          "Issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; stopping active agent"
+        )
 
         terminate_running_issue(state, issue.id, true)
 
       !issue_routable?(issue) ->
-        Logger.info("Issue no longer routed to this worker: #{issue_context(issue)} assignee=#{inspect(issue.assignee_id)}; stopping active agent")
+        Logger.info(
+          "Issue no longer routed to this worker: #{issue_context(issue)} assignee=#{inspect(issue.assignee_id)}; stopping active agent"
+        )
 
         terminate_running_issue(state, issue.id, false)
 
@@ -426,7 +457,9 @@ defmodule SymphonyElixir.Orchestrator do
         refresh_running_issue_state(state, issue)
 
       true ->
-        Logger.info("Issue moved to non-active state: #{issue_context(issue)} state=#{issue.state}; stopping active agent")
+        Logger.info(
+          "Issue moved to non-active state: #{issue_context(issue)} state=#{issue.state}; stopping active agent"
+        )
 
         terminate_running_issue(state, issue.id, false)
     end
@@ -448,19 +481,28 @@ defmodule SymphonyElixir.Orchestrator do
   defp reconcile_blocked_issue_state(%Issue{} = issue, state, active_states, terminal_states) do
     cond do
       terminal_issue_state?(issue.state, terminal_states) ->
-        Logger.info("Blocked issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; releasing block")
+        Logger.info(
+          "Blocked issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; releasing block"
+        )
+
         cleanup_issue_workspace(issue.identifier, blocked_issue_worker_host(state, issue.id))
         release_issue_claim(state, issue.id)
 
       !issue_routable?(issue) ->
-        Logger.info("Blocked issue no longer routed to this worker: #{issue_context(issue)} assignee=#{inspect(issue.assignee_id)}; releasing block")
+        Logger.info(
+          "Blocked issue no longer routed to this worker: #{issue_context(issue)} assignee=#{inspect(issue.assignee_id)}; releasing block"
+        )
+
         release_issue_claim(state, issue.id)
 
       active_issue_state?(issue.state, active_states) ->
         refresh_blocked_issue_state(state, issue)
 
       true ->
-        Logger.info("Blocked issue moved to non-active state: #{issue_context(issue)} state=#{issue.state}; releasing block")
+        Logger.info(
+          "Blocked issue moved to non-active state: #{issue_context(issue)} state=#{issue.state}; releasing block"
+        )
+
         release_issue_claim(state, issue.id)
     end
   end
@@ -503,7 +545,10 @@ defmodule SymphonyElixir.Orchestrator do
       if MapSet.member?(visible_issue_ids, issue_id) do
         state_acc
       else
-        Logger.info("Blocked issue no longer visible during state refresh: issue_id=#{issue_id}; releasing block")
+        Logger.info(
+          "Blocked issue no longer visible during state refresh: issue_id=#{issue_id}; releasing block"
+        )
+
         release_issue_claim(state_acc, issue_id)
       end
     end)
@@ -514,10 +559,14 @@ defmodule SymphonyElixir.Orchestrator do
   defp log_missing_running_issue(%State{} = state, issue_id) when is_binary(issue_id) do
     case Map.get(state.running, issue_id) do
       %{identifier: identifier} ->
-        Logger.info("Issue no longer visible during running-state refresh: issue_id=#{issue_id} issue_identifier=#{identifier}; stopping active agent")
+        Logger.info(
+          "Issue no longer visible during running-state refresh: issue_id=#{issue_id} issue_identifier=#{identifier}; stopping active agent"
+        )
 
       _ ->
-        Logger.info("Issue no longer visible during running-state refresh: issue_id=#{issue_id}; stopping active agent")
+        Logger.info(
+          "Issue no longer visible during running-state refresh: issue_id=#{issue_id}; stopping active agent"
+        )
     end
   end
 
@@ -606,15 +655,23 @@ defmodule SymphonyElixir.Orchestrator do
       session_id = running_entry_session_id(running_entry)
 
       if input_required_blocker?(running_entry) do
-        error = blocker_error(running_entry, "stalled for #{elapsed_ms}ms after the agent requested operator input")
+        error =
+          blocker_error(
+            running_entry,
+            "stalled for #{elapsed_ms}ms after the agent requested operator input"
+          )
 
-        Logger.warning("Issue blocked: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; #{error}")
+        Logger.warning(
+          "Issue blocked: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; #{error}"
+        )
 
         state
         |> record_session_completion_totals(running_entry)
         |> stop_and_block_issue(issue_id, running_entry, error)
       else
-        Logger.warning("Issue stalled: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; restarting with backoff")
+        Logger.warning(
+          "Issue stalled: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; restarting with backoff"
+        )
 
         next_attempt = next_retry_attempt_from_running(running_entry)
 
@@ -695,9 +752,14 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp completion_blocker_error(completion) do
     case input_required_completion_outcome(completion) do
-      outcome when outcome in [:input_required, :needs_input] -> "codex turn requires operator input"
-      :approval_required -> "codex turn requires approval"
-      nil -> nil
+      outcome when outcome in [:input_required, :needs_input] ->
+        "codex turn requires operator input"
+
+      :approval_required ->
+        "codex turn requires approval"
+
+      nil ->
+        nil
     end
   end
 
@@ -784,7 +846,8 @@ defmodule SymphonyElixir.Orchestrator do
   defp sort_issues_for_dispatch(issues) when is_list(issues) do
     Enum.sort_by(issues, fn
       %Issue{} = issue ->
-        {priority_rank(issue.priority), issue_created_at_sort_key(issue), issue.identifier || issue.id || ""}
+        {priority_rank(issue.priority), issue_created_at_sort_key(issue),
+         issue.identifier || issue.id || ""}
 
       _ ->
         {priority_rank(nil), issue_created_at_sort_key(nil), ""}
@@ -907,21 +970,33 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp dispatch_issue(%State{} = state, issue, attempt \\ nil, preferred_worker_host \\ nil) do
-    case revalidate_issue_for_dispatch(issue, &Tracker.fetch_issue_states_by_ids/1, terminal_state_set()) do
+    case revalidate_issue_for_dispatch(
+           issue,
+           &Tracker.fetch_issue_states_by_ids/1,
+           terminal_state_set()
+         ) do
       {:ok, %Issue{} = refreshed_issue} ->
         do_dispatch_issue(state, refreshed_issue, attempt, preferred_worker_host)
 
       {:skip, :missing} ->
-        Logger.info("Skipping dispatch; issue no longer active or visible: #{issue_context(issue)}")
+        Logger.info(
+          "Skipping dispatch; issue no longer active or visible: #{issue_context(issue)}"
+        )
+
         state
 
       {:skip, %Issue{} = refreshed_issue} ->
-        Logger.info("Skipping stale dispatch after issue refresh: #{issue_context(refreshed_issue)} state=#{inspect(refreshed_issue.state)} blocked_by=#{length(refreshed_issue.blocked_by)}")
+        Logger.info(
+          "Skipping stale dispatch after issue refresh: #{issue_context(refreshed_issue)} state=#{inspect(refreshed_issue.state)} blocked_by=#{length(refreshed_issue.blocked_by)}"
+        )
 
         state
 
       {:error, reason} ->
-        Logger.warning("Skipping dispatch; issue refresh failed for #{issue_context(issue)}: #{inspect(reason)}")
+        Logger.warning(
+          "Skipping dispatch; issue refresh failed for #{issue_context(issue)}: #{inspect(reason)}"
+        )
+
         state
     end
   end
@@ -931,7 +1006,10 @@ defmodule SymphonyElixir.Orchestrator do
 
     case select_worker_host(state, preferred_worker_host) do
       :no_worker_capacity ->
-        Logger.debug("No SSH worker slots available for #{issue_context(issue)} preferred_worker_host=#{inspect(preferred_worker_host)}")
+        Logger.debug(
+          "No SSH worker slots available for #{issue_context(issue)} preferred_worker_host=#{inspect(preferred_worker_host)}"
+        )
+
         state
 
       worker_host ->
@@ -946,7 +1024,9 @@ defmodule SymphonyElixir.Orchestrator do
       {:ok, pid} ->
         ref = Process.monitor(pid)
 
-        Logger.info("Dispatching issue to agent: #{issue_context(issue)} pid=#{inspect(pid)} attempt=#{inspect(attempt)} worker_host=#{worker_host || "local"}")
+        Logger.info(
+          "Dispatching issue to agent: #{issue_context(issue)} pid=#{inspect(pid)} attempt=#{inspect(attempt)} worker_host=#{worker_host || "local"}"
+        )
 
         running =
           Map.put(state.running, issue.id, %{
@@ -1042,7 +1122,9 @@ defmodule SymphonyElixir.Orchestrator do
 
     error_suffix = if is_binary(error), do: " error=#{error}", else: ""
 
-    Logger.warning("Retrying issue_id=#{issue_id} issue_identifier=#{identifier} in #{delay_ms}ms (attempt #{next_attempt})#{error_suffix}")
+    Logger.warning(
+      "Retrying issue_id=#{issue_id} issue_identifier=#{identifier} in #{delay_ms}ms (attempt #{next_attempt})#{error_suffix}"
+    )
 
     %{
       state
@@ -1061,7 +1143,8 @@ defmodule SymphonyElixir.Orchestrator do
     }
   end
 
-  defp pop_retry_attempt_state(%State{} = state, issue_id, retry_token) when is_reference(retry_token) do
+  defp pop_retry_attempt_state(%State{} = state, issue_id, retry_token)
+       when is_reference(retry_token) do
     case Map.get(state.retry_attempts, issue_id) do
       %{attempt: attempt, retry_token: ^retry_token} = retry_entry ->
         metadata = %{
@@ -1072,7 +1155,8 @@ defmodule SymphonyElixir.Orchestrator do
           workspace_path: Map.get(retry_entry, :workspace_path)
         }
 
-        {:ok, attempt, metadata, %{state | retry_attempts: Map.delete(state.retry_attempts, issue_id)}}
+        {:ok, attempt, metadata,
+         %{state | retry_attempts: Map.delete(state.retry_attempts, issue_id)}}
 
       _ ->
         :missing
@@ -1087,7 +1171,9 @@ defmodule SymphonyElixir.Orchestrator do
         |> handle_retry_issue_lookup(state, issue_id, attempt, metadata)
 
       {:error, reason} ->
-        Logger.warning("Retry poll failed for issue_id=#{issue_id} issue_identifier=#{metadata[:identifier] || issue_id}: #{inspect(reason)}")
+        Logger.warning(
+          "Retry poll failed for issue_id=#{issue_id} issue_identifier=#{metadata[:identifier] || issue_id}: #{inspect(reason)}"
+        )
 
         {:noreply,
          schedule_issue_retry(
@@ -1104,7 +1190,9 @@ defmodule SymphonyElixir.Orchestrator do
 
     cond do
       terminal_issue_state?(issue.state, terminal_states) ->
-        Logger.info("Issue state is terminal: issue_id=#{issue_id} issue_identifier=#{issue.identifier} state=#{issue.state}; removing associated workspace")
+        Logger.info(
+          "Issue state is terminal: issue_id=#{issue_id} issue_identifier=#{issue.identifier} state=#{issue.state}; removing associated workspace"
+        )
 
         cleanup_issue_workspace(issue.identifier, metadata[:worker_host])
         {:noreply, release_issue_claim(state, issue_id)}
@@ -1113,7 +1201,9 @@ defmodule SymphonyElixir.Orchestrator do
         handle_active_retry(state, issue, attempt, metadata)
 
       true ->
-        Logger.debug("Issue left active states, removing claim issue_id=#{issue_id} issue_identifier=#{issue.identifier}")
+        Logger.debug(
+          "Issue left active states, removing claim issue_id=#{issue_id} issue_identifier=#{issue.identifier}"
+        )
 
         {:noreply, release_issue_claim(state, issue_id)}
     end
@@ -1151,7 +1241,9 @@ defmodule SymphonyElixir.Orchestrator do
         end)
 
       {:error, reason} ->
-        Logger.warning("Skipping startup terminal workspace cleanup; failed to fetch terminal issues: #{inspect(reason)}")
+        Logger.warning(
+          "Skipping startup terminal workspace cleanup; failed to fetch terminal issues: #{inspect(reason)}"
+        )
     end
   end
 
@@ -1189,7 +1281,8 @@ defmodule SymphonyElixir.Orchestrator do
     }
   end
 
-  defp retry_delay(attempt, metadata) when is_integer(attempt) and attempt > 0 and is_map(metadata) do
+  defp retry_delay(attempt, metadata)
+       when is_integer(attempt) and attempt > 0 and is_map(metadata) do
     if metadata[:delay_type] == :continuation and attempt == 1 do
       @continuation_retry_delay_ms
     else
@@ -1199,7 +1292,11 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp failure_retry_delay(attempt) do
     max_delay_power = min(attempt - 1, 10)
-    min(@failure_retry_base_ms * (1 <<< max_delay_power), Config.settings!().agent.max_retry_backoff_ms)
+
+    min(
+      @failure_retry_base_ms * (1 <<< max_delay_power),
+      Config.settings!().agent.max_retry_backoff_ms
+    )
   end
 
   defp normalize_retry_attempt(attempt) when is_integer(attempt) and attempt > 0, do: attempt
@@ -1275,7 +1372,8 @@ defmodule SymphonyElixir.Orchestrator do
     |> elem(0)
   end
 
-  defp running_worker_host_count(running, worker_host) when is_map(running) and is_binary(worker_host) do
+  defp running_worker_host_count(running, worker_host)
+       when is_map(running) and is_binary(worker_host) do
     Enum.count(running, fn
       {_issue_id, %{worker_host: ^worker_host}} -> true
       _ -> false

--- a/elixir/symphony_elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/orchestrator.ex
@@ -1,6 +1,6 @@
 defmodule SymphonyElixir.Orchestrator do
   @moduledoc """
-  Polls Linear and dispatches repository copies to Codex-backed workers.
+  Polls Linear and dispatches repository copies to OpenCode-backed workers.
   """
 
   use GenServer
@@ -606,7 +606,7 @@ defmodule SymphonyElixir.Orchestrator do
       session_id = running_entry_session_id(running_entry)
 
       if input_required_blocker?(running_entry) do
-        error = blocker_error(running_entry, "stalled for #{elapsed_ms}ms after Codex requested operator input")
+        error = blocker_error(running_entry, "stalled for #{elapsed_ms}ms after the agent requested operator input")
 
         Logger.warning("Issue blocked: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; #{error}")
 

--- a/elixir/symphony_elixir/test/support/opencode_fakes.exs
+++ b/elixir/symphony_elixir/test/support/opencode_fakes.exs
@@ -1,0 +1,76 @@
+defmodule SymphonyElixir.OpencodeFakes.SessionApi do
+  @moduledoc false
+
+  @spec session_create(map(), keyword()) :: {:ok, map()}
+  def session_create(body, client) do
+    notify(client, {:opencode_session_create, body, client})
+    {:ok, %{"id" => Keyword.get(client, :session_id, "ses_test")}}
+  end
+
+  @spec session_prompt_async(String.t(), map(), keyword()) :: :ok
+  def session_prompt_async(session_id, body, client) do
+    notify(client, {:opencode_prompt_async, session_id, body, client})
+    :ok
+  end
+
+  @spec session_delete(String.t(), keyword()) :: {:ok, boolean()}
+  def session_delete(session_id, client) do
+    notify(client, {:opencode_session_delete, session_id, client})
+    {:ok, true}
+  end
+
+  defp notify(client, message) do
+    case Keyword.get(client, :test_pid) do
+      pid when is_pid(pid) -> send(pid, message)
+      _ -> :ok
+    end
+  end
+end
+
+defmodule SymphonyElixir.OpencodeFakes.EventStream do
+  @moduledoc false
+
+  @spec stream(keyword()) :: {:ok, Enumerable.t()}
+  def stream(client) do
+    session_id = Keyword.get(client, :session_id, "ses_test")
+    {:ok, Keyword.get(client, :events, [idle_event(session_id)])}
+  end
+
+  @spec idle_event(String.t()) :: map()
+  def idle_event(session_id) do
+    %{type: "session.idle", data: %{"properties" => %{"sessionID" => session_id}}}
+  end
+end
+
+defmodule SymphonyElixir.OpencodeFakes.Server do
+  @moduledoc false
+
+  @spec start(keyword()) :: {:ok, map()} | {:error, term()}
+  def start(opts) do
+    case Keyword.get(opts, :start_error) do
+      nil ->
+        server = %{
+          test_pid: Keyword.get(opts, :test_pid),
+          url: Keyword.get(opts, :url, "http://127.0.0.1:4096")
+        }
+
+        notify(server, {:opencode_server_start, opts})
+        {:ok, server}
+
+      error ->
+        {:error, error}
+    end
+  end
+
+  @spec url(map()) :: String.t() | {:error, term()}
+  def url(%{url: url}), do: url
+
+  @spec stop(map()) :: :ok
+  def stop(server) do
+    notify(server, {:opencode_server_stop, server})
+    :ok
+  end
+
+  defp notify(%{test_pid: pid}, message) when is_pid(pid), do: send(pid, message)
+  defp notify(_server, _message), do: :ok
+end

--- a/elixir/symphony_elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/core_test.exs
@@ -1116,7 +1116,7 @@ defmodule SymphonyElixir.CoreTest do
     assert prompt == "Retry #2"
   end
 
-  test "agent runner keeps workspace after successful codex run" do
+  test "agent runner keeps workspace after successful OpenCode run" do
     test_root =
       Path.join(
         System.tmp_dir!(),
@@ -1126,7 +1126,6 @@ defmodule SymphonyElixir.CoreTest do
     try do
       template_repo = Path.join(test_root, "source")
       workspace_root = Path.join(test_root, "workspaces")
-      codex_binary = Path.join(test_root, "fake-codex")
 
       File.mkdir_p!(template_repo)
       File.mkdir_p!(workspace_root)
@@ -1137,37 +1136,9 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "add", "README.md"])
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-        case "$count" in
-          1)
-            printf '%s\\n' '{\"id\":1,\"result\":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-1\"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'
-            printf '%s\\n' '{\"method\":\"turn/completed\"}'
-            exit 0
-            ;;
-          *)
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
-
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        hook_after_create: "cp #{Path.join(template_repo, "README.md")} README.md",
-        codex_command: "#{codex_binary} app-server"
+        hook_after_create: "cp #{Path.join(template_repo, "README.md")} README.md"
       )
 
       issue = %Issue{
@@ -1180,7 +1151,7 @@ defmodule SymphonyElixir.CoreTest do
       }
 
       before = MapSet.new(File.ls!(workspace_root))
-      assert :ok = AgentRunner.run(issue)
+      assert :ok = AgentRunner.run(issue, nil, opencode_fake_opts(self(), "ses_workspace"))
       entries_after = MapSet.new(File.ls!(workspace_root))
 
       created =
@@ -1200,7 +1171,7 @@ defmodule SymphonyElixir.CoreTest do
     end
   end
 
-  test "agent runner forwards timestamped codex updates to recipient" do
+  test "agent runner forwards timestamped OpenCode updates to recipient" do
     test_root =
       Path.join(
         System.tmp_dir!(),
@@ -1210,7 +1181,6 @@ defmodule SymphonyElixir.CoreTest do
     try do
       template_repo = Path.join(test_root, "source")
       workspace_root = Path.join(test_root, "workspaces")
-      codex_binary = Path.join(test_root, "fake-codex")
 
       File.mkdir_p!(template_repo)
       File.write!(Path.join(template_repo, "README.md"), "# test")
@@ -1220,39 +1190,9 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "add", "README.md"])
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
-      File.write!(
-        codex_binary,
-        """
-        #!/bin/sh
-        count=0
-        while IFS= read -r line; do
-          count=$((count + 1))
-          case "$count" in
-            1)
-              printf '%s\\n' '{\"id\":1,\"result\":{}}'
-              ;;
-            2)
-              printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-live\"}}}'
-              ;;
-            3)
-              printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-live\"}}}'
-              ;;
-            4)
-              printf '%s\\n' '{\"method\":\"turn/completed\"}'
-              ;;
-            *)
-              ;;
-          esac
-        done
-        """
-      )
-
-      File.chmod!(codex_binary, 0o755)
-
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        hook_after_create: "cp #{Path.join(template_repo, "README.md")} README.md",
-        codex_command: "#{codex_binary} app-server"
+        hook_after_create: "cp #{Path.join(template_repo, "README.md")} README.md"
       )
 
       issue = %Issue{
@@ -1271,7 +1211,10 @@ defmodule SymphonyElixir.CoreTest do
                AgentRunner.run(
                  issue,
                  test_pid,
-                 issue_state_fetcher: fn [_issue_id] -> {:ok, [%{issue | state: "Done"}]} end
+                 opencode_fake_opts(test_pid, "ses_live") ++
+                   [
+                     issue_state_fetcher: fn [_issue_id] -> {:ok, [%{issue | state: "Done"}]} end
+                   ]
                )
 
       assert_receive {:codex_worker_update, "issue-live-updates",
@@ -1282,7 +1225,7 @@ defmodule SymphonyElixir.CoreTest do
                       }},
                      500
 
-      assert session_id == "thread-live-turn-live"
+      assert session_id == "ses_live"
     after
       File.rm_rf(test_root)
     end
@@ -1368,8 +1311,6 @@ defmodule SymphonyElixir.CoreTest do
     try do
       template_repo = Path.join(test_root, "source")
       workspace_root = Path.join(test_root, "workspaces")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex.trace")
 
       File.mkdir_p!(template_repo)
       File.write!(Path.join(template_repo, "README.md"), "# test")
@@ -1379,46 +1320,9 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "add", "README.md"])
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex.trace}"
-      run_id="$(date +%s%N)-$$"
-      printf 'RUN:%s\\n' "$run_id" >> "$trace_file"
-      count=0
-
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' "$line" >> "$trace_file"
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-cont"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-cont-1"}}}'
-            printf '%s\\n' '{"method":"turn/completed"}'
-            ;;
-          5)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-cont-2"}}}'
-            printf '%s\\n' '{"method":"turn/completed"}'
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
-      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
-
-      on_exit(fn -> System.delete_env("SYMP_TEST_CODEx_TRACE") end)
-
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
         hook_after_create: "cp #{Path.join(template_repo, "README.md")} README.md",
-        codex_command: "#{codex_binary} app-server",
         max_turns: 3
       )
 
@@ -1458,33 +1362,26 @@ defmodule SymphonyElixir.CoreTest do
         labels: []
       }
 
-      assert :ok = AgentRunner.run(issue, nil, issue_state_fetcher: state_fetcher)
+      assert :ok =
+               AgentRunner.run(
+                 issue,
+                 nil,
+                 opencode_fake_opts(parent, "ses_continue") ++ [issue_state_fetcher: state_fetcher]
+               )
+
       assert_receive {:issue_state_fetch, 1}
       assert_receive {:issue_state_fetch, 2}
 
-      lines = File.read!(trace_file) |> String.split("\n", trim: true)
+      assert_received {:opencode_session_create, _body, _client}
+      assert_received {:opencode_prompt_async, "ses_continue", %{parts: [%{text: first_prompt}]}, _client}
+      assert_received {:opencode_prompt_async, "ses_continue", %{parts: [%{text: second_prompt}]}, _client}
+      assert_received {:opencode_session_delete, "ses_continue", _client}
 
-      assert length(Enum.filter(lines, &String.starts_with?(&1, "RUN:"))) == 1
-      assert length(Enum.filter(lines, &String.contains?(&1, "\"method\":\"thread/start\""))) == 1
-
-      turn_texts =
-        lines
-        |> Enum.filter(&String.starts_with?(&1, "JSON:"))
-        |> Enum.map(&String.trim_leading(&1, "JSON:"))
-        |> Enum.map(&Jason.decode!/1)
-        |> Enum.filter(&(&1["method"] == "turn/start"))
-        |> Enum.map(fn payload ->
-          get_in(payload, ["params", "input"])
-          |> Enum.map_join("\n", &Map.get(&1, "text", ""))
-        end)
-
-      assert length(turn_texts) == 2
-      assert Enum.at(turn_texts, 0) =~ "You are an agent for this repository."
-      refute Enum.at(turn_texts, 1) =~ "You are an agent for this repository."
-      assert Enum.at(turn_texts, 1) =~ "Continuation guidance:"
-      assert Enum.at(turn_texts, 1) =~ "continuation turn #2 of 3"
+      assert first_prompt =~ "You are an agent for this repository."
+      refute second_prompt =~ "You are an agent for this repository."
+      assert second_prompt =~ "Continuation guidance:"
+      assert second_prompt =~ "continuation turn #2 of 3"
     after
-      System.delete_env("SYMP_TEST_CODEx_TRACE")
       File.rm_rf(test_root)
     end
   end
@@ -1499,8 +1396,6 @@ defmodule SymphonyElixir.CoreTest do
     try do
       template_repo = Path.join(test_root, "source")
       workspace_root = Path.join(test_root, "workspaces")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex.trace")
 
       File.mkdir_p!(template_repo)
       File.write!(Path.join(template_repo, "README.md"), "# test")
@@ -1510,45 +1405,9 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "add", "README.md"])
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex.trace}"
-      printf 'RUN\\n' >> "$trace_file"
-      count=0
-
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' "$line" >> "$trace_file"
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-max"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-max-1"}}}'
-            printf '%s\\n' '{"method":"turn/completed"}'
-            ;;
-          5)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-max-2"}}}'
-            printf '%s\\n' '{"method":"turn/completed"}'
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
-      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
-
-      on_exit(fn -> System.delete_env("SYMP_TEST_CODEx_TRACE") end)
-
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
         hook_after_create: "cp #{Path.join(template_repo, "README.md")} README.md",
-        codex_command: "#{codex_binary} app-server",
         max_turns: 2
       )
 
@@ -1575,13 +1434,19 @@ defmodule SymphonyElixir.CoreTest do
         labels: []
       }
 
-      assert :ok = AgentRunner.run(issue, nil, issue_state_fetcher: state_fetcher)
+      assert :ok =
+               AgentRunner.run(
+                 issue,
+                 nil,
+                 opencode_fake_opts(self(), "ses_max_turns") ++ [issue_state_fetcher: state_fetcher]
+               )
 
-      trace = File.read!(trace_file)
-      assert length(String.split(trace, "RUN", trim: true)) == 1
-      assert length(Regex.scan(~r/"method":"turn\/start"/, trace)) == 2
+      assert_received {:opencode_session_create, _body, _client}
+      assert_received {:opencode_prompt_async, "ses_max_turns", _body, _client}
+      assert_received {:opencode_prompt_async, "ses_max_turns", _body, _client}
+      refute_received {:opencode_prompt_async, "ses_max_turns", _body, _client}
+      assert_received {:opencode_session_delete, "ses_max_turns", _client}
     after
-      System.delete_env("SYMP_TEST_CODEx_TRACE")
       File.rm_rf(test_root)
     end
   end
@@ -1939,5 +1804,15 @@ defmodule SymphonyElixir.CoreTest do
     after
       File.rm_rf(test_root)
     end
+  end
+
+  defp opencode_fake_opts(test_pid, session_id) do
+    [
+      base_url: "http://opencode.test",
+      client_opts: [test_pid: test_pid, session_id: session_id],
+      event_stream: SymphonyElixir.OpencodeFakes.EventStream,
+      session_api: SymphonyElixir.OpencodeFakes.SessionApi,
+      turn_timeout_ms: 1_000
+    ]
   end
 end

--- a/elixir/symphony_elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/core_test.exs
@@ -14,7 +14,15 @@ defmodule SymphonyElixir.CoreTest do
     config = Config.settings!()
     assert config.polling.interval_ms == 30_000
     assert config.tracker.active_states == ["Todo", "In Progress"]
-    assert config.tracker.terminal_states == ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]
+
+    assert config.tracker.terminal_states == [
+             "Closed",
+             "Cancelled",
+             "Canceled",
+             "Duplicate",
+             "Done"
+           ]
+
     assert config.tracker.assignee == nil
     assert config.agent.max_turns == 20
 
@@ -64,7 +72,10 @@ defmodule SymphonyElixir.CoreTest do
     write_workflow_file!(Workflow.workflow_file_path(), codex_command: "/bin/sh app-server")
     assert :ok = Config.validate!()
 
-    write_workflow_file!(Workflow.workflow_file_path(), codex_approval_policy: "definitely-not-valid")
+    write_workflow_file!(Workflow.workflow_file_path(),
+      codex_approval_policy: "definitely-not-valid"
+    )
+
     assert :ok = Config.validate!()
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_thread_sandbox: "unsafe-ish")
@@ -105,10 +116,15 @@ defmodule SymphonyElixir.CoreTest do
 
     hooks = Map.get(config, "hooks", %{})
     assert is_map(hooks)
-    assert Map.get(hooks, "after_create") =~ "git clone --depth 1 https://github.com/openai/symphony ."
+
+    assert Map.get(hooks, "after_create") =~
+             "git clone --depth 1 https://github.com/openai/symphony ."
+
     assert Map.get(hooks, "after_create") =~ "cd elixir && mise trust"
     assert Map.get(hooks, "after_create") =~ "mise exec -- mix deps.get"
-    assert Map.get(hooks, "before_remove") =~ "cd elixir && mise exec -- mix workspace.before_remove"
+
+    assert Map.get(hooks, "before_remove") =~
+             "cd elixir && mise exec -- mix workspace.before_remove"
 
     assert String.trim(prompt) != ""
     assert is_binary(Config.workflow_prompt())
@@ -174,7 +190,9 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "workflow load accepts prompt-only files without front matter" do
-    workflow_path = Path.join(Path.dirname(Workflow.workflow_file_path()), "PROMPT_ONLY_WORKFLOW.md")
+    workflow_path =
+      Path.join(Path.dirname(Workflow.workflow_file_path()), "PROMPT_ONLY_WORKFLOW.md")
+
     File.write!(workflow_path, "Prompt only\n")
 
     assert {:ok, %{config: %{}, prompt: "Prompt only", prompt_template: "Prompt only"}} =
@@ -182,15 +200,20 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "workflow load accepts unterminated front matter with an empty prompt" do
-    workflow_path = Path.join(Path.dirname(Workflow.workflow_file_path()), "UNTERMINATED_WORKFLOW.md")
+    workflow_path =
+      Path.join(Path.dirname(Workflow.workflow_file_path()), "UNTERMINATED_WORKFLOW.md")
+
     File.write!(workflow_path, "---\ntracker:\n  kind: linear\n")
 
-    assert {:ok, %{config: %{"tracker" => %{"kind" => "linear"}}, prompt: "", prompt_template: ""}} =
+    assert {:ok,
+            %{config: %{"tracker" => %{"kind" => "linear"}}, prompt: "", prompt_template: ""}} =
              Workflow.load(workflow_path)
   end
 
   test "workflow load rejects non-map front matter" do
-    workflow_path = Path.join(Path.dirname(Workflow.workflow_file_path()), "INVALID_FRONT_MATTER_WORKFLOW.md")
+    workflow_path =
+      Path.join(Path.dirname(Workflow.workflow_file_path()), "INVALID_FRONT_MATTER_WORKFLOW.md")
+
     File.write!(workflow_path, "---\n- not-a-map\n---\nPrompt body\n")
 
     assert {:error, :workflow_front_matter_not_a_map} = Workflow.load(workflow_path)
@@ -211,7 +234,8 @@ defmodule SymphonyElixir.CoreTest do
     end)
 
     if is_pid(orchestrator_pid) do
-      assert :ok = Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.Orchestrator)
+      assert :ok =
+               Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.Orchestrator)
     end
 
     assert {:ok, pid} = SymphonyElixir.start_link()
@@ -824,7 +848,9 @@ defmodule SymphonyElixir.CoreTest do
              Orchestrator.handle_call(:request_refresh, {self(), make_ref()}, refreshed_state)
 
     assert coalesced_state.tick_token == refreshed_state.tick_token
-    assert {:noreply, ^coalesced_state} = Orchestrator.handle_info({:tick, stale_tick_token}, coalesced_state)
+
+    assert {:noreply, ^coalesced_state} =
+             Orchestrator.handle_info({:tick, stale_tick_token}, coalesced_state)
   end
 
   test "select_worker_host_for_test skips full ssh hosts under the shared per-host cap" do
@@ -911,7 +937,8 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "prompt builder renders issue datetime fields without crashing" do
-    workflow_prompt = "Ticket {{ issue.identifier }} created={{ issue.created_at }} updated={{ issue.updated_at }}"
+    workflow_prompt =
+      "Ticket {{ issue.identifier }} created={{ issue.created_at }} updated={{ issue.updated_at }}"
 
     write_workflow_file!(Workflow.workflow_file_path(), prompt: workflow_prompt)
 
@@ -1048,9 +1075,12 @@ defmodule SymphonyElixir.CoreTest do
       end
     end)
 
-    assert :ok = Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.WorkflowStore)
+    assert :ok =
+             Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.WorkflowStore)
 
-    Workflow.set_workflow_file_path(Path.join(System.tmp_dir!(), "missing-workflow-#{System.unique_integer([:positive])}.md"))
+    Workflow.set_workflow_file_path(
+      Path.join(System.tmp_dir!(), "missing-workflow-#{System.unique_integer([:positive])}.md")
+    )
 
     issue = %Issue{
       identifier: "MT-780",
@@ -1366,15 +1396,21 @@ defmodule SymphonyElixir.CoreTest do
                AgentRunner.run(
                  issue,
                  nil,
-                 opencode_fake_opts(parent, "ses_continue") ++ [issue_state_fetcher: state_fetcher]
+                 opencode_fake_opts(parent, "ses_continue") ++
+                   [issue_state_fetcher: state_fetcher]
                )
 
       assert_receive {:issue_state_fetch, 1}
       assert_receive {:issue_state_fetch, 2}
 
       assert_received {:opencode_session_create, _body, _client}
-      assert_received {:opencode_prompt_async, "ses_continue", %{parts: [%{text: first_prompt}]}, _client}
-      assert_received {:opencode_prompt_async, "ses_continue", %{parts: [%{text: second_prompt}]}, _client}
+
+      assert_received {:opencode_prompt_async, "ses_continue", %{parts: [%{text: first_prompt}]},
+                       _client}
+
+      assert_received {:opencode_prompt_async, "ses_continue", %{parts: [%{text: second_prompt}]},
+                       _client}
+
       assert_received {:opencode_session_delete, "ses_continue", _client}
 
       assert first_prompt =~ "You are an agent for this repository."
@@ -1438,7 +1474,8 @@ defmodule SymphonyElixir.CoreTest do
                AgentRunner.run(
                  issue,
                  nil,
-                 opencode_fake_opts(self(), "ses_max_turns") ++ [issue_state_fetcher: state_fetcher]
+                 opencode_fake_opts(self(), "ses_max_turns") ++
+                   [issue_state_fetcher: state_fetcher]
                )
 
       assert_received {:opencode_session_create, _body, _client}

--- a/elixir/symphony_elixir/test/symphony_elixir/opencode_app_server_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/opencode_app_server_test.exs
@@ -55,6 +55,47 @@ defmodule SymphonyElixir.OpencodeAppServerTest do
     end
   end
 
+  test "app server ignores SSE lifecycle events for other sessions" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-opencode-app-server-session-filter-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-OC-2")
+      File.mkdir_p!(workspace)
+
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+
+      issue = %Issue{
+        id: "issue-opencode-session-filter",
+        identifier: "MT-OC-2",
+        title: "Filter OpenCode session events",
+        description: "Ignore unrelated global SSE events",
+        state: "In Progress"
+      }
+
+      events = [
+        EventStream.idle_event("ses_other"),
+        EventStream.idle_event("ses_target")
+      ]
+
+      assert {:ok, %{session_id: "ses_target"}} =
+               AppServer.run(workspace, "Use OpenCode", issue,
+                 client_opts: [events: events, session_id: "ses_target"],
+                 event_stream: EventStream,
+                 server_module: Server,
+                 server_opts: [url: "http://127.0.0.1:4999"],
+                 session_api: SessionApi,
+                 turn_timeout_ms: 1_000
+               )
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
   test "app server rejects unsafe local workspace paths before creating OpenCode sessions" do
     test_root =
       Path.join(

--- a/elixir/symphony_elixir/test/symphony_elixir/opencode_app_server_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/opencode_app_server_test.exs
@@ -1,0 +1,94 @@
+defmodule SymphonyElixir.OpencodeAppServerTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.Opencode.AppServer
+  alias SymphonyElixir.OpencodeFakes.{EventStream, Server, SessionApi}
+
+  test "app server uses opencode_client server, session API, event stream, and cleanup lifecycle" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-opencode-app-server-lifecycle-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-OC-1")
+      File.mkdir_p!(workspace)
+
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+
+      issue = %Issue{
+        id: "issue-opencode-lifecycle",
+        identifier: "MT-OC-1",
+        title: "Validate OpenCode lifecycle",
+        description: "Exercise generated OpenCode client path",
+        state: "In Progress"
+      }
+
+      assert {:ok, %{session_id: "ses_lifecycle"}} =
+               AppServer.run(workspace, "Use OpenCode", issue,
+                 client_opts: [test_pid: self(), session_id: "ses_lifecycle"],
+                 event_stream: EventStream,
+                 server_module: Server,
+                 server_opts: [test_pid: self(), url: "http://127.0.0.1:4999"],
+                 session_api: SessionApi,
+                 turn_timeout_ms: 1_000
+               )
+
+      assert_received {:opencode_server_start, server_opts}
+      assert Keyword.get(server_opts, :config) == %{}
+
+      assert_received {:opencode_session_create, body, client}
+      assert {:ok, canonical_workspace} = SymphonyElixir.PathSafety.canonicalize(workspace)
+      assert body.title == "Symphony agent run"
+      assert body.directory == canonical_workspace
+      assert Keyword.get(client, :base_url) == "http://127.0.0.1:4999"
+
+      assert_received {:opencode_prompt_async, "ses_lifecycle", prompt_body, _client}
+      assert prompt_body == %{parts: [%{type: "text", text: "Use OpenCode"}]}
+
+      assert_received {:opencode_session_delete, "ses_lifecycle", _client}
+      assert_received {:opencode_server_stop, %{url: "http://127.0.0.1:4999"}}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server rejects unsafe local workspace paths before creating OpenCode sessions" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-opencode-app-server-cwd-guard-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      outside_workspace = Path.join(test_root, "outside")
+      File.mkdir_p!(workspace_root)
+      File.mkdir_p!(outside_workspace)
+
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+
+      assert {:error, {:invalid_workspace_cwd, :workspace_root, _path}} =
+               AppServer.start_session(workspace_root,
+                 base_url: "http://127.0.0.1:4999",
+                 client_opts: [test_pid: self()],
+                 event_stream: EventStream,
+                 session_api: SessionApi
+               )
+
+      assert {:error, {:invalid_workspace_cwd, :outside_workspace_root, _path, _root}} =
+               AppServer.start_session(outside_workspace,
+                 base_url: "http://127.0.0.1:4999",
+                 client_opts: [test_pid: self()],
+                 event_stream: EventStream,
+                 session_api: SessionApi
+               )
+
+      refute_received {:opencode_session_create, _body, _client}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+end

--- a/elixir/symphony_elixir/test/test_helper.exs
+++ b/elixir/symphony_elixir/test/test_helper.exs
@@ -1,3 +1,4 @@
 ExUnit.start()
 Code.require_file("support/snapshot_support.exs", __DIR__)
+Code.require_file("support/opencode_fakes.exs", __DIR__)
 Code.require_file("support/test_support.exs", __DIR__)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,23 +61,23 @@ export default defineConfig({
         dependsOn: ['ex:check:format', 'ex:check:compile'],
       },
       'ex:check:compile': {
-        command: 'mix compile',
+        command: 'elixir -S mix compile',
         input: [{ auto: true }, '!_build/**', '!deps/**'],
       },
       'ex:check:format': {
-        command: 'mix format --check-formatted',
+        command: 'elixir -S mix format --check-formatted',
         input: [{ auto: true }, '!_build/**', '!deps/**'],
       },
       'ex:check:lint': {
-        command: 'mix lint',
+        command: 'elixir -S mix lint',
         input: [{ auto: true }, '!_build/**', '!deps/**'],
       },
       'ex:fix': {
-        command: 'mix format',
+        command: 'elixir -S mix format',
         input: [{ auto: true }, '!_build/**', '!deps/**'],
       },
       'ex:test': {
-        command: 'mix test',
+        command: 'elixir -S mix test',
         input: [{ auto: true }, '!_build/**', '!deps/**'],
       },
       fix: {


### PR DESCRIPTION
#### Context

TOT-9 replaces the Symphony Elixir agent backend with OpenCode and the in-repo `opencode_client`.

#### TL;DR

_Symphony now runs agent turns through OpenCode instead of Codex._

#### Summary

- Wire canonical `SymphonyElixir.AgentRunner` to `SymphonyElixir.Opencode.AppServer`.
- Start/connect to OpenCode through `opencode_client`, including sessions, prompts, SSE, and cleanup.
- Preserve dashboard-compatible update events while normalizing OpenCode stream events.
- Add OpenCode backend lifecycle tests and update Symphony Elixir docs.
- Add Elixir to root Devbox so CI can run the existing `ex:*` tasks.

#### Alternatives

- Kept the existing Codex app-server implementation as legacy context only; TOT-9 asks to ignore Codex for now.
- Did not add a multi-backend adapter yet because the ticket requests OpenCode-first behavior.

#### Test Plan

- [x] `HEX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.hex_home MIX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.mix_home mix test test/symphony_elixir/opencode_app_server_test.exs test/symphony_elixir/core_test.exs:1119 test/symphony_elixir/core_test.exs:1174 test/symphony_elixir/core_test.exs:1304 test/symphony_elixir/core_test.exs:1389`
- [x] `HEX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.hex_home MIX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.mix_home mix test test/opencode_client_test.exs`
- [x] `HEX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.hex_home MIX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.mix_home mix test test/symphony_elixir/workspace_and_config_test.exs`
- [x] `HEX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.hex_home MIX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.mix_home mix format --check-formatted elixir/symphony_elixir/lib/symphony_elixir/agent_runner.ex elixir/symphony_elixir/lib/symphony_elixir/opencode/app_server.ex elixir/symphony_elixir/test/support/opencode_fakes.exs elixir/symphony_elixir/test/symphony_elixir/opencode_app_server_test.exs elixir/symphony_elixir/test/symphony_elixir/core_test.exs elixir/symphony_elixir/test/test_helper.exs elixir/opencode_client/lib/opencode_client/event_stream.ex elixir/opencode_client/test/opencode_client_test.exs`
- [x] `HEX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.hex_home MIX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.mix_home mix compile` in `elixir/symphony_elixir`
- [x] `HEX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.hex_home MIX_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.mix_home mix compile` in `elixir/opencode_client`
- [x] `XDG_CACHE_HOME=/Users/totto2727/symphony-workspaces-test/TOT-9/.devbox-cache devbox run -- mix --version`
- [ ] `vp run ex:check` did not reach Elixir locally: current JS task graph fails resolving `@totto2727/fp/vite` and `vite-plus` from `js/app/feed-platform-backend/vite.config.ts`.

## CI status

- Latest commit SHA: c3e69e7
- Latest `check` job: pending
- Retry history:
  - commit 4405596: attempt 1 failure (`mix` missing in CI Devbox PATH) -> fix push c3e69e7 attempt 2 pending
