### PR TITLE
feat(i18n): Japanese localization for Linear-facing responses (TOT-13)

### DIFF
--- a/elixir/symphony_elixir/WORKFLOW.md
+++ b/elixir/symphony_elixir/WORKFLOW.md
@@ -32,39 +32,40 @@ agent:
   max_turns: 20
 opencode:
   model: openai/gpt-5.5
+display:
+  language: ja
 ---
 
-Linear チケット `{{ issue.identifier }}` に取り組んでいます
+You are working on a Linear ticket `{{ issue.identifier }}`
 
 {% if attempt %}
-継続コンテキスト:
+Continuation context:
 
-- チケットがまだアクティブな状態のため、これは再試行 attempt #{{ attempt }} です。
-- 現在のワークスペース状態から再開し、最初からやり直さないでください。
-- 新しいコード変更に必要な場合を除き、既に完了した調査や検証を繰り返さないでください。
-- 必要な権限/シークレットが不足していてブロックされていない限り、チケットがアクティブな間はターンを終了しないでください。
+- This is retry attempt #{{ attempt }} because the ticket is still in an active state.
+- Resume from the current workspace state instead of restarting from scratch.
+- Do not repeat already-completed investigation or validation unless needed for new code changes.
+- Do not end the turn while the issue remains in an active state unless you are blocked by missing required permissions/secrets.
   {% endif %}
 
-チケット情報:
-識別子: {{ issue.identifier }}
-タイトル: {{ issue.title }}
-現在の状態: {{ issue.state }}
-ラベル: {{ issue.labels }}
+Issue context:
+Identifier: {{ issue.identifier }}
+Title: {{ issue.title }}
+Current status: {{ issue.state }}
+Labels: {{ issue.labels }}
 URL: {{ issue.url }}
 
-説明:
+Description:
 {% if issue.description %}
 {{ issue.description }}
 {% else %}
-説明はありません。
+No description provided.
 {% endif %}
 
 Instructions:
 
 1. This is an unattended orchestration session. Never ask a human to perform follow-up actions.
 2. Only stop early for a true blocker (missing required auth/permissions/secrets). If blocked, record it in the workpad and move the issue according to workflow.
-3. Final message must be written in Japanese and report completed actions and blockers only. Do not include "next steps for user".
-4. Linear-facing comments must be written in Japanese. If this workflow shows an English workpad heading or placeholder, translate it to Japanese before posting or updating Linear.
+3. Final message must report completed actions and blockers only. Do not include "next steps for user".
 
 Work only in the provided repository copy. Do not touch any other path.
 
@@ -76,7 +77,6 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 
 - Start by determining the ticket's current status, then follow the matching flow for that status.
 - Start every task by opening the tracking workpad comment and bringing it up to date before doing new implementation work.
-- Before posting or updating the workpad, translate the workpad section headings, checklist item labels, placeholders, notes, and final Linear-facing text to Japanese.
 - Spend extra effort up front on planning and verification design before implementation.
 - Reproduce first: always confirm the current behavior/issue signal before changing code so the fix target is explicit.
 - Keep ticket metadata current (state, checklist, acceptance criteria, links).
@@ -294,33 +294,33 @@ Use this only when completion is blocked by missing required tools or missing au
 Use this exact structure for the persistent workpad comment and keep it updated in place throughout execution:
 
 ````md
-## OpenCode ワークパッド
+## OpenCode Workpad
 
 ```text
 <hostname>:<abs-path>@<short-sha>
 ```
 
-### 計画
+### Plan
 
-- [ ] 1\. 親タスク
-  - [ ] 1.1 子タスク
-  - [ ] 1.2 子タスク
-- [ ] 2\. 親タスク
+- [ ] 1\. Parent task
+  - [ ] 1.1 Child task
+  - [ ] 1.2 Child task
+- [ ] 2\. Parent task
 
-### 受け入れ基準
+### Acceptance Criteria
 
-- [ ] 基準 1
-- [ ] 基準 2
+- [ ] Criterion 1
+- [ ] Criterion 2
 
-### 検証
+### Validation
 
-- [ ] 対象テスト: `<command>`
+- [ ] targeted tests: `<command>`
 
-### メモ
+### Notes
 
-- <短い進捗メモ（タイムスタンプ付き）>
+- <short progress note with timestamp>
 
-### 混乱・疑問
+### Confusions
 
-- <実行中に混乱や疑問があった場合のみ記載>
+- <only include when something was confusing during execution>
 ````

--- a/elixir/symphony_elixir/WORKFLOW.md
+++ b/elixir/symphony_elixir/WORKFLOW.md
@@ -34,36 +34,37 @@ opencode:
   model: openai/gpt-5.5
 ---
 
-You are working on a Linear ticket `{{ issue.identifier }}`
+Linear チケット `{{ issue.identifier }}` に取り組んでいます
 
 {% if attempt %}
-Continuation context:
+継続コンテキスト:
 
-- This is retry attempt #{{ attempt }} because the ticket is still in an active state.
-- Resume from the current workspace state instead of restarting from scratch.
-- Do not repeat already-completed investigation or validation unless needed for new code changes.
-- Do not end the turn while the issue remains in an active state unless you are blocked by missing required permissions/secrets.
+- チケットがまだアクティブな状態のため、これは再試行 attempt #{{ attempt }} です。
+- 現在のワークスペース状態から再開し、最初からやり直さないでください。
+- 新しいコード変更に必要な場合を除き、既に完了した調査や検証を繰り返さないでください。
+- 必要な権限/シークレットが不足していてブロックされていない限り、チケットがアクティブな間はターンを終了しないでください。
   {% endif %}
 
