### PR TITLE
feat(symphony): translate Linear comments via agent

### DIFF
--- a/elixir/symphony_elixir/lib/symphony_elixir/linear/client.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/linear/client.ex
@@ -164,7 +164,7 @@ defmodule SymphonyElixir.Linear.Client do
   @spec graphql(String.t(), map(), keyword()) :: {:ok, map()} | {:error, term()}
   def graphql(query, variables \\ %{}, opts \\ [])
       when is_binary(query) and is_map(variables) and is_list(opts) do
-    variables = translate_linear_comment_variables(query, variables)
+    variables = translate_linear_comment_variables(query, variables, opts)
     payload = build_graphql_payload(query, variables, Keyword.get(opts, :operation_name))
     request_fun = Keyword.get(opts, :request_fun, &post_graphql_request/2)
 
@@ -437,9 +437,9 @@ defmodule SymphonyElixir.Linear.Client do
     )
   end
 
-  defp translate_linear_comment_variables(query, variables) do
+  defp translate_linear_comment_variables(query, variables, opts) do
     if linear_comment_mutation?(query) do
-      translate_comment_body_values(variables)
+      translate_comment_body_values(variables, opts)
     else
       variables
     end
@@ -449,21 +449,21 @@ defmodule SymphonyElixir.Linear.Client do
     String.contains?(query, ["commentCreate", "commentUpdate"])
   end
 
-  defp translate_comment_body_values(value) when is_map(value) do
+  defp translate_comment_body_values(value, opts) when is_map(value) do
     Map.new(value, fn
       {key, body} when key in [:body, "body"] and is_binary(body) ->
-        {key, CommentTranslator.translate_for_linear(body)}
+        {key, CommentTranslator.translate_for_linear(body, opts)}
 
       {key, nested} ->
-        {key, translate_comment_body_values(nested)}
+        {key, translate_comment_body_values(nested, opts)}
     end)
   end
 
-  defp translate_comment_body_values(value) when is_list(value) do
-    Enum.map(value, &translate_comment_body_values/1)
+  defp translate_comment_body_values(value, opts) when is_list(value) do
+    Enum.map(value, &translate_comment_body_values(&1, opts))
   end
 
-  defp translate_comment_body_values(value), do: value
+  defp translate_comment_body_values(value, _opts), do: value
 
   defp decode_linear_response(%{"data" => %{"issues" => %{"nodes" => nodes}}}, assignee_filter) do
     issues =

--- a/elixir/symphony_elixir/lib/symphony_elixir/linear/comment_translator.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/linear/comment_translator.ex
@@ -30,7 +30,7 @@ defmodule SymphonyElixir.Linear.CommentTranslator do
   def run_translation_agent(body, language, opts) when is_binary(body) and is_binary(language) do
     workspace = Keyword.get_lazy(opts, :translation_workspace, &default_translation_workspace/0)
     agent_opts = Keyword.get(opts, :translation_agent_opts, [])
-    prompt = translation_prompt(body, language)
+    system = translation_system_prompt(language)
     ref = make_ref()
     parent = self()
 
@@ -45,9 +45,11 @@ defmodule SymphonyElixir.Linear.CommentTranslator do
          {:ok, _result} <-
            AppServer.run(
              workspace,
-             prompt,
+             body,
              issue,
-             Keyword.put(agent_opts, :on_message, on_message)
+             agent_opts
+             |> Keyword.put(:on_message, on_message)
+             |> Keyword.put(:system, system)
            ) do
       case collect_agent_output(ref) do
         translated when is_binary(translated) and translated != "" -> {:ok, translated}
@@ -105,20 +107,16 @@ defmodule SymphonyElixir.Linear.CommentTranslator do
     do_translate_with_retries(body, language, opts, agent_fun, attempts_left - 1)
   end
 
