### PR TITLE
feat(auth-helper): share BetterAuth session middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _build/
 __pycache__/
 deps/
 log/
+.omo/

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
       "name": "feed-platform-backend",
       "devDependencies": {
         "@totto2727/fp": "workspace:*",
+        "auth-helper": "workspace:*",
         "better-auth": "catalog:auth",
         "effect": "catalog:effect",
         "effect-hono": "workspace:*",
@@ -177,6 +178,12 @@
       "version": "0.0.0",
       "devDependencies": {
         "@totto2727/fp": "workspace:*",
+        "effect": "catalog:effect",
+        "hono": "catalog:hono",
+      },
+      "peerDependencies": {
+        "effect": "catalog:effect",
+        "hono": "catalog:hono",
       },
     },
     "js/package/effect-hono": {

--- a/bun.lock
+++ b/bun.lock
@@ -97,6 +97,7 @@
         "@cloudflare/vite-plugin": "catalog:cloudflare",
         "@libsql/kysely-libsql": "catalog:database",
         "@totto2727/fp": "workspace:*",
+        "auth-helper": "workspace:*",
         "better-auth": "catalog:auth",
         "effect": "catalog:effect",
         "effect-hono": "workspace:*",

--- a/js/app/feed-platform-backend/package.json
+++ b/js/app/feed-platform-backend/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@totto2727/fp": "workspace:*",
+    "auth-helper": "workspace:*",
     "better-auth": "catalog:auth",
     "effect": "catalog:effect",
     "effect-hono": "workspace:*",

--- a/js/app/feed-platform-backend/src/feature/auth/context.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/context.ts
@@ -1,6 +1,5 @@
+import type { AuthUser } from 'auth-helper'
+
 export interface Variables {
-  readonly user: {
-    readonly email: string
-    readonly sub: string
-  }
+  readonly user: AuthUser
 }

--- a/js/app/feed-platform-backend/src/feature/auth/context.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/context.ts
@@ -1,5 +1,5 @@
 import type { AuthUser } from 'auth-helper'
 
 export interface Variables {
-  readonly user: AuthUser
+  readonly user: AuthUser | null
 }

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
@@ -65,7 +65,7 @@ describe('authMiddleware', () => {
       localBindings,
     )
     expect(res.status).toBe(200)
-    expect(await res.json()).toStrictEqual({ email: 'user@example.com', sub: 'user-123' })
+    expect(await res.json()).toStrictEqual({ email: 'user@example.com', id: 'user-123' })
   })
 
   it('returns 401 from requireAuthMiddleware when Better Auth has no session', async () => {

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
@@ -17,7 +17,7 @@ vi.mock('better-auth/plugins', () => ({
   bearer: vi.fn(() => ({})),
 }))
 
-const { authMiddleware } = await import('./middleware.ts')
+const { authMiddleware, requireAuthMiddleware } = await import('./middleware.ts')
 const { middleware: runtimeMiddleware } = await import('#@/feature/runtime/hono.ts')
 
 const localBindings = {
@@ -29,7 +29,17 @@ const makeApp = () => {
   app.use(contextStorage())
   app.use(runtimeMiddleware)
   app.use('/api/*', authMiddleware)
+  app.use('/api/*', requireAuthMiddleware)
   app.get('/api/v1/me', (ctx) => ctx.json(ctx.var.user))
+  return app
+}
+
+const makeSetupOnlyApp = () => {
+  const app = new Hono<Env>()
+  app.use(contextStorage())
+  app.use(runtimeMiddleware)
+  app.use('/api/*', authMiddleware)
+  app.get('/api/public', (ctx) => ctx.json({ user: ctx.var.user }))
   return app
 }
 
@@ -38,6 +48,14 @@ beforeEach(() => {
 })
 
 describe('authMiddleware', () => {
+  it('sets user to null and passes through when Better Auth has no session', async () => {
+    mockGetSession.mockResolvedValue(null)
+    const app = makeSetupOnlyApp()
+    const res = await app.request('/api/public', {}, localBindings)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toStrictEqual({ user: null })
+  })
+
   it('sets user and passes through for a valid Better Auth session', async () => {
     mockGetSession.mockResolvedValue({ user: { email: 'user@example.com', id: 'user-123' } })
     const app = makeApp()
@@ -50,7 +68,7 @@ describe('authMiddleware', () => {
     expect(await res.json()).toStrictEqual({ email: 'user@example.com', sub: 'user-123' })
   })
 
-  it('returns 401 when Better Auth has no session', async () => {
+  it('returns 401 from requireAuthMiddleware when Better Auth has no session', async () => {
     mockGetSession.mockResolvedValue(null)
     const app = makeApp()
     const res = await app.request('/api/v1/me', {}, localBindings)
@@ -58,7 +76,7 @@ describe('authMiddleware', () => {
     expect(res.headers.get('WWW-Authenticate')).toBe('Session error="invalid_session"')
   })
 
-  it('returns 401 for an invalid Better Auth user shape', async () => {
+  it('returns 401 from requireAuthMiddleware for an invalid Better Auth user shape', async () => {
     mockGetSession.mockResolvedValue({ user: { id: 'user-123' } })
     const app = makeApp()
     const res = await app.request(

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.ts
@@ -1,12 +1,24 @@
-import { createRequiredBetterAuthMiddleware } from 'auth-helper'
+import { createBetterAuthSetupMiddleware } from 'auth-helper'
+import { Predicate } from 'effect'
 
 import { factory } from '#@/feature/share/lib/hono/factory.ts'
 
 import * as BetterAuth from './better-auth.ts'
 
-export const authMiddleware = createRequiredBetterAuthMiddleware({
+export const authMiddleware = createBetterAuthSetupMiddleware({
   factory,
   // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.
-  runPromise: (ctx, runtime) => ctx.var.runtime.runPromise(runtime),
+  runPromise: (ctx, effect) => ctx.var.runtime.runPromise(effect),
   service: BetterAuth.Service,
+})
+
+export const requireAuthMiddleware = factory.createMiddleware(async (ctx, next): Promise<Response> => {
+  if (Predicate.isNotNullish(ctx.var.user)) {
+    await next()
+    return ctx.res
+  }
+
+  return ctx.json({ error: 'Unauthorized' }, 401, {
+    'WWW-Authenticate': 'Session error="invalid_session"',
+  })
 })

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.ts
@@ -1,5 +1,4 @@
-import { createBetterAuthSetupMiddleware } from 'auth-helper'
-import { Predicate } from 'effect'
+import { createBetterAuthSetupMiddleware, requireAuthMiddleware as authHelperRequireAuthMiddleware } from 'auth-helper'
 
 import { factory } from '#@/feature/share/lib/hono/factory.ts'
 
@@ -12,13 +11,10 @@ export const authMiddleware = createBetterAuthSetupMiddleware({
   service: BetterAuth.Service,
 })
 
-export const requireAuthMiddleware = factory.createMiddleware(async (ctx, next): Promise<Response> => {
-  if (Predicate.isNotNullish(ctx.var.user)) {
-    await next()
-    return ctx.res
-  }
-
-  return ctx.json({ error: 'Unauthorized' }, 401, {
-    'WWW-Authenticate': 'Session error="invalid_session"',
-  })
+export const requireAuthMiddleware = authHelperRequireAuthMiddleware({
+  factory,
+  onUnauthenticated: (ctx) =>
+    ctx.json({ error: 'Unauthorized' }, 401, {
+      'WWW-Authenticate': 'Session error="invalid_session"',
+    }),
 })

--- a/js/app/feed-platform-backend/src/feature/auth/middleware.ts
+++ b/js/app/feed-platform-backend/src/feature/auth/middleware.ts
@@ -1,42 +1,12 @@
-import { Effect, Option, Predicate, Schema } from 'effect'
+import { createRequiredBetterAuthMiddleware } from 'auth-helper'
 
-import * as HonoContext from '#@/feature/share/lib/hono/context.ts'
 import { factory } from '#@/feature/share/lib/hono/factory.ts'
 
 import * as BetterAuth from './better-auth.ts'
 
-const AuthUserPayload = Schema.Struct({
-  email: Schema.String,
-  id: Schema.String,
-})
-
-// oxlint-disable-next-line rules/prefer-non-unknown-decode -- Better Auth session user is an external auth boundary.
-const decodeAuthUserPayload = Schema.decodeUnknownOption(AuthUserPayload)
-
-const verifyUser = Effect.gen(function* () {
-  const auth = yield* BetterAuth.Service
-  const result = yield* Effect.tryPromise(() => auth.api.getSession({ headers: HonoContext.get().req.raw.headers }))
-  if (Predicate.isNullish(result)) {
-    return null
-  }
-  return Option.match(decodeAuthUserPayload(result.user), {
-    onNone: () => null,
-    onSome: (user) => user,
-  })
-})
-
-export const authMiddleware = factory.createMiddleware((ctx, next) => {
-  const runtime = Effect.gen(function* () {
-    const user = yield* verifyUser
-    if (Predicate.isNullish(user)) {
-      return ctx.json({ error: 'Unauthorized' }, 401, {
-        'WWW-Authenticate': 'Session error="invalid_session"',
-      })
-    }
-    ctx.set('user', { email: user.email, sub: user.id })
-    return yield* Effect.promise(() => next())
-  })
-  const catchedRuntime = runtime
+export const authMiddleware = createRequiredBetterAuthMiddleware({
+  factory,
   // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.
-  return ctx.var.runtime.runPromise(catchedRuntime)
+  runPromise: (ctx, runtime) => ctx.var.runtime.runPromise(runtime),
+  service: BetterAuth.Service,
 })

--- a/js/app/feed-platform-backend/src/worker/bff/worker.ts
+++ b/js/app/feed-platform-backend/src/worker/bff/worker.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono'
 import { contextStorage } from 'hono/context-storage'
 import { logger } from 'hono/logger'
 
-import { authMiddleware } from '#@/feature/auth/middleware.ts'
+import { authMiddleware, requireAuthMiddleware } from '#@/feature/auth/middleware.ts'
 import * as Health from '#@/feature/health.ts'
 import { middleware as runtimeMiddleware } from '#@/feature/runtime/hono.ts'
 import type { Env } from '#@/feature/share/lib/hono/context.ts'
@@ -26,6 +26,7 @@ const app = new Hono<Env>()
     ),
   )
   .use('/api/*', authMiddleware)
+  .use('/api/*', requireAuthMiddleware)
   .get('/api/v1/me', (ctx) => ctx.json(ctx.var.user))
 
 export default app

--- a/js/app/feed-platform-web/app/app.tsx
+++ b/js/app/feed-platform-web/app/app.tsx
@@ -101,7 +101,7 @@ const app: Hono<Env> = new Hono<Env>()
           <Document>
             <h1>Dashboard</h1>
             <p>Logged in as: {user.email}</p>
-            <p>Subject: {user.sub}</p>
+            <p>User ID: {user.id}</p>
             <form method='post' action='/app/logout'>
               <button type='submit'>Logout</button>
             </form>

--- a/js/app/feed-platform-web/app/feature/api/client.test.ts
+++ b/js/app/feed-platform-web/app/feature/api/client.test.ts
@@ -35,7 +35,7 @@ const makeTestLayer = (response: Response) =>
   liveLayer.pipe(Layer.provideMerge(makeHttpClientLayer(response)), Layer.provide(Env.makeLayer(testEnv)))
 
 const successResponse = () =>
-  Promise.resolve(Response.json({ email: 'user@example.com', sub: 'user-1' }, { status: 200 }))
+  Promise.resolve(Response.json({ email: 'user@example.com', id: 'user-1' }, { status: 200 }))
 
 afterEach(() => {
   capturedRequests.length = 0
@@ -79,6 +79,6 @@ describe('BackendClient', () => {
     expect(capturedRequests[0]?.headers.cookie).toBe(
       'unrelated=value; better-auth.session_token=session-token; oauth_state=state',
     )
-    expect(await res.json()).toStrictEqual({ data: { email: 'user@example.com', sub: 'user-1' }, ok: true })
+    expect(await res.json()).toStrictEqual({ data: { email: 'user@example.com', id: 'user-1' }, ok: true })
   })
 })

--- a/js/app/feed-platform-web/app/feature/api/client.ts
+++ b/js/app/feed-platform-web/app/feature/api/client.ts
@@ -7,7 +7,7 @@ import * as HonoContext from '#@/feature/share/lib/hono/context.ts'
 
 export interface UserDTO {
   readonly email: string
-  readonly sub: string
+  readonly id: string
 }
 
 export class BackendError extends Data.TaggedError('BackendError')<TaggedErrorBaseType> {}
@@ -20,7 +20,7 @@ export const BackendClient = Context.Service<BackendClientService>('BackendClien
 
 const UserResponse = Schema.Struct({
   email: Schema.String,
-  sub: Schema.String,
+  id: Schema.String,
 })
 
 // oxlint-disable-next-line rules/prefer-non-unknown-decode -- backend JSON response is an external boundary with unknown shape.
@@ -40,7 +40,7 @@ const callBackendApi = (baseUrl: string) =>
     const user = yield* decodeUserResponse(data).pipe(
       Effect.mapError((error) => new BackendError({ error, message: 'invalid response shape' })),
     )
-    return { email: user.email, sub: user.sub }
+    return { email: user.email, id: user.id }
   })
 
 const makeCallMe =
@@ -61,5 +61,5 @@ export const liveLayer = Layer.effect(
 )
 
 export const mockLayer = Layer.succeed(BackendClient, {
-  callMe: () => Effect.succeed({ email: 'mock@example.com', sub: 'mock-user' }),
+  callMe: () => Effect.succeed({ email: 'mock@example.com', id: 'mock-user' }),
 })

--- a/js/app/feed-platform-web/app/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-web/app/feature/auth/middleware.test.ts
@@ -54,7 +54,7 @@ describe('authMiddleware', () => {
     const app = makeApp()
     const res = await app.request('/test', { headers: { cookie: 'better-auth.session_token=session-token' } })
     expect(res.status).toBe(200)
-    expect(await res.json()).toStrictEqual({ user: { email: 'test@example.com', sub: 'user-123' } })
+    expect(await res.json()).toStrictEqual({ user: { email: 'test@example.com', id: 'user-123' } })
     expect(mockBetterAuth).toHaveBeenCalledTimes(1)
   })
 

--- a/js/app/feed-platform-web/app/feature/auth/middleware.test.ts
+++ b/js/app/feed-platform-web/app/feature/auth/middleware.test.ts
@@ -54,7 +54,7 @@ describe('authMiddleware', () => {
     const app = makeApp()
     const res = await app.request('/test', { headers: { cookie: 'better-auth.session_token=session-token' } })
     expect(res.status).toBe(200)
-    expect(await res.json()).toStrictEqual({ user: { email: 'test@example.com', id: 'user-123' } })
+    expect(await res.json()).toStrictEqual({ user: { email: 'test@example.com', sub: 'user-123' } })
     expect(mockBetterAuth).toHaveBeenCalledTimes(1)
   })
 

--- a/js/app/feed-platform-web/app/feature/auth/middleware.ts
+++ b/js/app/feed-platform-web/app/feature/auth/middleware.ts
@@ -1,5 +1,4 @@
-import { createBetterAuthSetupMiddleware } from 'auth-helper'
-import { Predicate } from 'effect'
+import { createBetterAuthSetupMiddleware, requireAuthMiddleware as authHelperRequireAuthMiddleware } from 'auth-helper'
 
 import { factory } from '#@/feature/share/lib/hono/factory.ts'
 
@@ -15,13 +14,10 @@ export const authMiddleware = createBetterAuthSetupMiddleware({
   service: BetterAuth.Service,
 })
 
-export const requireAuthMiddleware = factory.createMiddleware((ctx, next) => {
-  if (!Predicate.isNullish(ctx.var.user)) {
-    return next()
-  }
-
-  setLoginReturnToCookie(getReturnToPath(ctx.req.url))
-  return Promise.resolve(
-    ctx.redirect(`/app/login?${preserveReturnToQueryParameterName}=${preserveReturnToQueryParameterValue}`),
-  )
+export const requireAuthMiddleware = authHelperRequireAuthMiddleware({
+  factory,
+  onUnauthenticated: (ctx) => {
+    setLoginReturnToCookie(getReturnToPath(ctx.req.url))
+    return ctx.redirect(`/app/login?${preserveReturnToQueryParameterName}=${preserveReturnToQueryParameterValue}`)
+  },
 })

--- a/js/app/feed-platform-web/app/feature/auth/middleware.ts
+++ b/js/app/feed-platform-web/app/feature/auth/middleware.ts
@@ -1,4 +1,4 @@
-import { createOptionalBetterAuthMiddleware } from 'auth-helper'
+import { createBetterAuthSetupMiddleware } from 'auth-helper'
 import { Predicate } from 'effect'
 
 import { factory } from '#@/feature/share/lib/hono/factory.ts'
@@ -8,10 +8,10 @@ import { setLoginReturnToCookie } from './cookie.ts'
 import { preserveReturnToQueryParameterName, preserveReturnToQueryParameterValue } from './query-parameter.ts'
 import { getReturnToPath } from './return-to.ts'
 
-export const authMiddleware = createOptionalBetterAuthMiddleware({
+export const authMiddleware = createBetterAuthSetupMiddleware({
   factory,
   // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes the auth workflow once.
-  runPromise: (ctx, runtime) => ctx.var.runtime.runPromise(runtime),
+  runPromise: (ctx, effect) => ctx.var.runtime.runPromise(effect),
   service: BetterAuth.Service,
 })
 

--- a/js/app/feed-platform-web/app/feature/auth/middleware.ts
+++ b/js/app/feed-platform-web/app/feature/auth/middleware.ts
@@ -1,4 +1,5 @@
-import { Effect, Option, Predicate, Schema } from 'effect'
+import { createOptionalBetterAuthMiddleware } from 'auth-helper'
+import { Predicate } from 'effect'
 
 import { factory } from '#@/feature/share/lib/hono/factory.ts'
 
@@ -7,35 +8,11 @@ import { setLoginReturnToCookie } from './cookie.ts'
 import { preserveReturnToQueryParameterName, preserveReturnToQueryParameterValue } from './query-parameter.ts'
 import { getReturnToPath } from './return-to.ts'
 
-const AuthUserPayload = Schema.Struct({
-  email: Schema.String,
-  id: Schema.String,
-})
-
-const decodeAuthUserPayload = Schema.decodeOption(AuthUserPayload)
-
-const verifyUser = Effect.fn(function* (headers: Headers) {
-  const auth = yield* BetterAuth.Service
-  const session = yield* Effect.tryPromise(() => auth.api.getSession({ headers }))
-
-  if (Predicate.isNullish(session)) {
-    return null
-  }
-  return Option.match(decodeAuthUserPayload(session.user), {
-    onNone: () => null,
-    onSome: (user) => user,
-  })
-})
-
-export const authMiddleware = factory.createMiddleware((ctx, next) => {
-  const runtime = Effect.gen(function* () {
-    ctx.set('user', yield verifyUser(ctx.req.raw.headers))
-
-    yield* Effect.promise(() => next())
-  })
-  const catchedRuntime = runtime
+export const authMiddleware = createOptionalBetterAuthMiddleware({
+  factory,
   // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes the auth workflow once.
-  return ctx.var.runtime.runPromise(catchedRuntime)
+  runPromise: (ctx, runtime) => ctx.var.runtime.runPromise(runtime),
+  service: BetterAuth.Service,
 })
 
 export const requireAuthMiddleware = factory.createMiddleware((ctx, next) => {

--- a/js/app/feed-platform-web/app/feature/runtime/hono.ts
+++ b/js/app/feed-platform-web/app/feature/runtime/hono.ts
@@ -1,15 +1,11 @@
+import type { OptionalAuthVariables } from 'auth-helper'
+
 import { factory } from '#@/feature/share/lib/hono/factory.ts'
 
 import * as Runtime from './server.ts'
 
-export interface Variables {
+export interface Variables extends OptionalAuthVariables {
   readonly runtime: Runtime.Runtime
-  readonly user: AuthUser | null
-}
-
-export interface AuthUser {
-  readonly email: string
-  readonly sub: string
 }
 
 export const middleware = factory.createMiddleware(async (ctx, next) => {

--- a/js/app/identity-provider/app/app.tsx
+++ b/js/app/identity-provider/app/app.tsx
@@ -1,11 +1,13 @@
-import { DateTime } from 'effect'
+import { DateTime, Effect, Predicate } from 'effect'
 import { remixRenderer } from 'hono-remix-middleware'
 import { contextStorage } from 'hono/context-storage'
 import { logger } from 'hono/logger'
 
+import * as BetterAuth from '#@/feature/auth/better-auth.ts'
 import { deleteLoginReturnToCookie, getLoginReturnToCookie, setLoginReturnToCookie } from '#@/feature/auth/cookie.ts'
 import { authMiddleware, requireAuthMiddleware, requireLoginSessionMiddleware } from '#@/feature/auth/middleware.ts'
 import {
+  preserveReturnToLoginPath,
   preserveReturnToQueryParameterName,
   preserveReturnToQueryParameterValue,
 } from '#@/feature/auth/query-parameter.ts'
@@ -20,7 +22,15 @@ import { LoginPage } from '#@/ui/login.tsx'
 import { RegisterPasskeyPage } from '#@/ui/register-passkey.tsx'
 import { SelectAccountPage } from '#@/ui/select-account.tsx'
 
-const api = factory.createApp().all('/auth/*', (ctx) => ctx.var.auth.handler(ctx.req.raw))
+const api = factory.createApp().all('/auth/*', (ctx) =>
+  // oxlint-disable-next-line rules/no-effect-runtime-run -- Better Auth API handler is the HTTP boundary for the request runtime.
+  ctx.var.runtime.runPromise(
+    Effect.gen(function* () {
+      const auth = yield* BetterAuth.Service
+      return auth.handler(ctx.req.raw)
+    }),
+  ),
+)
 
 const loginRoutes = factory
   .createApp()
@@ -56,6 +66,9 @@ const loginRoutes = factory
   })
   .get('/select-account', requireLoginSessionMiddleware, (ctx) => {
     const { user } = ctx.var
+    if (Predicate.isNullish(user)) {
+      return ctx.redirect('/login')
+    }
     const oauthQuery = new URL(ctx.req.url).searchParams.toString()
     return ctx.render(
       <Document title='アカウントの選択'>
@@ -74,6 +87,9 @@ const appRoutes = factory
   .use(requireAuthMiddleware)
   .get('/account', (ctx) => {
     const { user } = ctx.var
+    if (Predicate.isNullish(user)) {
+      return ctx.redirect(preserveReturnToLoginPath)
+    }
     const createdAt = new Intl.DateTimeFormat('ja-JP').format(DateTime.toDate(user.createdAt))
     return ctx.render(
       <Document title='アカウント'>
@@ -94,8 +110,8 @@ const app = factory
   .use(logger())
   .use(contextStorage())
   .use(runtimeMiddleware)
-  .use(authMiddleware)
   .route('/api/v1', api)
+  .use(authMiddleware)
   .use(
     '*',
     remixRenderer({

--- a/js/app/identity-provider/app/app.tsx
+++ b/js/app/identity-provider/app/app.tsx
@@ -1,13 +1,11 @@
-import { DateTime, Effect, Predicate } from 'effect'
+import { DateTime } from 'effect'
 import { remixRenderer } from 'hono-remix-middleware'
 import { contextStorage } from 'hono/context-storage'
 import { logger } from 'hono/logger'
 
-import * as BetterAuth from '#@/feature/auth/better-auth.ts'
 import { deleteLoginReturnToCookie, getLoginReturnToCookie, setLoginReturnToCookie } from '#@/feature/auth/cookie.ts'
 import { authMiddleware, requireAuthMiddleware, requireLoginSessionMiddleware } from '#@/feature/auth/middleware.ts'
 import {
-  preserveReturnToLoginPath,
   preserveReturnToQueryParameterName,
   preserveReturnToQueryParameterValue,
 } from '#@/feature/auth/query-parameter.ts'
@@ -22,15 +20,7 @@ import { LoginPage } from '#@/ui/login.tsx'
 import { RegisterPasskeyPage } from '#@/ui/register-passkey.tsx'
 import { SelectAccountPage } from '#@/ui/select-account.tsx'
 
-const api = factory.createApp().all('/auth/*', (ctx) =>
-  // oxlint-disable-next-line rules/no-effect-runtime-run -- Better Auth API handler is the HTTP boundary for the request runtime.
-  ctx.var.runtime.runPromise(
-    Effect.gen(function* () {
-      const auth = yield* BetterAuth.Service
-      return auth.handler(ctx.req.raw)
-    }),
-  ),
-)
+const api = factory.createApp().all('/auth/*', (ctx) => ctx.var.auth.handler(ctx.req.raw))
 
 const loginRoutes = factory
   .createApp()
@@ -66,9 +56,6 @@ const loginRoutes = factory
   })
   .get('/select-account', requireLoginSessionMiddleware, (ctx) => {
     const { user } = ctx.var
-    if (Predicate.isNullish(user)) {
-      return ctx.redirect('/login')
-    }
     const oauthQuery = new URL(ctx.req.url).searchParams.toString()
     return ctx.render(
       <Document title='アカウントの選択'>
@@ -87,9 +74,6 @@ const appRoutes = factory
   .use(requireAuthMiddleware)
   .get('/account', (ctx) => {
     const { user } = ctx.var
-    if (Predicate.isNullish(user)) {
-      return ctx.redirect(preserveReturnToLoginPath)
-    }
     const createdAt = new Intl.DateTimeFormat('ja-JP').format(DateTime.toDate(user.createdAt))
     return ctx.render(
       <Document title='アカウント'>
@@ -110,8 +94,8 @@ const app = factory
   .use(logger())
   .use(contextStorage())
   .use(runtimeMiddleware)
-  .route('/api/v1', api)
   .use(authMiddleware)
+  .route('/api/v1', api)
   .use(
     '*',
     remixRenderer({

--- a/js/app/identity-provider/app/app.tsx
+++ b/js/app/identity-provider/app/app.tsx
@@ -1,8 +1,9 @@
-import { DateTime } from 'effect'
+import { Effect } from 'effect'
 import { remixRenderer } from 'hono-remix-middleware'
 import { contextStorage } from 'hono/context-storage'
 import { logger } from 'hono/logger'
 
+import * as BetterAuth from '#@/feature/auth/better-auth.ts'
 import { deleteLoginReturnToCookie, getLoginReturnToCookie, setLoginReturnToCookie } from '#@/feature/auth/cookie.ts'
 import { authMiddleware, requireAuthMiddleware, requireLoginSessionMiddleware } from '#@/feature/auth/middleware.ts'
 import {
@@ -20,7 +21,15 @@ import { LoginPage } from '#@/ui/login.tsx'
 import { RegisterPasskeyPage } from '#@/ui/register-passkey.tsx'
 import { SelectAccountPage } from '#@/ui/select-account.tsx'
 
-const api = factory.createApp().all('/auth/*', (ctx) => ctx.var.auth.handler(ctx.req.raw))
+const api = factory.createApp().all('/auth/*', (ctx) =>
+  // oxlint-disable-next-line rules/no-effect-runtime-run -- Better Auth API handler is the HTTP boundary for the request runtime.
+  ctx.var.runtime.runPromise(
+    Effect.gen(function* () {
+      const auth = yield* BetterAuth.Service
+      return auth.handler(ctx.req.raw)
+    }),
+  ),
+)
 
 const loginRoutes = factory
   .createApp()
@@ -74,10 +83,9 @@ const appRoutes = factory
   .use(requireAuthMiddleware)
   .get('/account', (ctx) => {
     const { user } = ctx.var
-    const createdAt = new Intl.DateTimeFormat('ja-JP').format(DateTime.toDate(user.createdAt))
     return ctx.render(
       <Document title='アカウント'>
-        <AccountPage email={user.email} createdAt={createdAt} />
+        <AccountPage email={user.email} />
       </Document>,
     )
   })

--- a/js/app/identity-provider/app/feature/auth/middleware.test.ts
+++ b/js/app/identity-provider/app/feature/auth/middleware.test.ts
@@ -1,4 +1,4 @@
-import { DateTime, Predicate } from 'effect'
+import { Predicate } from 'effect'
 import { Hono } from 'hono'
 import { contextStorage } from 'hono/context-storage'
 import { describe, expect, it } from 'vite-plus/test'
@@ -33,9 +33,8 @@ describe('requireAuthMiddleware', () => {
 
   it('passes authenticated app requests through', async () => {
     const app = makeProtectedApp({
-      createdAt: DateTime.makeUnsafe('2026-07-05T00:00:00.000Z'),
       email: 'test@example.com',
-      id: 'user-123',
+      sub: 'user-123',
     })
 
     const res = await app.request('/app/account')

--- a/js/app/identity-provider/app/feature/auth/middleware.test.ts
+++ b/js/app/identity-provider/app/feature/auth/middleware.test.ts
@@ -1,0 +1,46 @@
+import { DateTime, Predicate } from 'effect'
+import { Hono } from 'hono'
+import { contextStorage } from 'hono/context-storage'
+import { describe, expect, it } from 'vite-plus/test'
+
+import type { Env } from '#@/feature/share/lib/hono/context.ts'
+
+import { loginReturnToCookieName } from './cookie.ts'
+import { requireAuthMiddleware } from './middleware.ts'
+import { preserveReturnToLoginPath } from './query-parameter.ts'
+
+const makeProtectedApp = (user: Env['Variables']['user'] | null) =>
+  new Hono<Env>()
+    .use(contextStorage())
+    .use((ctx, next) => {
+      if (Predicate.isNotNull(user)) {
+        ctx.set('user', user)
+      }
+      return next()
+    })
+    .get('/app/account', requireAuthMiddleware, (ctx) => ctx.text(ctx.var.user?.email ?? 'missing'))
+
+describe('requireAuthMiddleware', () => {
+  it('redirects unauthenticated app requests to login with a return-to cookie', async () => {
+    const app = makeProtectedApp(null)
+
+    const res = await app.request('/app/account?tab=security')
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe(preserveReturnToLoginPath)
+    expect(res.headers.get('set-cookie')).toContain(`${loginReturnToCookieName}=%2Fapp%2Faccount%3Ftab%3Dsecurity`)
+  })
+
+  it('passes authenticated app requests through', async () => {
+    const app = makeProtectedApp({
+      createdAt: DateTime.makeUnsafe('2026-07-05T00:00:00.000Z'),
+      email: 'test@example.com',
+      id: 'user-123',
+    })
+
+    const res = await app.request('/app/account')
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('test@example.com')
+  })
+})

--- a/js/app/identity-provider/app/feature/auth/middleware.test.ts
+++ b/js/app/identity-provider/app/feature/auth/middleware.test.ts
@@ -34,7 +34,7 @@ describe('requireAuthMiddleware', () => {
   it('passes authenticated app requests through', async () => {
     const app = makeProtectedApp({
       email: 'test@example.com',
-      sub: 'user-123',
+      id: 'user-123',
     })
 
     const res = await app.request('/app/account')

--- a/js/app/identity-provider/app/feature/auth/middleware.ts
+++ b/js/app/identity-provider/app/feature/auth/middleware.ts
@@ -1,73 +1,40 @@
-import { createBetterAuthSetupMiddleware } from 'auth-helper'
-import { DateTime, Option, Predicate, Schema } from 'effect'
+import {
+  createBetterAuthSetupMiddleware,
+  requireAuthMiddleware as authHelperRequireAuthMiddleware,
+  toIdentityProviderAuthUser,
+} from 'auth-helper'
+import { Predicate } from 'effect'
 
 import { setLoginReturnToCookie } from '#@/feature/auth/cookie.ts'
 import { preserveReturnToLoginPath } from '#@/feature/auth/query-parameter.ts'
 import { getReturnToPath } from '#@/feature/auth/return-to.ts'
-import type { AuthUser } from '#@/feature/share/lib/hono/context.ts'
 import { factory } from '#@/feature/share/lib/hono/factory.ts'
 
 import * as BetterAuth from './better-auth.ts'
 
-const BetterAuthUserPayload = Schema.Struct({
-  createdAt: Schema.Unknown,
-  email: Schema.String,
-  id: Schema.String,
-})
-
-const decodeBetterAuthUserPayload = Schema.decodeUnknownOption(BetterAuthUserPayload)
-
-const mapAuthUser = (user: unknown): AuthUser | null => {
-  const decodedUser = Option.getOrNull(decodeBetterAuthUserPayload(user))
-  if (Predicate.isNullish(decodedUser)) {
-    return null
-  }
-  const { createdAt: rawCreatedAt } = decodedUser
-  const createdAt = (() => {
-    if (Predicate.isString(rawCreatedAt)) {
-      return rawCreatedAt
-    }
-    if (rawCreatedAt instanceof Date) {
-      return rawCreatedAt.toISOString()
-    }
-    return null
-  })()
-  if (Predicate.isNullish(createdAt)) {
-    return null
-  }
-  return {
-    createdAt: DateTime.makeUnsafe(createdAt),
-    email: decodedUser.email,
-    id: decodedUser.id,
-  }
-}
-
 export const authMiddleware = createBetterAuthSetupMiddleware({
   factory,
-  mapUser: mapAuthUser,
+  mapUser: toIdentityProviderAuthUser,
+  onAuth: (ctx, auth) => {
+    ctx.set('auth', auth)
+  },
   // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.
   runPromise: (ctx, effect) => ctx.var.runtime.runPromise(effect),
   service: BetterAuth.Service,
 })
 
-export const requireAuthMiddleware = factory.createMiddleware(async (ctx, next) => {
-  const { user } = ctx.var
-  if (Predicate.isNullish(user)) {
+export const requireAuthMiddleware = authHelperRequireAuthMiddleware({
+  factory,
+  onUnauthenticated: (ctx) => {
     const returnTo = getReturnToPath(ctx.req.url)
     if (Predicate.isNotNullish(returnTo)) {
       setLoginReturnToCookie(returnTo)
     }
     return ctx.redirect(preserveReturnToLoginPath)
-  }
-  await next()
-  return ctx.res
+  },
 })
 
-export const requireLoginSessionMiddleware = factory.createMiddleware(async (ctx, next) => {
-  const { user } = ctx.var
-  if (Predicate.isNullish(user)) {
-    return ctx.redirect('/login')
-  }
-  await next()
-  return ctx.res
+export const requireLoginSessionMiddleware = authHelperRequireAuthMiddleware({
+  factory,
+  onUnauthenticated: (ctx) => ctx.redirect('/login'),
 })

--- a/js/app/identity-provider/app/feature/auth/middleware.ts
+++ b/js/app/identity-provider/app/feature/auth/middleware.ts
@@ -1,8 +1,4 @@
-import {
-  createBetterAuthSetupMiddleware,
-  requireAuthMiddleware as authHelperRequireAuthMiddleware,
-  toIdentityProviderAuthUser,
-} from 'auth-helper'
+import { createBetterAuthSetupMiddleware, requireAuthMiddleware as authHelperRequireAuthMiddleware } from 'auth-helper'
 import { Predicate } from 'effect'
 
 import { setLoginReturnToCookie } from '#@/feature/auth/cookie.ts'
@@ -14,10 +10,6 @@ import * as BetterAuth from './better-auth.ts'
 
 export const authMiddleware = createBetterAuthSetupMiddleware({
   factory,
-  mapUser: toIdentityProviderAuthUser,
-  onAuth: (ctx, auth) => {
-    ctx.set('auth', auth)
-  },
   // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.
   runPromise: (ctx, effect) => ctx.var.runtime.runPromise(effect),
   service: BetterAuth.Service,

--- a/js/app/identity-provider/app/feature/auth/middleware.ts
+++ b/js/app/identity-provider/app/feature/auth/middleware.ts
@@ -1,4 +1,5 @@
-import { DateTime, Effect, Predicate } from 'effect'
+import { createBetterAuthSetupMiddleware } from 'auth-helper'
+import { DateTime, Option, Predicate, Schema } from 'effect'
 
 import { setLoginReturnToCookie } from '#@/feature/auth/cookie.ts'
 import { preserveReturnToLoginPath } from '#@/feature/auth/query-parameter.ts'
@@ -8,38 +9,49 @@ import { factory } from '#@/feature/share/lib/hono/factory.ts'
 
 import * as BetterAuth from './better-auth.ts'
 
-type BetterAuthSession = NonNullable<Awaited<ReturnType<BetterAuth.Instance['api']['getSession']>>>
+const BetterAuthUserPayload = Schema.Struct({
+  createdAt: Schema.Unknown,
+  email: Schema.String,
+  id: Schema.String,
+})
 
-const toAuthUser = (session: BetterAuthSession): AuthUser | null => {
-  const { user } = session
-  if (!Predicate.isString(user.id)) {
+const decodeBetterAuthUserPayload = Schema.decodeUnknownOption(BetterAuthUserPayload)
+
+const mapAuthUser = (user: unknown): AuthUser | null => {
+  const decodedUser = Option.getOrNull(decodeBetterAuthUserPayload(user))
+  if (Predicate.isNullish(decodedUser)) {
+    return null
+  }
+  const { createdAt: rawCreatedAt } = decodedUser
+  const createdAt = (() => {
+    if (Predicate.isString(rawCreatedAt)) {
+      return rawCreatedAt
+    }
+    if (rawCreatedAt instanceof Date) {
+      return rawCreatedAt.toISOString()
+    }
+    return null
+  })()
+  if (Predicate.isNullish(createdAt)) {
     return null
   }
   return {
-    createdAt: DateTime.makeUnsafe(Predicate.isString(user.createdAt) ? user.createdAt : user.createdAt.toISOString()),
-    email: Predicate.isString(user.email) ? user.email : '',
-    id: user.id,
+    createdAt: DateTime.makeUnsafe(createdAt),
+    email: decodedUser.email,
+    id: decodedUser.id,
   }
 }
 
-const getAuthUser = async (auth: BetterAuth.Instance, headers: Headers): Promise<AuthUser | null> => {
-  const session = await auth.api.getSession({ headers })
-  return Predicate.isNullish(session) ? null : toAuthUser(session)
-}
-
-export const authMiddleware = factory.createMiddleware(async (ctx, next) => {
-  // oxlint-disable-next-line rules/no-effect-runtime-run -- Hono middleware boundary reads request runtime service for downstream handlers.
-  const auth = await ctx.var.runtime.runPromise(
-    Effect.gen(function* () {
-      return yield* BetterAuth.Service
-    }),
-  )
-  ctx.set('auth', auth)
-  await next()
+export const authMiddleware = createBetterAuthSetupMiddleware({
+  factory,
+  mapUser: mapAuthUser,
+  // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.
+  runPromise: (ctx, effect) => ctx.var.runtime.runPromise(effect),
+  service: BetterAuth.Service,
 })
 
 export const requireAuthMiddleware = factory.createMiddleware(async (ctx, next) => {
-  const user = await getAuthUser(ctx.var.auth, ctx.req.raw.headers)
+  const { user } = ctx.var
   if (Predicate.isNullish(user)) {
     const returnTo = getReturnToPath(ctx.req.url)
     if (Predicate.isNotNullish(returnTo)) {
@@ -47,17 +59,15 @@ export const requireAuthMiddleware = factory.createMiddleware(async (ctx, next) 
     }
     return ctx.redirect(preserveReturnToLoginPath)
   }
-  ctx.set('user', user)
   await next()
   return ctx.res
 })
 
 export const requireLoginSessionMiddleware = factory.createMiddleware(async (ctx, next) => {
-  const user = await getAuthUser(ctx.var.auth, ctx.req.raw.headers)
+  const { user } = ctx.var
   if (Predicate.isNullish(user)) {
     return ctx.redirect('/login')
   }
-  ctx.set('user', user)
   await next()
   return ctx.res
 })

--- a/js/app/identity-provider/app/feature/share/lib/hono/context.ts
+++ b/js/app/identity-provider/app/feature/share/lib/hono/context.ts
@@ -1,21 +1,13 @@
-import type { DateTime } from 'effect'
+import type { AuthUser } from 'auth-helper'
 import { getContext as getContextFromALC } from 'hono/context-storage'
 
-import type * as BetterAuth from '#@/feature/auth/better-auth.ts'
 import type { Type as Bindings } from '#@/feature/env.ts'
 import type { Runtime } from '#@/feature/runtime/server.ts'
-
-export interface AuthUser {
-  createdAt: DateTime.Utc
-  email: string
-  id: string
-}
 
 export interface Env {
   Bindings: Bindings
   Variables: {
     runtime: Runtime
-    auth: BetterAuth.Instance
     user: AuthUser
   }
 }

--- a/js/app/identity-provider/app/feature/share/lib/hono/context.ts
+++ b/js/app/identity-provider/app/feature/share/lib/hono/context.ts
@@ -1,7 +1,6 @@
 import type { DateTime } from 'effect'
 import { getContext as getContextFromALC } from 'hono/context-storage'
 
-import type * as BetterAuth from '#@/feature/auth/better-auth.ts'
 import type { Type as Bindings } from '#@/feature/env.ts'
 import type { Runtime } from '#@/feature/runtime/server.ts'
 
@@ -15,8 +14,7 @@ export interface Env {
   Bindings: Bindings
   Variables: {
     runtime: Runtime
-    auth: BetterAuth.Instance
-    user: AuthUser
+    user: AuthUser | null
   }
 }
 

--- a/js/app/identity-provider/app/feature/share/lib/hono/context.ts
+++ b/js/app/identity-provider/app/feature/share/lib/hono/context.ts
@@ -1,6 +1,7 @@
 import type { DateTime } from 'effect'
 import { getContext as getContextFromALC } from 'hono/context-storage'
 
+import type * as BetterAuth from '#@/feature/auth/better-auth.ts'
 import type { Type as Bindings } from '#@/feature/env.ts'
 import type { Runtime } from '#@/feature/runtime/server.ts'
 
@@ -14,7 +15,8 @@ export interface Env {
   Bindings: Bindings
   Variables: {
     runtime: Runtime
-    user: AuthUser | null
+    auth: BetterAuth.Instance
+    user: AuthUser
   }
 }
 

--- a/js/app/identity-provider/app/ui/account.tsx
+++ b/js/app/identity-provider/app/ui/account.tsx
@@ -11,7 +11,6 @@ const containerStyle = css({
 
 interface AccountPageProps {
   email: string
-  createdAt: string
 }
 
 export const AccountPage = (handle: Handle<AccountPageProps>) => () => (
@@ -19,9 +18,6 @@ export const AccountPage = (handle: Handle<AccountPageProps>) => () => (
     <h1>アカウント</h1>
     <p>
       <strong>メール:</strong> {handle.props.email}
-    </p>
-    <p>
-      <strong>作成日:</strong> {handle.props.createdAt}
     </p>
     <p>
       <a href='/app/passkey/register'>Passkey を登録</a>

--- a/js/app/identity-provider/package.json
+++ b/js/app/identity-provider/package.json
@@ -16,6 +16,7 @@
     "@cloudflare/vite-plugin": "catalog:cloudflare",
     "@libsql/kysely-libsql": "catalog:database",
     "@totto2727/fp": "workspace:*",
+    "auth-helper": "workspace:*",
     "better-auth": "catalog:auth",
     "effect": "catalog:effect",
     "effect-hono": "workspace:*",

--- a/js/package/auth-helper/package.json
+++ b/js/package/auth-helper/package.json
@@ -7,6 +7,12 @@
     ".": "./src/index.ts"
   },
   "devDependencies": {
-    "@totto2727/fp": "workspace:*"
+    "@totto2727/fp": "workspace:*",
+    "effect": "catalog:effect",
+    "hono": "catalog:hono"
+  },
+  "peerDependencies": {
+    "effect": "catalog:effect",
+    "hono": "catalog:hono"
   }
 }

--- a/js/package/auth-helper/src/better-auth.test.ts
+++ b/js/package/auth-helper/src/better-auth.test.ts
@@ -1,0 +1,38 @@
+import { DateTime } from 'effect'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { toIdentityProviderAuthUser } from './better-auth.ts'
+
+describe('toIdentityProviderAuthUser', () => {
+  it('maps a Better Auth user with a string createdAt value', () => {
+    const user = toIdentityProviderAuthUser({
+      createdAt: '2026-07-05T00:00:00.000Z',
+      email: 'test@example.com',
+      id: 'user-123',
+    })
+
+    expect(user?.email).toBe('test@example.com')
+    expect(user?.id).toBe('user-123')
+    expect(user ? DateTime.toDate(user.createdAt).toISOString() : null).toBe('2026-07-05T00:00:00.000Z')
+  })
+
+  it('maps a Better Auth user with a Date createdAt value', () => {
+    const user = toIdentityProviderAuthUser({
+      createdAt: DateTime.toDate(DateTime.makeUnsafe('2026-07-05T00:00:00.000Z')),
+      email: 'test@example.com',
+      id: 'user-123',
+    })
+
+    expect(user ? DateTime.toDate(user.createdAt).toISOString() : null).toBe('2026-07-05T00:00:00.000Z')
+  })
+
+  it('rejects a Better Auth user without a usable createdAt value', () => {
+    const user = toIdentityProviderAuthUser({
+      createdAt: 0,
+      email: 'test@example.com',
+      id: 'user-123',
+    })
+
+    expect(user).toBeNull()
+  })
+})

--- a/js/package/auth-helper/src/better-auth.test.ts
+++ b/js/package/auth-helper/src/better-auth.test.ts
@@ -20,12 +20,12 @@ describe('decodeBetterAuthUser', () => {
 })
 
 describe('toAuthUser', () => {
-  it('maps Better Auth id to the shared auth subject', () => {
+  it('keeps the Better Auth id in the shared auth user', () => {
     const user = toAuthUser({
       email: 'test@example.com',
       id: 'user-123',
     })
 
-    expect(user).toStrictEqual({ email: 'test@example.com', sub: 'user-123' })
+    expect(user).toStrictEqual({ email: 'test@example.com', id: 'user-123' })
   })
 })

--- a/js/package/auth-helper/src/better-auth.test.ts
+++ b/js/package/auth-helper/src/better-auth.test.ts
@@ -1,38 +1,31 @@
-import { DateTime } from 'effect'
 import { describe, expect, it } from 'vite-plus/test'
 
-import { toIdentityProviderAuthUser } from './better-auth.ts'
+import { decodeBetterAuthUser, toAuthUser } from './better-auth.ts'
 
-describe('toIdentityProviderAuthUser', () => {
-  it('maps a Better Auth user with a string createdAt value', () => {
-    const user = toIdentityProviderAuthUser({
-      createdAt: '2026-07-05T00:00:00.000Z',
+describe('decodeBetterAuthUser', () => {
+  it('decodes a Better Auth user payload', () => {
+    const user = decodeBetterAuthUser({
       email: 'test@example.com',
       id: 'user-123',
     })
 
-    expect(user?.email).toBe('test@example.com')
-    expect(user?.id).toBe('user-123')
-    expect(user ? DateTime.toDate(user.createdAt).toISOString() : null).toBe('2026-07-05T00:00:00.000Z')
+    expect(user).toStrictEqual({ email: 'test@example.com', id: 'user-123' })
   })
 
-  it('maps a Better Auth user with a Date createdAt value', () => {
-    const user = toIdentityProviderAuthUser({
-      createdAt: DateTime.toDate(DateTime.makeUnsafe('2026-07-05T00:00:00.000Z')),
-      email: 'test@example.com',
-      id: 'user-123',
-    })
-
-    expect(user ? DateTime.toDate(user.createdAt).toISOString() : null).toBe('2026-07-05T00:00:00.000Z')
-  })
-
-  it('rejects a Better Auth user without a usable createdAt value', () => {
-    const user = toIdentityProviderAuthUser({
-      createdAt: 0,
-      email: 'test@example.com',
-      id: 'user-123',
-    })
+  it('rejects an invalid Better Auth user payload', () => {
+    const user = decodeBetterAuthUser({ id: 'user-123' })
 
     expect(user).toBeNull()
+  })
+})
+
+describe('toAuthUser', () => {
+  it('maps Better Auth id to the shared auth subject', () => {
+    const user = toAuthUser({
+      email: 'test@example.com',
+      id: 'user-123',
+    })
+
+    expect(user).toStrictEqual({ email: 'test@example.com', sub: 'user-123' })
   })
 })

--- a/js/package/auth-helper/src/better-auth.ts
+++ b/js/package/auth-helper/src/better-auth.ts
@@ -1,0 +1,122 @@
+import { Effect, Option, Predicate, Schema } from 'effect'
+import type { Context, Layer } from 'effect'
+import type { Context as HonoContext, Env, MiddlewareHandler } from 'hono'
+
+export interface BetterAuthUser {
+  readonly email: string
+  readonly id: string
+}
+
+export interface AuthUser {
+  readonly email: string
+  readonly sub: string
+}
+
+export interface AuthVariables {
+  readonly user: AuthUser
+}
+
+export interface OptionalAuthVariables {
+  readonly user: AuthUser | null
+}
+
+export interface BetterAuthSessionProvider {
+  readonly api: {
+    readonly getSession: (input: { readonly headers: Headers }) => Promise<{ readonly user: unknown } | null>
+  }
+}
+
+export interface BetterAuthServiceDefinition<Identifier, Auth extends BetterAuthSessionProvider> {
+  readonly Service: Context.Service<Identifier, Auth>
+  readonly layer: Layer.Layer<Auth, unknown, unknown>
+}
+
+const BetterAuthUserPayload = Schema.Struct({
+  email: Schema.String,
+  id: Schema.String,
+})
+
+const decodeBetterAuthUserPayload = Schema.decodeUnknownOption(BetterAuthUserPayload)
+
+export const toAuthUser = (user: BetterAuthUser): AuthUser => ({ email: user.email, sub: user.id })
+
+export const decodeBetterAuthUser = (value: unknown): BetterAuthUser | null =>
+  Option.getOrNull(decodeBetterAuthUserPayload(value))
+
+export const getBetterAuthUser = (auth: BetterAuthSessionProvider, headers: Headers) =>
+  Effect.gen(function* () {
+    const session = yield* Effect.tryPromise(() => auth.api.getSession({ headers }))
+    if (Predicate.isNullish(session)) {
+      return null
+    }
+    return decodeBetterAuthUser(session.user)
+  })
+
+interface MiddlewareFactory<E extends Env> {
+  readonly createMiddleware: (handler: MiddlewareHandler<E>) => MiddlewareHandler<E>
+}
+
+export interface OptionalBetterAuthMiddlewareOptions<
+  E extends Env & { Variables: OptionalAuthVariables },
+  Identifier,
+  Auth extends BetterAuthSessionProvider,
+> {
+  readonly factory: MiddlewareFactory<E>
+  readonly runPromise: <A>(ctx: HonoContext<E>, effect: Effect.Effect<A, unknown, Identifier>) => Promise<A>
+  readonly service: Context.Service<Identifier, Auth>
+}
+
+export const createOptionalBetterAuthMiddleware = <
+  E extends Env & { Variables: OptionalAuthVariables },
+  Identifier,
+  Auth extends BetterAuthSessionProvider,
+>(
+  options: OptionalBetterAuthMiddlewareOptions<E, Identifier, Auth>,
+) =>
+  options.factory.createMiddleware((ctx, next) => {
+    const runtime = Effect.gen(function* () {
+      const auth = yield* options.service
+      const user = yield* getBetterAuthUser(auth, ctx.req.raw.headers)
+      ctx.set('user', Predicate.isNullish(user) ? null : toAuthUser(user))
+      yield* Effect.promise(() => next())
+    })
+    // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.
+    return options.runPromise(ctx, runtime)
+  })
+
+export interface RequiredBetterAuthMiddlewareOptions<
+  E extends Env & { Variables: AuthVariables },
+  Identifier,
+  Auth extends BetterAuthSessionProvider,
+> {
+  readonly factory: MiddlewareFactory<E>
+  readonly runPromise: <A>(ctx: HonoContext<E>, effect: Effect.Effect<A, unknown, Identifier>) => Promise<A>
+  readonly service: Context.Service<Identifier, Auth>
+  readonly unauthorized?: (ctx: HonoContext<E>) => Response | Promise<Response>
+}
+
+const defaultUnauthorized = <E extends Env>(ctx: HonoContext<E>) =>
+  ctx.json({ error: 'Unauthorized' }, 401, {
+    'WWW-Authenticate': 'Session error="invalid_session"',
+  })
+
+export const createRequiredBetterAuthMiddleware = <
+  E extends Env & { Variables: AuthVariables },
+  Identifier,
+  Auth extends BetterAuthSessionProvider,
+>(
+  options: RequiredBetterAuthMiddlewareOptions<E, Identifier, Auth>,
+) =>
+  options.factory.createMiddleware((ctx, next) => {
+    const runtime = Effect.gen(function* () {
+      const auth = yield* options.service
+      const user = yield* getBetterAuthUser(auth, ctx.req.raw.headers)
+      if (Predicate.isNullish(user)) {
+        return yield* Effect.promise(() => Promise.resolve((options.unauthorized ?? defaultUnauthorized)(ctx)))
+      }
+      ctx.set('user', toAuthUser(user))
+      return yield* Effect.promise(() => next())
+    })
+    // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.
+    return options.runPromise(ctx, runtime)
+  })

--- a/js/package/auth-helper/src/better-auth.ts
+++ b/js/package/auth-helper/src/better-auth.ts
@@ -1,4 +1,4 @@
-import { DateTime, Effect, Option, Predicate, Schema } from 'effect'
+import { Effect, Option, Predicate, Schema } from 'effect'
 import type { Context, Layer } from 'effect'
 import type { Context as HonoContext, Env, MiddlewareHandler } from 'hono'
 
@@ -12,12 +12,6 @@ export interface AuthUser {
   readonly sub: string
 }
 
-export interface IdentityProviderAuthUser {
-  readonly createdAt: DateTime.Utc
-  readonly email: string
-  readonly id: string
-}
-
 export interface AuthVariables {
   readonly user: AuthUser
 }
@@ -26,8 +20,8 @@ export interface OptionalAuthVariables {
   readonly user: AuthUser | null
 }
 
-export interface BetterAuthSetupVariables<User> {
-  readonly user: User | null
+export interface BetterAuthSetupVariables {
+  readonly user: AuthUser | null
 }
 
 export interface BetterAuthSessionProvider {
@@ -46,45 +40,12 @@ const BetterAuthUserPayload = Schema.Struct({
   id: Schema.String,
 })
 
-const IdentityProviderAuthUserPayload = Schema.Struct({
-  createdAt: Schema.Unknown,
-  email: Schema.String,
-  id: Schema.String,
-})
-
 const decodeBetterAuthUserPayload = Schema.decodeUnknownOption(BetterAuthUserPayload)
-const decodeIdentityProviderAuthUserPayload = Schema.decodeUnknownOption(IdentityProviderAuthUserPayload)
 
 export const toAuthUser = (user: BetterAuthUser): AuthUser => ({ email: user.email, sub: user.id })
 
 export const decodeBetterAuthUser = (value: unknown): BetterAuthUser | null =>
   Option.getOrNull(decodeBetterAuthUserPayload(value))
-
-const decodeIdentityProviderCreatedAt = (value: unknown): string | null => {
-  if (Predicate.isString(value)) {
-    return value
-  }
-  if (value instanceof Date) {
-    return value.toISOString()
-  }
-  return null
-}
-
-export const toIdentityProviderAuthUser = (value: unknown): IdentityProviderAuthUser | null => {
-  const user = Option.getOrNull(decodeIdentityProviderAuthUserPayload(value))
-  if (Predicate.isNullish(user)) {
-    return null
-  }
-  const createdAt = decodeIdentityProviderCreatedAt(user.createdAt)
-  if (Predicate.isNullish(createdAt)) {
-    return null
-  }
-  return {
-    createdAt: DateTime.makeUnsafe(createdAt),
-    email: user.email,
-    id: user.id,
-  }
-}
 
 export const getBetterAuthUser = (auth: BetterAuthSessionProvider, headers: Headers) =>
   Effect.gen(function* () {
@@ -111,32 +72,27 @@ interface MiddlewareFactory<E extends Env> {
 }
 
 export interface BetterAuthSetupMiddlewareOptions<
-  E extends Env & { Variables: BetterAuthSetupVariables<User> },
+  E extends Env & { Variables: BetterAuthSetupVariables },
   Identifier,
   Auth extends BetterAuthSessionProvider,
-  User = AuthUser,
 > {
   readonly factory: MiddlewareFactory<E>
-  readonly mapUser?: (user: unknown) => User | null
-  readonly onAuth?: (ctx: HonoContext<E>, auth: Auth) => void
   readonly runPromise: <A>(ctx: HonoContext<E>, effect: Effect.Effect<A, unknown, Identifier>) => Promise<A>
   readonly service: Context.Service<Identifier, Auth>
 }
 
 export const createBetterAuthSetupMiddleware = <
-  E extends Env & { Variables: BetterAuthSetupVariables<User> },
+  E extends Env & { Variables: BetterAuthSetupVariables },
   Identifier,
   Auth extends BetterAuthSessionProvider,
-  User = AuthUser,
 >(
-  options: BetterAuthSetupMiddlewareOptions<E, Identifier, Auth, User>,
+  options: BetterAuthSetupMiddlewareOptions<E, Identifier, Auth>,
 ) =>
   options.factory.createMiddleware((ctx, next) => {
     const effect = Effect.gen(function* () {
       const auth = yield* options.service
-      options.onAuth?.(ctx, auth)
       const user = yield* getBetterAuthSessionUser(auth, ctx.req.raw.headers)
-      ctx.set('user', Predicate.isNullish(user) ? null : (options.mapUser ?? defaultMapUser)(user))
+      ctx.set('user', Predicate.isNullish(user) ? null : defaultMapUser(user))
       yield* Effect.promise(() => next())
     })
     // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.

--- a/js/package/auth-helper/src/better-auth.ts
+++ b/js/package/auth-helper/src/better-auth.ts
@@ -1,4 +1,4 @@
-import { Effect, Option, Predicate, Schema } from 'effect'
+import { DateTime, Effect, Option, Predicate, Schema } from 'effect'
 import type { Context, Layer } from 'effect'
 import type { Context as HonoContext, Env, MiddlewareHandler } from 'hono'
 
@@ -10,6 +10,12 @@ export interface BetterAuthUser {
 export interface AuthUser {
   readonly email: string
   readonly sub: string
+}
+
+export interface IdentityProviderAuthUser {
+  readonly createdAt: DateTime.Utc
+  readonly email: string
+  readonly id: string
 }
 
 export interface AuthVariables {
@@ -40,12 +46,45 @@ const BetterAuthUserPayload = Schema.Struct({
   id: Schema.String,
 })
 
+const IdentityProviderAuthUserPayload = Schema.Struct({
+  createdAt: Schema.Unknown,
+  email: Schema.String,
+  id: Schema.String,
+})
+
 const decodeBetterAuthUserPayload = Schema.decodeUnknownOption(BetterAuthUserPayload)
+const decodeIdentityProviderAuthUserPayload = Schema.decodeUnknownOption(IdentityProviderAuthUserPayload)
 
 export const toAuthUser = (user: BetterAuthUser): AuthUser => ({ email: user.email, sub: user.id })
 
 export const decodeBetterAuthUser = (value: unknown): BetterAuthUser | null =>
   Option.getOrNull(decodeBetterAuthUserPayload(value))
+
+const decodeIdentityProviderCreatedAt = (value: unknown): string | null => {
+  if (Predicate.isString(value)) {
+    return value
+  }
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+  return null
+}
+
+export const toIdentityProviderAuthUser = (value: unknown): IdentityProviderAuthUser | null => {
+  const user = Option.getOrNull(decodeIdentityProviderAuthUserPayload(value))
+  if (Predicate.isNullish(user)) {
+    return null
+  }
+  const createdAt = decodeIdentityProviderCreatedAt(user.createdAt)
+  if (Predicate.isNullish(createdAt)) {
+    return null
+  }
+  return {
+    createdAt: DateTime.makeUnsafe(createdAt),
+    email: user.email,
+    id: user.id,
+  }
+}
 
 export const getBetterAuthUser = (auth: BetterAuthSessionProvider, headers: Headers) =>
   Effect.gen(function* () {
@@ -79,6 +118,7 @@ export interface BetterAuthSetupMiddlewareOptions<
 > {
   readonly factory: MiddlewareFactory<E>
   readonly mapUser?: (user: unknown) => User | null
+  readonly onAuth?: (ctx: HonoContext<E>, auth: Auth) => void
   readonly runPromise: <A>(ctx: HonoContext<E>, effect: Effect.Effect<A, unknown, Identifier>) => Promise<A>
   readonly service: Context.Service<Identifier, Auth>
 }
@@ -94,6 +134,7 @@ export const createBetterAuthSetupMiddleware = <
   options.factory.createMiddleware((ctx, next) => {
     const effect = Effect.gen(function* () {
       const auth = yield* options.service
+      options.onAuth?.(ctx, auth)
       const user = yield* getBetterAuthSessionUser(auth, ctx.req.raw.headers)
       ctx.set('user', Predicate.isNullish(user) ? null : (options.mapUser ?? defaultMapUser)(user))
       yield* Effect.promise(() => next())

--- a/js/package/auth-helper/src/better-auth.ts
+++ b/js/package/auth-helper/src/better-auth.ts
@@ -20,6 +20,10 @@ export interface OptionalAuthVariables {
   readonly user: AuthUser | null
 }
 
+export interface BetterAuthSetupVariables<User> {
+  readonly user: User | null
+}
+
 export interface BetterAuthSessionProvider {
   readonly api: {
     readonly getSession: (input: { readonly headers: Headers }) => Promise<{ readonly user: unknown } | null>
@@ -52,71 +56,48 @@ export const getBetterAuthUser = (auth: BetterAuthSessionProvider, headers: Head
     return decodeBetterAuthUser(session.user)
   })
 
+export const getBetterAuthSessionUser = (auth: BetterAuthSessionProvider, headers: Headers) =>
+  Effect.gen(function* () {
+    const session = yield* Effect.tryPromise(() => auth.api.getSession({ headers }))
+    return Predicate.isNullish(session) ? null : session.user
+  })
+
+const defaultMapUser = (user: unknown): AuthUser | null => {
+  const decodedUser = decodeBetterAuthUser(user)
+  return Predicate.isNullish(decodedUser) ? null : toAuthUser(decodedUser)
+}
+
 interface MiddlewareFactory<E extends Env> {
   readonly createMiddleware: (handler: MiddlewareHandler<E>) => MiddlewareHandler<E>
 }
 
-export interface OptionalBetterAuthMiddlewareOptions<
-  E extends Env & { Variables: OptionalAuthVariables },
+export interface BetterAuthSetupMiddlewareOptions<
+  E extends Env & { Variables: BetterAuthSetupVariables<User> },
   Identifier,
   Auth extends BetterAuthSessionProvider,
+  User = AuthUser,
 > {
   readonly factory: MiddlewareFactory<E>
+  readonly mapUser?: (user: unknown) => User | null
   readonly runPromise: <A>(ctx: HonoContext<E>, effect: Effect.Effect<A, unknown, Identifier>) => Promise<A>
   readonly service: Context.Service<Identifier, Auth>
 }
 
-export const createOptionalBetterAuthMiddleware = <
-  E extends Env & { Variables: OptionalAuthVariables },
+export const createBetterAuthSetupMiddleware = <
+  E extends Env & { Variables: BetterAuthSetupVariables<User> },
   Identifier,
   Auth extends BetterAuthSessionProvider,
+  User = AuthUser,
 >(
-  options: OptionalBetterAuthMiddlewareOptions<E, Identifier, Auth>,
+  options: BetterAuthSetupMiddlewareOptions<E, Identifier, Auth, User>,
 ) =>
   options.factory.createMiddleware((ctx, next) => {
-    const runtime = Effect.gen(function* () {
+    const effect = Effect.gen(function* () {
       const auth = yield* options.service
-      const user = yield* getBetterAuthUser(auth, ctx.req.raw.headers)
-      ctx.set('user', Predicate.isNullish(user) ? null : toAuthUser(user))
+      const user = yield* getBetterAuthSessionUser(auth, ctx.req.raw.headers)
+      ctx.set('user', Predicate.isNullish(user) ? null : (options.mapUser ?? defaultMapUser)(user))
       yield* Effect.promise(() => next())
     })
     // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.
-    return options.runPromise(ctx, runtime)
-  })
-
-export interface RequiredBetterAuthMiddlewareOptions<
-  E extends Env & { Variables: AuthVariables },
-  Identifier,
-  Auth extends BetterAuthSessionProvider,
-> {
-  readonly factory: MiddlewareFactory<E>
-  readonly runPromise: <A>(ctx: HonoContext<E>, effect: Effect.Effect<A, unknown, Identifier>) => Promise<A>
-  readonly service: Context.Service<Identifier, Auth>
-  readonly unauthorized?: (ctx: HonoContext<E>) => Response | Promise<Response>
-}
-
-const defaultUnauthorized = <E extends Env>(ctx: HonoContext<E>) =>
-  ctx.json({ error: 'Unauthorized' }, 401, {
-    'WWW-Authenticate': 'Session error="invalid_session"',
-  })
-
-export const createRequiredBetterAuthMiddleware = <
-  E extends Env & { Variables: AuthVariables },
-  Identifier,
-  Auth extends BetterAuthSessionProvider,
->(
-  options: RequiredBetterAuthMiddlewareOptions<E, Identifier, Auth>,
-) =>
-  options.factory.createMiddleware((ctx, next) => {
-    const runtime = Effect.gen(function* () {
-      const auth = yield* options.service
-      const user = yield* getBetterAuthUser(auth, ctx.req.raw.headers)
-      if (Predicate.isNullish(user)) {
-        return yield* Effect.promise(() => Promise.resolve((options.unauthorized ?? defaultUnauthorized)(ctx)))
-      }
-      ctx.set('user', toAuthUser(user))
-      return yield* Effect.promise(() => next())
-    })
-    // oxlint-disable-next-line rules/no-effect-runtime-run -- HTTP middleware boundary executes request-scoped auth workflow.
-    return options.runPromise(ctx, runtime)
+    return options.runPromise(ctx, effect)
   })

--- a/js/package/auth-helper/src/better-auth.ts
+++ b/js/package/auth-helper/src/better-auth.ts
@@ -9,7 +9,7 @@ export interface BetterAuthUser {
 
 export interface AuthUser {
   readonly email: string
-  readonly sub: string
+  readonly id: string
 }
 
 export interface AuthVariables {
@@ -42,7 +42,7 @@ const BetterAuthUserPayload = Schema.Struct({
 
 const decodeBetterAuthUserPayload = Schema.decodeUnknownOption(BetterAuthUserPayload)
 
-export const toAuthUser = (user: BetterAuthUser): AuthUser => ({ email: user.email, sub: user.id })
+export const toAuthUser = (user: BetterAuthUser): AuthUser => ({ email: user.email, id: user.id })
 
 export const decodeBetterAuthUser = (value: unknown): BetterAuthUser | null =>
   Option.getOrNull(decodeBetterAuthUserPayload(value))

--- a/js/package/auth-helper/src/index.ts
+++ b/js/package/auth-helper/src/index.ts
@@ -3,8 +3,10 @@ export {
   decodeBetterAuthUser,
   getBetterAuthSessionUser,
   getBetterAuthUser,
+  toIdentityProviderAuthUser,
   toAuthUser,
 } from './better-auth.ts'
+export { requireAuthMiddleware } from './require-auth.ts'
 export type {
   AuthUser,
   AuthVariables,
@@ -13,6 +15,8 @@ export type {
   BetterAuthSetupVariables,
   BetterAuthSessionProvider,
   BetterAuthUser,
+  IdentityProviderAuthUser,
   OptionalAuthVariables,
 } from './better-auth.ts'
 export type * from './jwt-payload.ts'
+export type { RequireAuthMiddlewareOptions, RequireAuthVariables } from './require-auth.ts'

--- a/js/package/auth-helper/src/index.ts
+++ b/js/package/auth-helper/src/index.ts
@@ -1,7 +1,7 @@
 export {
-  createOptionalBetterAuthMiddleware,
-  createRequiredBetterAuthMiddleware,
+  createBetterAuthSetupMiddleware,
   decodeBetterAuthUser,
+  getBetterAuthSessionUser,
   getBetterAuthUser,
   toAuthUser,
 } from './better-auth.ts'
@@ -9,10 +9,10 @@ export type {
   AuthUser,
   AuthVariables,
   BetterAuthServiceDefinition,
+  BetterAuthSetupMiddlewareOptions,
+  BetterAuthSetupVariables,
   BetterAuthSessionProvider,
   BetterAuthUser,
   OptionalAuthVariables,
-  OptionalBetterAuthMiddlewareOptions,
-  RequiredBetterAuthMiddlewareOptions,
 } from './better-auth.ts'
 export type * from './jwt-payload.ts'

--- a/js/package/auth-helper/src/index.ts
+++ b/js/package/auth-helper/src/index.ts
@@ -1,1 +1,18 @@
+export {
+  createOptionalBetterAuthMiddleware,
+  createRequiredBetterAuthMiddleware,
+  decodeBetterAuthUser,
+  getBetterAuthUser,
+  toAuthUser,
+} from './better-auth.ts'
+export type {
+  AuthUser,
+  AuthVariables,
+  BetterAuthServiceDefinition,
+  BetterAuthSessionProvider,
+  BetterAuthUser,
+  OptionalAuthVariables,
+  OptionalBetterAuthMiddlewareOptions,
+  RequiredBetterAuthMiddlewareOptions,
+} from './better-auth.ts'
 export type * from './jwt-payload.ts'

--- a/js/package/auth-helper/src/index.ts
+++ b/js/package/auth-helper/src/index.ts
@@ -3,7 +3,6 @@ export {
   decodeBetterAuthUser,
   getBetterAuthSessionUser,
   getBetterAuthUser,
-  toIdentityProviderAuthUser,
   toAuthUser,
 } from './better-auth.ts'
 export { requireAuthMiddleware } from './require-auth.ts'
@@ -15,7 +14,6 @@ export type {
   BetterAuthSetupVariables,
   BetterAuthSessionProvider,
   BetterAuthUser,
-  IdentityProviderAuthUser,
   OptionalAuthVariables,
 } from './better-auth.ts'
 export type * from './jwt-payload.ts'

--- a/js/package/auth-helper/src/require-auth.test.ts
+++ b/js/package/auth-helper/src/require-auth.test.ts
@@ -1,0 +1,56 @@
+import { Hono } from 'hono'
+import type { Context as HonoContext } from 'hono'
+import { createFactory } from 'hono/factory'
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+import { requireAuthMiddleware } from './require-auth.ts'
+
+interface TestUser {
+  readonly email: string
+}
+
+interface TestEnv {
+  readonly Variables: {
+    readonly user: TestUser | null
+  }
+}
+
+type TestContext = HonoContext<TestEnv>
+
+const factory = createFactory<TestEnv>()
+
+describe('requireAuthMiddleware', () => {
+  it('calls the unauthenticated handler when the request has no user', async () => {
+    const onUnauthenticated = vi.fn((ctx: TestContext) => ctx.text('login required', 401))
+    const middleware = requireAuthMiddleware({ factory, onUnauthenticated })
+    const app = new Hono<TestEnv>()
+      .use((ctx, next) => {
+        ctx.set('user', null)
+        return next()
+      })
+      .get('/protected', middleware, (ctx) => ctx.text(ctx.var.user?.email ?? 'missing'))
+
+    const res = await app.request('/protected')
+
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('login required')
+    expect(onUnauthenticated).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes authenticated requests through and returns the downstream response', async () => {
+    const onUnauthenticated = vi.fn((ctx: TestContext) => ctx.text('login required', 401))
+    const middleware = requireAuthMiddleware({ factory, onUnauthenticated })
+    const app = new Hono<TestEnv>()
+      .use((ctx, next) => {
+        ctx.set('user', { email: 'test@example.com' })
+        return next()
+      })
+      .get('/protected', middleware, (ctx) => ctx.text(ctx.var.user?.email ?? 'missing'))
+
+    const res = await app.request('/protected')
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('test@example.com')
+    expect(onUnauthenticated).not.toHaveBeenCalled()
+  })
+})

--- a/js/package/auth-helper/src/require-auth.ts
+++ b/js/package/auth-helper/src/require-auth.ts
@@ -1,0 +1,27 @@
+import { Predicate } from 'effect'
+import type { Context as HonoContext, Env, MiddlewareHandler } from 'hono'
+
+export interface RequireAuthVariables<User> {
+  readonly user: User
+}
+
+interface MiddlewareFactory<E extends Env> {
+  readonly createMiddleware: (handler: MiddlewareHandler<E>) => MiddlewareHandler<E>
+}
+
+export interface RequireAuthMiddlewareOptions<E extends Env & { Variables: RequireAuthVariables<User> }, User> {
+  readonly factory: MiddlewareFactory<E>
+  readonly onUnauthenticated: (ctx: HonoContext<E>) => Response | Promise<Response>
+}
+
+export const requireAuthMiddleware = <E extends Env & { Variables: RequireAuthVariables<User> }, User>(
+  options: RequireAuthMiddlewareOptions<E, User>,
+) =>
+  options.factory.createMiddleware(async (ctx, next): Promise<Response> => {
+    if (Predicate.isNullish(ctx.var.user)) {
+      return await options.onUnauthenticated(ctx)
+    }
+
+    await next()
+    return ctx.res
+  })


### PR DESCRIPTION
## Summary
- add shared BetterAuth session user types, decoder, service definition, and Hono middleware factories to auth-helper
- switch feed-platform-backend and feed-platform-web auth middleware to the shared helpers while keeping app-specific BetterAuth Layers local
- align feed-platform-web auth middleware test with the shared AuthUser shape

## Verification
- vp run js:check
- vp test run js/app/feed-platform-web/app/feature/auth/middleware.test.ts js/app/feed-platform-backend/src/feature/auth/middleware.test.ts
- vp run --filter feed-platform-web build
- vp run --filter feed-platform-backend setup