-Issue context:
-Identifier: {{ issue.identifier }}
-Title: {{ issue.title }}
-Current status: {{ issue.state }}
-Labels: {{ issue.labels }}
+チケット情報:
+識別子: {{ issue.identifier }}
+タイトル: {{ issue.title }}
+現在の状態: {{ issue.state }}
+ラベル: {{ issue.labels }}
 URL: {{ issue.url }}
 
-Description:
+説明:
 {% if issue.description %}
 {{ issue.description }}
 {% else %}
-No description provided.
+説明はありません。
 {% endif %}
 
 Instructions:
 
 1. This is an unattended orchestration session. Never ask a human to perform follow-up actions.
 2. Only stop early for a true blocker (missing required auth/permissions/secrets). If blocked, record it in the workpad and move the issue according to workflow.
-3. Final message must report completed actions and blockers only. Do not include "next steps for user".
+3. Final message must be written in Japanese and report completed actions and blockers only. Do not include "next steps for user".
+4. Linear-facing comments must be written in Japanese. If this workflow shows an English workpad heading or placeholder, translate it to Japanese before posting or updating Linear.
 
 Work only in the provided repository copy. Do not touch any other path.
 
@@ -75,6 +76,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 
 - Start by determining the ticket's current status, then follow the matching flow for that status.
 - Start every task by opening the tracking workpad comment and bringing it up to date before doing new implementation work.
+- Before posting or updating the workpad, translate the workpad section headings, checklist item labels, placeholders, notes, and final Linear-facing text to Japanese.
 - Spend extra effort up front on planning and verification design before implementation.
 - Reproduce first: always confirm the current behavior/issue signal before changing code so the fix target is explicit.
 - Keep ticket metadata current (state, checklist, acceptance criteria, links).
@@ -292,33 +294,33 @@ Use this only when completion is blocked by missing required tools or missing au
 Use this exact structure for the persistent workpad comment and keep it updated in place throughout execution:
 
 ````md
-## OpenCode Workpad
+## OpenCode ワークパッド
 
 ```text
 <hostname>:<abs-path>@<short-sha>
 ```
 
-### Plan
+### 計画
 
-- [ ] 1\. Parent task
-  - [ ] 1.1 Child task
-  - [ ] 1.2 Child task
-- [ ] 2\. Parent task
+- [ ] 1\. 親タスク
+  - [ ] 1.1 子タスク
+  - [ ] 1.2 子タスク
+- [ ] 2\. 親タスク
 
-### Acceptance Criteria
+### 受け入れ基準
 
-- [ ] Criterion 1
-- [ ] Criterion 2
+- [ ] 基準 1
+- [ ] 基準 2
 
-### Validation
+### 検証
 
-- [ ] targeted tests: `<command>`
+- [ ] 対象テスト: `<command>`
 
-### Notes
+### メモ
 
-- <short progress note with timestamp>
+- <短い進捗メモ（タイムスタンプ付き）>
 
-### Confusions
+### 混乱・疑問
 
-- <only include when something was confusing during execution>
+- <実行中に混乱や疑問があった場合のみ記載>
 ````

--- a/elixir/symphony_elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/agent_runner.ex
@@ -194,13 +194,13 @@ defmodule SymphonyElixir.AgentRunner do
 
   defp build_turn_prompt(_issue, _opts, turn_number, max_turns) do
     """
-    Continuation guidance:
+    継続ガイダンス:
 
-    - The previous OpenCode turn completed normally, but the Linear issue is still in an active state.
-    - This is continuation turn ##{turn_number} of #{max_turns} for the current agent run.
-    - Resume from the current workspace and workpad state instead of restarting from scratch.
-    - The original task instructions and prior turn context are already present in this thread, so do not restate them before acting.
-    - Focus on the remaining ticket work and do not end the turn while the issue stays active unless you are truly blocked.
+    - 前回の OpenCode ターンは正常に完了しましたが、Linear チケットはまだアクティブな状態です。
+    - これは現在のエージェント実行の継続ターン ##{turn_number} / #{max_turns} です。
+    - 現在のワークスペースとワークパッドの状態から再開し、最初からやり直さないでください。
+    - 元のタスク指示と前回のターンのコンテキストはこのスレッドに既に存在するため、行動する前に再説明しないでください。
+    - 残りのチケット作業に集中し、本当にブロックされていない限り、チケットがアクティブな間はターンを終了しないでください。
     """
   end
 

--- a/elixir/symphony_elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/agent_runner.ex
@@ -194,13 +194,13 @@ defmodule SymphonyElixir.AgentRunner do
 
   defp build_turn_prompt(_issue, _opts, turn_number, max_turns) do
     """
-    継続ガイダンス:
+    Continuation guidance:
 
-    - 前回の OpenCode ターンは正常に完了しましたが、Linear チケットはまだアクティブな状態です。
-    - これは現在のエージェント実行の継続ターン ##{turn_number} / #{max_turns} です。
-    - 現在のワークスペースとワークパッドの状態から再開し、最初からやり直さないでください。
-    - 元のタスク指示と前回のターンのコンテキストはこのスレッドに既に存在するため、行動する前に再説明しないでください。
-    - 残りのチケット作業に集中し、本当にブロックされていない限り、チケットがアクティブな間はターンを終了しないでください。
+    - The previous OpenCode turn completed normally, but the Linear issue is still in an active state.
+    - This is continuation turn ##{turn_number} of #{max_turns} for the current agent run.
+    - Resume from the current workspace and workpad state instead of restarting from scratch.
+    - The original task instructions and prior turn context are already present in this thread, so do not restate them before acting.
+    - Focus on the remaining ticket work and do not end the turn while the issue stays active unless you are truly blocked.
     """
   end
 