-  defp translation_prompt(body, language) do
+  defp translation_system_prompt(language) do
     """
     You are a translation-only agent.
 
     Target language: #{language}
 
-    Translate only the text inside <linear-comment> into the target language.
+    Translate the user's input into the target language.
     Preserve Markdown structure, code fences, URLs, identifiers, checkboxes, and commands.
     If the text is already appropriate for the target language and no wording needs to change, output it unchanged.
     Output only the final comment body. Do not explain, summarize, quote, wrap, or add any other text.
-
-    <linear-comment>
-    #{body}
-    </linear-comment>
     """
   end
 

--- a/elixir/symphony_elixir/lib/symphony_elixir/linear/comment_translator.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/linear/comment_translator.ex
@@ -1,38 +1,195 @@
 defmodule SymphonyElixir.Linear.CommentTranslator do
   @moduledoc false
 
+  require Logger
+
   alias SymphonyElixir.Config
+  alias SymphonyElixir.Opencode.AppServer
+
+  @default_retry_attempts 3
+  @translation_workspace_name ".linear-comment-translation"
+
+  @type agent_fun :: (String.t(), String.t(), keyword() -> {:ok, String.t()} | {:error, term()})
 
   @spec translate_for_linear(String.t()) :: String.t()
-  def translate_for_linear(body) when is_binary(body) do
+  def translate_for_linear(body) when is_binary(body), do: translate_for_linear(body, [])
+
+  @spec translate_for_linear(String.t(), keyword()) :: String.t()
+  def translate_for_linear(body, opts) when is_binary(body) and is_list(opts) do
     case Config.linear_output_language() do
-      "ja" -> translate_to_japanese(body)
-      "jp" -> translate_to_japanese(body)
-      "japanese" -> translate_to_japanese(body)
-      _ -> body
+      language when is_binary(language) and language != "" ->
+        translate_with_retries(body, language, opts)
+
+      _ ->
+        body
     end
   end
 