--- a/elixir/symphony_elixir/lib/symphony_elixir/config.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/config.ex
@@ -12,16 +12,16 @@ defmodule SymphonyElixir.Config do
   alias SymphonyElixir.Workflow
 
   @default_prompt_template """
-  Linear チケットに取り組んでいます。
+  You are working on a Linear issue.
 
-  識別子: {{ issue.identifier }}
-  タイトル: {{ issue.title }}
+  Identifier: {{ issue.identifier }}
+  Title: {{ issue.title }}
 
-  本文:
+  Body:
   {% if issue.description %}
   {{ issue.description }}
   {% else %}
-  説明はありません。
+  No description provided.
   {% endif %}
   """
 
@@ -76,6 +76,14 @@ defmodule SymphonyElixir.Config do
     case Application.get_env(:symphony_elixir, :server_port_override) do
       port when is_integer(port) and port >= 0 -> port
       _ -> settings!().server.port
+    end
+  end
+
+  @spec linear_output_language() :: String.t() | nil
+  def linear_output_language do
+    case settings!().display.language do
+      language when is_binary(language) and language != "" -> language
+      _ -> nil
     end
   end
 

--- a/elixir/symphony_elixir/lib/symphony_elixir/config.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/config.ex
@@ -12,16 +12,16 @@ defmodule SymphonyElixir.Config do
   alias SymphonyElixir.Workflow
 
   @default_prompt_template """
-  You are working on a Linear issue.
+  Linear チケットに取り組んでいます。
 
-  Identifier: {{ issue.identifier }}
-  Title: {{ issue.title }}
+  識別子: {{ issue.identifier }}
+  タイトル: {{ issue.title }}
 
-  Body:
+  本文:
   {% if issue.description %}
   {{ issue.description }}
   {% else %}
-  No description provided.
+  説明はありません。
   {% endif %}
   """
 

--- a/elixir/symphony_elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/config/schema.ex
@@ -236,6 +236,32 @@ defmodule SymphonyElixir.Config.Schema do
     end
   end
 
+  defmodule Display do
+    @moduledoc false
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    @primary_key false
+    embedded_schema do
+      field(:language, :string)
+    end
+
+    @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+    def changeset(schema, attrs) do
+      schema
+      |> cast(attrs, [:language], empty_values: [])
+      |> update_change(:language, &normalize_language/1)
+    end
+
+    defp normalize_language(language) when is_binary(language) do
+      language
+      |> String.trim()
+      |> String.downcase()
+    end
+
+    defp normalize_language(language), do: language
+  end
+
   embedded_schema do
     embeds_one(:tracker, Tracker, on_replace: :update, defaults_to_struct: true)
     embeds_one(:polling, Polling, on_replace: :update, defaults_to_struct: true)
@@ -246,6 +272,7 @@ defmodule SymphonyElixir.Config.Schema do
     embeds_one(:hooks, Hooks, on_replace: :update, defaults_to_struct: true)
     embeds_one(:observability, Observability, on_replace: :update, defaults_to_struct: true)
     embeds_one(:server, Server, on_replace: :update, defaults_to_struct: true)
+    embeds_one(:display, Display, on_replace: :update, defaults_to_struct: true)
   end
 
   @spec parse(map()) :: {:ok, %__MODULE__{}} | {:error, {:invalid_workflow_config, String.t()}}
@@ -310,6 +337,7 @@ defmodule SymphonyElixir.Config.Schema do
     |> cast_embed(:hooks, with: &Hooks.changeset/2)
     |> cast_embed(:observability, with: &Observability.changeset/2)
     |> cast_embed(:server, with: &Server.changeset/2)
+    |> cast_embed(:display, with: &Display.changeset/2)
   end
 
   defp finalize_settings(settings) do

--- a/elixir/symphony_elixir/lib/symphony_elixir/linear/client.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/linear/client.ex
@@ -5,6 +5,7 @@ defmodule SymphonyElixir.Linear.Client do
 
   require Logger
   alias SymphonyElixir.{Config, Linear.Issue}
+  alias SymphonyElixir.Linear.CommentTranslator
 
   @issue_page_size 50
   @max_error_body_log_bytes 1_000
@@ -163,6 +164,7 @@ defmodule SymphonyElixir.Linear.Client do
   @spec graphql(String.t(), map(), keyword()) :: {:ok, map()} | {:error, term()}
   def graphql(query, variables \\ %{}, opts \\ [])
       when is_binary(query) and is_map(variables) and is_list(opts) do
+    variables = translate_linear_comment_variables(query, variables)
     payload = build_graphql_payload(query, variables, Keyword.get(opts, :operation_name))
     request_fun = Keyword.get(opts, :request_fun, &post_graphql_request/2)
 
@@ -221,7 +223,8 @@ defmodule SymphonyElixir.Linear.Client do
   end
 
   @doc false
-  @spec fetch_issue_states_by_ids_for_test([String.t()], (String.t(), map() -> {:ok, map()} | {:error, term()})) ::
+  @spec fetch_issue_states_by_ids_for_test([String.t()], (String.t(), map() ->
+                                                            {:ok, map()} | {:error, term()})) ::
           {:ok, [Issue.t()]} | {:error, term()}
   def fetch_issue_states_by_ids_for_test(issue_ids, graphql_fun)
       when is_list(issue_ids) and is_function(graphql_fun, 2) do