-  defp translate_to_japanese(body) do
-    body
-    |> replace_heading("## OpenCode Workpad", "## OpenCode ワークパッド")
-    |> replace_heading("### Plan", "### 計画")
-    |> replace_heading("### Acceptance Criteria", "### 受け入れ基準")
-    |> replace_heading("### Validation", "### 検証")
-    |> replace_heading("### Notes", "### メモ")
-    |> replace_heading("### Confusions", "### 混乱・疑問")
-    |> String.replace("Parent task", "親タスク")
-    |> String.replace("Child task", "子タスク")
-    |> String.replace("Criterion ", "基準 ")
-    |> String.replace("targeted tests:", "対象テスト:")
-    |> String.replace("<short progress note with timestamp>", "<短い進捗メモ（タイムスタンプ付き）>")
-    |> String.replace(
-      "<only include when something was confusing during execution>",
-      "<実行中に混乱や疑問があった場合のみ記載>"
-    )
+  @spec run_translation_agent(String.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  def run_translation_agent(body, language, opts) when is_binary(body) and is_binary(language) do
+    workspace = Keyword.get_lazy(opts, :translation_workspace, &default_translation_workspace/0)
+    agent_opts = Keyword.get(opts, :translation_agent_opts, [])
+    prompt = translation_prompt(body, language)
+    ref = make_ref()
+    parent = self()
+
+    on_message = fn message ->
+      send(parent, {:linear_comment_translation_agent_message, ref, message})
+      :ok
+    end
+
+    issue = %{id: "linear-comment-translation", identifier: "LINEAR-COMMENT-TRANSLATION"}
+
+    with :ok <- File.mkdir_p(workspace),
+         {:ok, _result} <-
+           AppServer.run(
+             workspace,
+             prompt,
+             issue,
+             Keyword.put(agent_opts, :on_message, on_message)
+           ) do
+      case collect_agent_output(ref) do
+        translated when is_binary(translated) and translated != "" -> {:ok, translated}
+        _ -> {:error, :empty_translation}
+      end
+    end
   end
 
-  defp replace_heading(body, from, to) do
-    String.replace(body, from, to)
+  defp translate_with_retries(body, language, opts) do
+    agent_fun = Keyword.get(opts, :translation_agent_fun, &run_translation_agent/3)
+    attempts = Keyword.get(opts, :translation_retry_attempts, @default_retry_attempts)
+
+    case do_translate_with_retries(body, language, opts, agent_fun, max(attempts, 1)) do
+      {:ok, translated} ->
+        translated
+
+      {:error, reason} ->
+        Logger.warning(
+          "Linear comment translation failed after #{max(attempts, 1)} attempt(s); posting original body: #{inspect(reason)}"
+        )
+
+        body
+    end
   end
+
+  defp do_translate_with_retries(_body, _language, _opts, _agent_fun, 0),
+    do: {:error, :retry_exhausted}
+
+  defp do_translate_with_retries(body, language, opts, agent_fun, attempts_left) do
+    case agent_fun.(body, language, opts) do
+      {:ok, translated} when is_binary(translated) ->
+        {:ok, translated}
+
+      {:ok, other} ->
+        retry_or_error(
+          body,
+          language,
+          opts,
+          agent_fun,
+          attempts_left,
+          {:invalid_translation, other}
+        )
+
+      {:error, reason} ->
+        retry_or_error(body, language, opts, agent_fun, attempts_left, reason)
+    end
+  catch
+    kind, reason ->
+      retry_or_error(body, language, opts, agent_fun, attempts_left, {kind, reason})
+  end
+
+  defp retry_or_error(_body, _language, _opts, _agent_fun, 1, reason), do: {:error, reason}
+
+  defp retry_or_error(body, language, opts, agent_fun, attempts_left, _reason) do
+    do_translate_with_retries(body, language, opts, agent_fun, attempts_left - 1)
+  end
+
+  defp translation_prompt(body, language) do
+    """
+    You are a translation-only agent.
+
+    Target language: #{language}
+
+    Translate only the text inside <linear-comment> into the target language.
+    Preserve Markdown structure, code fences, URLs, identifiers, checkboxes, and commands.
+    If the text is already appropriate for the target language and no wording needs to change, output it unchanged.
+    Output only the final comment body. Do not explain, summarize, quote, wrap, or add any other text.
+
+    <linear-comment>
+    #{body}
+    </linear-comment>
+    """
+  end
+
+  defp default_translation_workspace do
+    Config.settings!().workspace.root
+    |> Path.expand()
+    |> Path.join(@translation_workspace_name)
+  end
+
+  defp collect_agent_output(ref, acc \\ []) do
+    receive do
+      {:linear_comment_translation_agent_message, ^ref, message} ->
+        collect_agent_output(ref, collect_message_text(message, acc))
+    after
+      0 ->
+        acc
+        |> Enum.reverse()
+        |> Enum.join("")
+        |> String.trim()
+    end
+  end
+
+  defp collect_message_text(%{event: :notification, type: type, payload: payload}, acc)
+       when is_binary(type) do
+    if String.contains?(type, "message") do
+      case text_from_payload(payload) do
+        text when is_binary(text) -> [text | acc]
+        _ -> acc
+      end
+    else
+      acc
+    end
+  end
+
+  defp collect_message_text(_message, acc), do: acc
+
+  defp text_from_payload(payload) do
+    find_text(payload, [
+      :delta,
+      "delta",
+      :text,
+      "text",
+      :content,
+      "content",
+      :message,
+      "message",
+      :output,
+      "output",
+      :result,
+      "result"
+    ])
+  end
+
+  defp find_text(nil, _keys), do: nil
+
+  defp find_text(value, _keys) when is_binary(value), do: value
+
+  defp find_text(value, keys) when is_list(value),
+    do: Enum.find_value(value, &find_text(&1, keys))
+
+  defp find_text(value, keys) when is_map(value) do
+    Enum.find_value(keys, fn key ->
+      case Map.get(value, key) do
+        text when is_binary(text) -> text
+        _ -> nil
+      end
+    end) ||
+      value
+      |> Map.values()
+      |> Enum.find_value(&find_text(&1, keys))
+  end
+
+  defp find_text(_value, _keys), do: nil
 end

--- a/elixir/symphony_elixir/lib/symphony_elixir/opencode/app_server.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/opencode/app_server.ex
@@ -84,7 +84,9 @@ defmodule SymphonyElixir.Opencode.AppServer do
       session.metadata
     )
 