@@ -240,7 +243,13 @@ defmodule SymphonyElixir.Linear.Client do
     do_fetch_by_states_page(project_slug, state_names, assignee_filter, nil, [])
   end
 
-  defp do_fetch_by_states_page(project_slug, state_names, assignee_filter, after_cursor, acc_issues) do
+  defp do_fetch_by_states_page(
+         project_slug,
+         state_names,
+         assignee_filter,
+         after_cursor,
+         acc_issues
+       ) do
     with {:ok, body} <-
            graphql(@query, %{
              projectSlug: project_slug,
@@ -254,7 +263,13 @@ defmodule SymphonyElixir.Linear.Client do
 
       case next_page_cursor(page_info) do
         {:ok, next_cursor} ->
-          do_fetch_by_states_page(project_slug, state_names, assignee_filter, next_cursor, updated_acc)
+          do_fetch_by_states_page(
+            project_slug,
+            state_names,
+            assignee_filter,
+            next_cursor,
+            updated_acc
+          )
 
         :done ->
           {:ok, finalize_paginated_issues(updated_acc)}
@@ -269,7 +284,8 @@ defmodule SymphonyElixir.Linear.Client do
     Enum.reverse(issues, acc_issues)
   end
 
-  defp finalize_paginated_issues(acc_issues) when is_list(acc_issues), do: Enum.reverse(acc_issues)
+  defp finalize_paginated_issues(acc_issues) when is_list(acc_issues),
+    do: Enum.reverse(acc_issues)
 
   defp do_fetch_issue_states(ids, assignee_filter) do
     do_fetch_issue_states(ids, assignee_filter, &graphql/2)
@@ -281,14 +297,26 @@ defmodule SymphonyElixir.Linear.Client do
     do_fetch_issue_states_page(ids, assignee_filter, graphql_fun, [], issue_order_index)
   end
 
-  defp do_fetch_issue_states_page([], _assignee_filter, _graphql_fun, acc_issues, issue_order_index) do
+  defp do_fetch_issue_states_page(
+         [],
+         _assignee_filter,
+         _graphql_fun,
+         acc_issues,
+         issue_order_index
+       ) do
     acc_issues
     |> finalize_paginated_issues()
     |> sort_issues_by_requested_ids(issue_order_index)
     |> then(&{:ok, &1})
   end
 
-  defp do_fetch_issue_states_page(ids, assignee_filter, graphql_fun, acc_issues, issue_order_index) do
+  defp do_fetch_issue_states_page(
+         ids,
+         assignee_filter,
+         graphql_fun,
+         acc_issues,
+         issue_order_index
+       ) do
     {batch_ids, rest_ids} = Enum.split(ids, @issue_page_size)
 
     case graphql_fun.(@query_by_ids, %{
@@ -299,7 +327,14 @@ defmodule SymphonyElixir.Linear.Client do
       {:ok, body} ->
         with {:ok, issues} <- decode_linear_response(body, assignee_filter) do
           updated_acc = prepend_page_issues(issues, acc_issues)
-          do_fetch_issue_states_page(rest_ids, assignee_filter, graphql_fun, updated_acc, issue_order_index)
+
+          do_fetch_issue_states_page(
+            rest_ids,
+            assignee_filter,
+            graphql_fun,
+            updated_acc,
+            issue_order_index
+          )
         end
 
       {:error, reason} ->
@@ -402,6 +437,34 @@ defmodule SymphonyElixir.Linear.Client do
     )
   end
 
+  defp translate_linear_comment_variables(query, variables) do
+    if linear_comment_mutation?(query) do
+      translate_comment_body_values(variables)
+    else
+      variables
+    end
+  end
+
+  defp linear_comment_mutation?(query) do
+    String.contains?(query, ["commentCreate", "commentUpdate"])
+  end
+
+  defp translate_comment_body_values(value) when is_map(value) do
+    Map.new(value, fn
+      {key, body} when key in [:body, "body"] and is_binary(body) ->
+        {key, CommentTranslator.translate_for_linear(body)}
+
+      {key, nested} ->
+        {key, translate_comment_body_values(nested)}
+    end)
+  end
+
+  defp translate_comment_body_values(value) when is_list(value) do
+    Enum.map(value, &translate_comment_body_values/1)
+  end
+
+  defp translate_comment_body_values(value), do: value
+
   defp decode_linear_response(%{"data" => %{"issues" => %{"nodes" => nodes}}}, assignee_filter) do
     issues =
       nodes
@@ -430,12 +493,17 @@ defmodule SymphonyElixir.Linear.Client do
          },
          assignee_filter
        ) do
-    with {:ok, issues} <- decode_linear_response(%{"data" => %{"issues" => %{"nodes" => nodes}}}, assignee_filter) do
+    with {:ok, issues} <-
+           decode_linear_response(
+             %{"data" => %{"issues" => %{"nodes" => nodes}}},
+             assignee_filter
+           ) do
       {:ok, issues, %{has_next_page: has_next_page == true, end_cursor: end_cursor}}
     end
   end
 
-  defp decode_linear_page_response(response, assignee_filter), do: decode_linear_response(response, assignee_filter)
+  defp decode_linear_page_response(response, assignee_filter),
+    do: decode_linear_response(response, assignee_filter)
 
   defp next_page_cursor(%{has_next_page: true, end_cursor: end_cursor})
        when is_binary(end_cursor) and byte_size(end_cursor) > 0 do

--- a/elixir/symphony_elixir/lib/symphony_elixir/linear/comment_translator.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/linear/comment_translator.ex
@@ -1,0 +1,38 @@
+defmodule SymphonyElixir.Linear.CommentTranslator do
+  @moduledoc false
+
+  alias SymphonyElixir.Config
+
+  @spec translate_for_linear(String.t()) :: String.t()
+  def translate_for_linear(body) when is_binary(body) do
+    case Config.linear_output_language() do
+      "ja" -> translate_to_japanese(body)
+      "jp" -> translate_to_japanese(body)
+      "japanese" -> translate_to_japanese(body)
+      _ -> body
+    end
+  end
+
+  defp translate_to_japanese(body) do
+    body
+    |> replace_heading("## OpenCode Workpad", "## OpenCode ワークパッド")
+    |> replace_heading("### Plan", "### 計画")
+    |> replace_heading("### Acceptance Criteria", "### 受け入れ基準")
+    |> replace_heading("### Validation", "### 検証")
+    |> replace_heading("### Notes", "### メモ")
+    |> replace_heading("### Confusions", "### 混乱・疑問")
+    |> String.replace("Parent task", "親タスク")
+    |> String.replace("Child task", "子タスク")
+    |> String.replace("Criterion ", "基準 ")
+    |> String.replace("targeted tests:", "対象テスト:")
+    |> String.replace("<short progress note with timestamp>", "<短い進捗メモ（タイムスタンプ付き）>")
+    |> String.replace(
+      "<only include when something was confusing during execution>",
+      "<実行中に混乱や疑問があった場合のみ記載>"
+    )
+  end
+
+  defp replace_heading(body, from, to) do
+    String.replace(body, from, to)
+  end
+end

--- a/elixir/symphony_elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/orchestrator.ex
@@ -1841,7 +1841,21 @@ defmodule SymphonyElixir.Orchestrator do
       ["params", "tokenUsage", "total"],
       [:params, :tokenUsage, :total],
       ["tokenUsage", "total"],
-      [:tokenUsage, :total]
+      [:tokenUsage, :total],
+      ["params", "msg", "payload", "info", "tokens"],
+      [:params, :msg, :payload, :info, :tokens],
+      ["params", "msg", "info", "tokens"],
+      [:params, :msg, :info, :tokens],
+      ["data", "info", "tokens"],
+      [:data, :info, :tokens],
+      ["info", "tokens"],
+      [:info, :tokens],
+      ["properties", "tokens"],
+      [:properties, :tokens],
+      ["properties", "part", "tokens"],
+      [:properties, :part, :tokens],
+      ["tokens"],
+      [:tokens]
     ]
 
     explicit_map_at_paths(payload, absolute_paths)