-    body = %{parts: [%{type: "text", text: prompt}]}
+    body =
+      %{parts: [%{type: "text", text: prompt}]}
+      |> maybe_put_system(Keyword.get(opts, :system))
 
     parent = self()
     sse_pid = spawn_link(fn -> sse_listener(event_stream, client, parent) end)
@@ -238,6 +240,15 @@ defmodule SymphonyElixir.Opencode.AppServer do
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp maybe_put_system(body, system) when is_binary(system) do
+    case String.trim(system) do
+      "" -> body
+      trimmed -> Map.put(body, :system, trimmed)
+    end
+  end
+
+  defp maybe_put_system(body, _system), do: body
 
   defp validate_workspace_cwd(workspace, nil) when is_binary(workspace) do
     expanded_workspace = Path.expand(workspace)

--- a/elixir/symphony_elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -614,13 +614,13 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
                  ]
                )
 
-      assert_received {:opencode_prompt_async, "ses_translate", %{parts: [%{text: prompt}]},
-                       _client}
+      assert_received {:opencode_prompt_async, "ses_translate",
+                       %{parts: [%{text: "Hello"}], system: system}, _client}
 
-      assert prompt =~ "Target language: fr"
-      assert prompt =~ "<linear-comment>"
-      assert prompt =~ "Hello"
-      assert prompt =~ "Output only the final comment body"
+      assert system =~ "Target language: fr"
+      assert system =~ "Translate the user's input into the target language."
+      assert system =~ "Output only the final comment body"
+      refute system =~ "Hello"
     after
       File.rm_rf(test_root)
     end

--- a/elixir/symphony_elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -486,10 +486,41 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert log =~ "Variable \\\"$ids\\\" got invalid value"
   end
 
-  test "linear client translates comment bodies from front matter language before graphql post" do
+  test "linear client sends comment bodies through translation agent using front matter language before graphql post" do
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_api_token: "token",
-      display_language: "JA"
+      display_language: "FR"
+    )
+
+    mutation = """
+    mutation Create($input: CommentCreateInput!) {
+      commentCreate(input: $input) { success }
+    }
+    """
+
+    body = "Progress update"
+
+    assert {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}} =
+             Client.graphql(mutation, %{input: %{issueId: "issue-1", body: body}},
+               translation_agent_fun: fn ^body, language, _opts ->
+                 send(self(), {:translation_agent_called, language})
+                 {:ok, "Mise à jour"}
+               end,
+               request_fun: fn payload, _headers ->
+                 assert get_in(payload, ["variables", :input, :body]) == "Mise à jour"
+
+                 {:ok,
+                  %{status: 200, body: %{"data" => %{"commentCreate" => %{"success" => true}}}}}
+               end
+             )
+
+    assert_received {:translation_agent_called, "fr"}
+  end
+
+  test "linear client still sends same-language comment bodies through translation agent" do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_api_token: "token",
+      display_language: "en"
     )
 
     mutation = """
@@ -498,50 +529,101 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     }
     """
 
-    body = """
-    ## OpenCode Workpad
-
-    ### Plan
-
-    - [ ] 1\\. Parent task
-      - [ ] 1.1 Child task
-
-    ### Acceptance Criteria
-
-    - [ ] Criterion 1
-
-    ### Validation
-
-    - [ ] targeted tests: `mix test`
-
-    ### Notes
-
-    - <short progress note with timestamp>
-
-    ### Confusions
-
-    - <only include when something was confusing during execution>
-    """
+    body = "Already English"
 
     assert {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}} =
              Client.graphql(mutation, %{issueId: "issue-1", body: body},
+               translation_agent_fun: fn ^body, "en", _opts ->
+                 send(self(), :same_language_agent_called)
+                 {:ok, body}
+               end,
                request_fun: fn payload, _headers ->
-                 translated = get_in(payload, ["variables", :body])
-                 assert translated =~ "## OpenCode ワークパッド"
-                 assert translated =~ "### 計画"
-                 assert translated =~ "親タスク"
-                 assert translated =~ "子タスク"
-                 assert translated =~ "### 受け入れ基準"
-                 assert translated =~ "基準 1"
-                 assert translated =~ "### 検証"
-                 assert translated =~ "対象テスト: `mix test`"
-                 assert translated =~ "### メモ"
-                 assert translated =~ "### 混乱・疑問"
+                 assert get_in(payload, ["variables", :body]) == body
 
                  {:ok,
                   %{status: 200, body: %{"data" => %{"commentCreate" => %{"success" => true}}}}}
                end
              )