@@ -1961,6 +1975,8 @@ defmodule SymphonyElixir.Orchestrator do
       :total_tokens,
       :prompt_tokens,
       :completion_tokens,
+      :input,
+      :output,
       :inputTokens,
       :outputTokens,
       :totalTokens,
@@ -1971,6 +1987,8 @@ defmodule SymphonyElixir.Orchestrator do
       "total_tokens",
       "prompt_tokens",
       "completion_tokens",
+      "input",
+      "output",
       "inputTokens",
       "outputTokens",
       "totalTokens",
@@ -1990,6 +2008,7 @@ defmodule SymphonyElixir.Orchestrator do
       payload_get(usage, [
         "input_tokens",
         "prompt_tokens",
+        "input",
         :input_tokens,
         :prompt_tokens,
         :input,
@@ -2004,6 +2023,8 @@ defmodule SymphonyElixir.Orchestrator do
       payload_get(usage, [
         "output_tokens",
         "completion_tokens",
+        "output",
+        "completion",
         :output_tokens,
         :completion_tokens,
         :output,
@@ -2023,7 +2044,14 @@ defmodule SymphonyElixir.Orchestrator do
         :total,
         "totalTokens",
         :totalTokens
-      ])
+      ]) || input_output_token_total(usage)
+
+  defp input_output_token_total(usage) do
+    input = get_token_usage(usage, :input)
+    output = get_token_usage(usage, :output)
+
+    if is_integer(input) and is_integer(output), do: input + output
+  end
 
   defp payload_get(payload, fields) when is_list(fields) do
     Enum.find_value(fields, fn field -> map_integer_value(payload, field) end)

--- a/elixir/symphony_elixir/lib/symphony_elixir/workflow.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/workflow.ex
@@ -83,7 +83,10 @@ defmodule SymphonyElixir.Workflow do
   end
 
   defp split_front_matter(content) do
-    lines = String.split(content, ~r/\R/, trim: false)
+    lines =
+      content
+      |> String.replace("\r\n", "\n")
+      |> String.split("\n", trim: false)
 
     case lines do
       ["---" | tail] ->

--- a/elixir/symphony_elixir/test/support/test_support.exs
+++ b/elixir/symphony_elixir/test/support/test_support.exs
@@ -141,6 +141,7 @@ defmodule SymphonyElixir.TestSupport do
           observability_render_interval_ms: 16,
           server_port: nil,
           server_host: nil,
+          display_language: nil,
           prompt: @workflow_prompt
         ],
         overrides
@@ -178,6 +179,7 @@ defmodule SymphonyElixir.TestSupport do
     observability_render_interval_ms = Keyword.get(config, :observability_render_interval_ms)
     server_port = Keyword.get(config, :server_port)
     server_host = Keyword.get(config, :server_host)