+
+    assert_received :same_language_agent_called
+  end
+
+  test "linear client retries translation agent failures then posts original comment body" do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_api_token: "token",
+      display_language: "de"
+    )
+
+    mutation = """
+    mutation Update($body: String!) {
+      commentUpdate(id: "comment-1", input: {body: $body}) { success }
+    }
+    """
+
+    body = "Keep original after failures"
+
+    assert {:ok, %{"data" => %{"commentUpdate" => %{"success" => true}}}} =
+             Client.graphql(mutation, %{body: body},
+               translation_retry_attempts: 3,
+               translation_agent_fun: fn ^body, "de", _opts ->
+                 send(self(), :translation_attempt)
+                 {:error, :agent_unavailable}
+               end,
+               request_fun: fn payload, _headers ->
+                 assert get_in(payload, ["variables", :body]) == body
+
+                 {:ok,
+                  %{status: 200, body: %{"data" => %{"commentUpdate" => %{"success" => true}}}}}
+               end
+             )
+
+    assert_received :translation_attempt
+    assert_received :translation_attempt
+    assert_received :translation_attempt
+    refute_received :translation_attempt
+  end
+
+  test "comment translator can use an opencode agent run to produce translated body" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-comment-translator-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+
+      events = [
+        %{
+          type: "message.part.delta",
+          data: %{"properties" => %{"sessionID" => "ses_translate", "delta" => "Bonjour"}}
+        },
+        SymphonyElixir.OpencodeFakes.EventStream.idle_event("ses_translate")
+      ]
+
+      assert {:ok, "Bonjour"} =
+               SymphonyElixir.Linear.CommentTranslator.run_translation_agent("Hello", "fr",
+                 translation_agent_opts: [
+                   client_opts: [test_pid: self(), session_id: "ses_translate", events: events],
+                   event_stream: SymphonyElixir.OpencodeFakes.EventStream,
+                   server_module: SymphonyElixir.OpencodeFakes.Server,
+                   server_opts: [test_pid: self(), url: "http://127.0.0.1:4999"],
+                   session_api: SymphonyElixir.OpencodeFakes.SessionApi,
+                   turn_timeout_ms: 1_000
+                 ]
+               )
+
+      assert_received {:opencode_prompt_async, "ses_translate", %{parts: [%{text: prompt}]},
+                       _client}
+
+      assert prompt =~ "Target language: fr"
+      assert prompt =~ "<linear-comment>"
+      assert prompt =~ "Hello"
+      assert prompt =~ "Output only the final comment body"
+    after
+      File.rm_rf(test_root)
+    end
   end
 
   test "orchestrator sorts dispatch by priority then oldest created_at" do


### PR DESCRIPTION
#### Context

Linear-facing comments need configurable language output without hardcoded Japanese replacements.

#### TL;DR

_Translate Linear comment bodies via an OpenCode agent using display.language._

#### Summary

- Route Linear commentCreate/commentUpdate bodies through agent translation.
- Use front matter display.language as the target language.
- Split translation instructions into system and comment body into parts.

#### Alternatives

- Hardcoded Japanese replacement was rejected because output language must be configurable.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `mix format --check-formatted lib/symphony_elixir/opencode/app_server.ex lib/symphony_elixir/linear/comment_translator.ex test/symphony_elixir/workspace_and_config_test.exs`
- [x] `mix test test/symphony_elixir/workspace_and_config_test.exs`
- [x] `mix test test/symphony_elixir/opencode_app_server_test.exs`
- [x] `mix specs.check`
- [x] `mix escript.build`