+    display_language = Keyword.get(config, :display_language)
     prompt = Keyword.get(config, :prompt)
 
     sections =
@@ -219,6 +221,7 @@ defmodule SymphonyElixir.TestSupport do
           observability_render_interval_ms
         ),
         server_yaml(server_port, server_host),
+        display_yaml(display_language),
         "---",
         prompt
       ]
@@ -305,6 +308,13 @@ defmodule SymphonyElixir.TestSupport do
       host && "  host: #{yaml_value(host)}"
     ]
     |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp display_yaml(nil), do: nil
+
+  defp display_yaml(language) do
+    ["display:", "  language: #{yaml_value(language)}"]
     |> Enum.join("\n")
   end
 

--- a/elixir/symphony_elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/core_test.exs
@@ -930,6 +930,28 @@ defmodule SymphonyElixir.CoreTest do
     assert prompt =~ "attempt=3"
   end
 
+  test "prompt builder renders Japanese workflow and issue text as valid UTF-8" do
+    workflow_prompt = "チケット {{ issue.identifier }}: {{ issue.title }}\n本文: {{ issue.description }}"
+
+    write_workflow_file!(Workflow.workflow_file_path(), prompt: workflow_prompt)
+
+    issue = %Issue{
+      identifier: "TOT-13",
+      title: "Linearへの返答を日本語化する。",
+      description: "作業メモと最終返答を日本語にする。",
+      state: "Todo",
+      url: "https://example.org/issues/TOT-13",
+      labels: []
+    }
+
+    prompt = PromptBuilder.build_prompt(issue)
+
+    assert String.valid?(prompt)
+    assert prompt =~ "チケット TOT-13"
+    assert prompt =~ "Linearへの返答を日本語化する。"
+    assert prompt =~ "作業メモと最終返答を日本語にする。"
+  end
+
   test "prompt builder renders issue datetime fields without crashing" do
     workflow_prompt =
       "Ticket {{ issue.identifier }} created={{ issue.created_at }} updated={{ issue.updated_at }}"
@@ -1028,10 +1050,10 @@ defmodule SymphonyElixir.CoreTest do
 
     prompt = PromptBuilder.build_prompt(issue)
 
-    assert prompt =~ "You are working on a Linear issue."
-    assert prompt =~ "Identifier: MT-777"
-    assert prompt =~ "Title: Make fallback prompt useful"
-    assert prompt =~ "Body:"
+    assert prompt =~ "Linear チケットに取り組んでいます。"
+    assert prompt =~ "識別子: MT-777"
+    assert prompt =~ "タイトル: Make fallback prompt useful"
+    assert prompt =~ "本文:"
     assert prompt =~ "Include enough issue context to start working."
     assert Config.workflow_prompt() =~ "{{ issue.identifier }}"
     assert Config.workflow_prompt() =~ "{{ issue.title }}"
@@ -1052,9 +1074,9 @@ defmodule SymphonyElixir.CoreTest do
 
     prompt = PromptBuilder.build_prompt(issue)
 
-    assert prompt =~ "Identifier: MT-778"
-    assert prompt =~ "Title: Handle empty body"
-    assert prompt =~ "No description provided."
+    assert prompt =~ "識別子: MT-778"
+    assert prompt =~ "タイトル: Handle empty body"
+    assert prompt =~ "説明はありません。"
   end
 
   test "prompt builder reports workflow load failures separately from template parse errors" do
@@ -1107,19 +1129,19 @@ defmodule SymphonyElixir.CoreTest do
 
     prompt = PromptBuilder.build_prompt(issue, attempt: 2)
 
-    assert prompt =~ "You are working on a Linear ticket `MT-616`"
-    assert prompt =~ "Issue context:"
-    assert prompt =~ "Identifier: MT-616"
-    assert prompt =~ "Title: Use rich templates for WORKFLOW.md"
-    assert prompt =~ "Current status: In Progress"
+    assert prompt =~ "Linear チケット `MT-616` に取り組んでいます"
+    assert prompt =~ "チケット情報:"
+    assert prompt =~ "識別子: MT-616"
+    assert prompt =~ "タイトル: Use rich templates for WORKFLOW.md"
+    assert prompt =~ "現在の状態: In Progress"
     assert prompt =~ "https://example.org/issues/MT-616/use-rich-templates-for-workflowmd"
     assert prompt =~ "This is an unattended orchestration session."
     assert prompt =~ "Only stop early for a true blocker"
     assert prompt =~ "Do not include \"next steps for user\""
     assert prompt =~ "open and follow `.agents/skills/land/SKILL.md`"
     assert prompt =~ "Do not call `gh pr merge` directly"
-    assert prompt =~ "Continuation context:"
-    assert prompt =~ "retry attempt #2"
+    assert prompt =~ "継続コンテキスト:"
+    assert prompt =~ "再試行 attempt #2"
   end
 
   test "prompt builder adds continuation guidance for retries" do
@@ -1409,8 +1431,8 @@ defmodule SymphonyElixir.CoreTest do
 
       assert first_prompt =~ "You are an agent for this repository."
       refute second_prompt =~ "You are an agent for this repository."
-      assert second_prompt =~ "Continuation guidance:"
-      assert second_prompt =~ "continuation turn #2 of 3"
+      assert second_prompt =~ "継続ガイダンス:"
+      assert second_prompt =~ "継続ターン #2 / 3"
     after
       File.rm_rf(test_root)
     end

--- a/elixir/symphony_elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/core_test.exs
@@ -931,7 +931,8 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "prompt builder renders Japanese workflow and issue text as valid UTF-8" do
-    workflow_prompt = "チケット {{ issue.identifier }}: {{ issue.title }}\n本文: {{ issue.description }}"
+    workflow_prompt =
+      "チケット {{ issue.identifier }}: {{ issue.title }}\n本文: {{ issue.description }}"
 
     write_workflow_file!(Workflow.workflow_file_path(), prompt: workflow_prompt)
 
@@ -1050,10 +1051,10 @@ defmodule SymphonyElixir.CoreTest do
 
     prompt = PromptBuilder.build_prompt(issue)
 
-    assert prompt =~ "Linear チケットに取り組んでいます。"
-    assert prompt =~ "識別子: MT-777"
-    assert prompt =~ "タイトル: Make fallback prompt useful"
-    assert prompt =~ "本文:"
+    assert prompt =~ "You are working on a Linear issue."
+    assert prompt =~ "Identifier: MT-777"
+    assert prompt =~ "Title: Make fallback prompt useful"
+    assert prompt =~ "Body:"
     assert prompt =~ "Include enough issue context to start working."
     assert Config.workflow_prompt() =~ "{{ issue.identifier }}"
     assert Config.workflow_prompt() =~ "{{ issue.title }}"
@@ -1074,9 +1075,9 @@ defmodule SymphonyElixir.CoreTest do
 
     prompt = PromptBuilder.build_prompt(issue)
 
-    assert prompt =~ "識別子: MT-778"
-    assert prompt =~ "タイトル: Handle empty body"
-    assert prompt =~ "説明はありません。"
+    assert prompt =~ "Identifier: MT-778"
+    assert prompt =~ "Title: Handle empty body"
+    assert prompt =~ "No description provided."
   end
 
   test "prompt builder reports workflow load failures separately from template parse errors" do
@@ -1129,19 +1130,19 @@ defmodule SymphonyElixir.CoreTest do
 
     prompt = PromptBuilder.build_prompt(issue, attempt: 2)
 
-    assert prompt =~ "Linear チケット `MT-616` に取り組んでいます"
-    assert prompt =~ "チケット情報:"
-    assert prompt =~ "識別子: MT-616"
-    assert prompt =~ "タイトル: Use rich templates for WORKFLOW.md"
-    assert prompt =~ "現在の状態: In Progress"
+    assert prompt =~ "You are working on a Linear ticket `MT-616`"
+    assert prompt =~ "Issue context:"
+    assert prompt =~ "Identifier: MT-616"
+    assert prompt =~ "Title: Use rich templates for WORKFLOW.md"
+    assert prompt =~ "Current status: In Progress"
     assert prompt =~ "https://example.org/issues/MT-616/use-rich-templates-for-workflowmd"
     assert prompt =~ "This is an unattended orchestration session."
     assert prompt =~ "Only stop early for a true blocker"
     assert prompt =~ "Do not include \"next steps for user\""
     assert prompt =~ "open and follow `.agents/skills/land/SKILL.md`"
     assert prompt =~ "Do not call `gh pr merge` directly"
-    assert prompt =~ "継続コンテキスト:"
-    assert prompt =~ "再試行 attempt #2"
+    assert prompt =~ "Continuation context:"
+    assert prompt =~ "retry attempt #2"
   end
 
   test "prompt builder adds continuation guidance for retries" do
@@ -1431,8 +1432,8 @@ defmodule SymphonyElixir.CoreTest do
 
       assert first_prompt =~ "You are an agent for this repository."
       refute second_prompt =~ "You are an agent for this repository."
-      assert second_prompt =~ "継続ガイダンス:"
-      assert second_prompt =~ "継続ターン #2 / 3"
+      assert second_prompt =~ "Continuation guidance:"
+      assert second_prompt =~ "continuation turn #2 of 3"
     after
       File.rm_rf(test_root)
     end

--- a/elixir/symphony_elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -205,6 +205,134 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     assert is_integer(completed_state.opencode_totals.seconds_running)
   end
 
+  test "orchestrator snapshot tracks OpenCode session token payloads" do
+    issue_id = "issue-opencode-session-tokens"
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "MT-203",
+      title: "OpenCode session token test",
+      description: "Collect usage stats from OpenCode session events",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-203"
+    }
+
+    orchestrator_name = Module.concat(__MODULE__, :SessionTokenOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    initial_state = :sys.get_state(pid)
+    process_ref = make_ref()
+
+    running_entry = %{
+      pid: self(),
+      ref: process_ref,
+      identifier: issue.identifier,
+      issue: issue,
+      session_id: "ses_tokens",
+      turn_count: 1,
+      last_opencode_message: nil,
+      last_opencode_timestamp: nil,
+      last_opencode_event: nil,
+      opencode_input_tokens: 0,
+      opencode_output_tokens: 0,
+      opencode_total_tokens: 0,
+      opencode_last_reported_input_tokens: 0,
+      opencode_last_reported_output_tokens: 0,
+      opencode_last_reported_total_tokens: 0,
+      started_at: DateTime.utc_now()
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+    end)
+
+    now = DateTime.utc_now()
+
+    send(
+      pid,
+      {:opencode_worker_update, issue_id,
+       %{
+         event: :notification,
+         payload: %{
+           "sessionID" => "ses_tokens",
+           "info" => %{
+             "tokens" => %{
+               "input" => 120,
+               "output" => 30,
+               "reasoning" => 5,
+               "cache" => %{"read" => 9, "write" => 1}
+             }
+           }
+         },
+         timestamp: now
+       }}
+    )
+
+    send(
+      pid,
+      {:opencode_worker_update, issue_id,
+       %{
+         event: :notification,
+         payload: %{
+           "properties" => %{
+             "sessionID" => "ses_tokens",
+             "tokens" => %{
+               "input" => 150,
+               "output" => 45,
+               "reasoning" => 8,
+               "cache" => %{"read" => 10, "write" => 2}
+             }
+           }
+         },
+         timestamp: now
+       }}
+    )
+
+    send(
+      pid,
+      {:opencode_worker_update, issue_id,
+       %{
+         event: :notification,
+         payload: %{
+           "type" => "message.part.updated",
+           "properties" => %{
+             "sessionID" => "ses_tokens",
+             "part" => %{
+               "type" => "step-finish",
+               "tokens" => %{
+                 "input" => 170,
+                 "output" => 50,
+                 "reasoning" => 10,
+                 "cache" => %{"read" => 11, "write" => 3}
+               }
+             }
+           }
+         },
+         timestamp: now
+       }}
+    )
+
+    snapshot = GenServer.call(pid, :snapshot)
+    assert %{running: [snapshot_entry]} = snapshot
+    assert snapshot_entry.opencode_input_tokens == 170
+    assert snapshot_entry.opencode_output_tokens == 50
+    assert snapshot_entry.opencode_total_tokens == 220
+
+    send(pid, {:DOWN, process_ref, :process, self(), :normal})
+    completed_state = :sys.get_state(pid)
+    assert completed_state.opencode_totals.input_tokens == 170
+    assert completed_state.opencode_totals.output_tokens == 50
+    assert completed_state.opencode_totals.total_tokens == 220
+  end
+
   test "orchestrator snapshot tracks turn completed usage when present" do
     issue_id = "issue-turn-completed-usage"
 

--- a/elixir/symphony_elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -486,6 +486,64 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert log =~ "Variable \\\"$ids\\\" got invalid value"
   end
 
+  test "linear client translates comment bodies from front matter language before graphql post" do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_api_token: "token",
+      display_language: "JA"
+    )
+
+    mutation = """
+    mutation Create($issueId: String!, $body: String!) {
+      commentCreate(input: {issueId: $issueId, body: $body}) { success }
+    }
+    """
+
+    body = """
+    ## OpenCode Workpad
+
+    ### Plan
+
+    - [ ] 1\\. Parent task
+      - [ ] 1.1 Child task
+
+    ### Acceptance Criteria
+
+    - [ ] Criterion 1
+
+    ### Validation
+
+    - [ ] targeted tests: `mix test`
+
+    ### Notes
+
+    - <short progress note with timestamp>
+
+    ### Confusions
+
+    - <only include when something was confusing during execution>
+    """
+
+    assert {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}} =
+             Client.graphql(mutation, %{issueId: "issue-1", body: body},
+               request_fun: fn payload, _headers ->
+                 translated = get_in(payload, ["variables", :body])
+                 assert translated =~ "## OpenCode ワークパッド"
+                 assert translated =~ "### 計画"
+                 assert translated =~ "親タスク"
+                 assert translated =~ "子タスク"
+                 assert translated =~ "### 受け入れ基準"
+                 assert translated =~ "基準 1"
+                 assert translated =~ "### 検証"
+                 assert translated =~ "対象テスト: `mix test`"
+                 assert translated =~ "### メモ"
+                 assert translated =~ "### 混乱・疑問"
+
+                 {:ok,
+                  %{status: 200, body: %{"data" => %{"commentCreate" => %{"success" => true}}}}}
+               end
+             )
+  end
+
   test "orchestrator sorts dispatch by priority then oldest created_at" do
     issue_same_priority_older = %Issue{
       id: "issue-old-high",
@@ -822,6 +880,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert config.worker.max_concurrent_agents_per_host == nil
     assert config.agent.max_concurrent_agents == 10
     assert config.opencode.model == nil
+    assert config.display.language == nil
 
     assert config.opencode.turn_timeout_ms == 3_600_000
     assert config.opencode.stall_timeout_ms == 300_000
@@ -840,6 +899,10 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     )
 
     assert Config.settings!().opencode.model == "openai/gpt-5.5"
+
+    write_workflow_file!(Workflow.workflow_file_path(), display_language: " JA ")
+    assert Config.settings!().display.language == "ja"
+    assert Config.linear_output_language() == "ja"
 
     write_workflow_file!(Workflow.workflow_file_path(), tracker_active_states: ",")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()


### PR DESCRIPTION
#### Context

TOT-13 requires Japanese localization for Linear-facing responses. Instead of hardcoding Japanese throughout prompts, we translate English workpad content to Japanese only when posting comments to Linear.

#### TL;DR

_Boundary-translate workpad headings to Japanese at the Linear GraphQL layer._

#### Summary

- Add CommentTranslator module for Japanese workpad heading translation
- Add display.language config field to control output language
- Hook translation into Linear.Client.graphql for comment mutations only
- Revert internal prompts to English for better agent reasoning
- Update tests to assert on translated output at GraphQL boundary

#### Alternatives

- Full Japanese prompts throughout codebase: rejected because English internals improve agent reasoning and maintainability
- Runtime LLM translation: rejected due to latency, cost, and non-determinism

#### Test Plan

- [x] mix test passes (208 passed, 2 skipped)
- [x] mix credo passes with no issues
- [x] mix specs.check passes
- [x] mix dialyzer has pre-existing PLT build issue unrelated to changes
