### PR TITLE
TOT-16: Share OpenCode server ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _build/
 __pycache__/
 deps/
 log/
+.omo/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,8 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "linear": {
+      "command": "linear-mcp",
+      "args": []
+    }
+  }
 }

--- a/elixir/symphony_elixir/lib/symphony_elixir.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir.ex
@@ -27,6 +27,7 @@ defmodule SymphonyElixir.Application do
       {Phoenix.PubSub, name: SymphonyElixir.PubSub},
       {Task.Supervisor, name: SymphonyElixir.TaskSupervisor},
       SymphonyElixir.WorkflowStore,
+      SymphonyElixir.Opencode.ConnectionManager,
       SymphonyElixir.Orchestrator,
       SymphonyElixir.HttpServer,
       SymphonyElixir.StatusDashboard

--- a/elixir/symphony_elixir/lib/symphony_elixir/opencode/app_server.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/opencode/app_server.ex
@@ -212,6 +212,7 @@ defmodule SymphonyElixir.Opencode.AppServer do
         :auth,
         :base_url,
         :client_opts,
+        :connection_manager,
         :server_config,
         :server_module,
         :server_opts

--- a/elixir/symphony_elixir/lib/symphony_elixir/opencode/app_server.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/opencode/app_server.ex
@@ -23,6 +23,7 @@ defmodule SymphonyElixir.Opencode.AppServer do
   alias OpencodeClient.{Connection, EventStream}
   alias OpencodeClient.Generated.Session
   alias SymphonyElixir.{Config, Linear.Issue, PathSafety}
+  alias SymphonyElixir.Opencode.ConnectionManager
 
   @default_turn_timeout_ms 3_600_000
 
@@ -162,7 +163,7 @@ defmodule SymphonyElixir.Opencode.AppServer do
 
       :ok
   after
-    Connection.stop(session.connection)
+    stop_connection(session.connection)
   end
 
   defp create_session(workspace, opts, %{client: client} = connection) do
@@ -187,16 +188,16 @@ defmodule SymphonyElixir.Opencode.AppServer do
              }}
 
           _ ->
-            Connection.stop(connection)
+            stop_connection(connection)
             {:error, {:invalid_session_response, body_json}}
         end
 
       {:ok, body} ->
-        Connection.stop(connection)
+        stop_connection(connection)
         {:error, {:session_create_failed, body}}
 
       {:error, reason} ->
-        Connection.stop(connection)
+        stop_connection(connection)
         {:error, {:session_create_error, reason}}
     end
   end
@@ -218,6 +219,19 @@ defmodule SymphonyElixir.Opencode.AppServer do
       |> Keyword.put(:server_config, server_config)
       |> Keyword.put(:allow_server_start, is_nil(worker_host))
 
+    if shared_local_connection?(opts, worker_host) do
+      manager = Keyword.get(opts, :connection_manager, ConnectionManager)
+
+      case ConnectionManager.connection(opts, manager) do
+        {:ok, connection} -> {:ok, Map.put(connection, :worker_host, worker_host)}
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      start_direct_connection(opts, worker_host)
+    end
+  end
+
+  defp start_direct_connection(opts, worker_host) do
     case Connection.start(opts) do
       {:ok, connection} ->
         {:ok, Map.put(connection, :worker_host, worker_host)}
@@ -229,6 +243,25 @@ defmodule SymphonyElixir.Opencode.AppServer do
         {:error, reason}
     end
   end
+
+  defp shared_local_connection?(opts, nil), do: is_nil(explicit_base_url(opts))
+  defp shared_local_connection?(_opts, _worker_host), do: false
+
+  defp explicit_base_url(opts) do
+    opts
+    |> Keyword.get(:base_url, System.get_env("OPENCODE_BASE_URL"))
+    |> case do
+      url when is_binary(url) ->
+        url = String.trim(url)
+        if url == "", do: nil, else: url
+
+      _ ->
+        nil
+    end
+  end
+
+  defp stop_connection(%{shared_server_owner: ConnectionManager}), do: :ok
+  defp stop_connection(connection), do: Connection.stop(connection)
 
   defp session_metadata(session_id, client, connection) do
     connection

--- a/elixir/symphony_elixir/lib/symphony_elixir/opencode/connection_manager.ex
+++ b/elixir/symphony_elixir/lib/symphony_elixir/opencode/connection_manager.ex
@@ -1,0 +1,231 @@
+# このファイルは元のApache 2.0ライセンスのコードから新規に追加されています
+# 変更日: 2026-07-04
+# 変更者: totto2727
+# 変更内容: OpenCode のローカル共有サーバー接続を管理する GenServer を追加
+
+defmodule SymphonyElixir.Opencode.ConnectionManager do
+  @moduledoc """
+  Owns the app-wide local OpenCode server connection.
+
+  Explicit `base_url` connections remain externally owned by callers. This
+  manager only starts and supervises the local `opencode serve` process used
+  when Symphony runs agents on the local machine.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias OpencodeClient.Connection
+  alias OpencodeClient.Generated.Global
+
+  @default_health_interval_ms 30_000
+
+  defstruct connection: nil,
+            connection_key: nil,
+            connection_opts: nil,
+            health_api: Global,
+            health_interval_ms: @default_health_interval_ms,
+            health_timer: nil,
+            last_error: nil
+
+  @type server :: GenServer.server()
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @spec connection(keyword(), server()) :: {:ok, Connection.t()} | {:error, term()}
+  def connection(opts, server \\ __MODULE__) do
+    with :ok <- ensure_default_manager_started(server) do
+      GenServer.call(server, {:connection, opts}, :infinity)
+    end
+  end
+
+  @spec health_check(server()) :: :ok | {:error, term()}
+  def health_check(server \\ __MODULE__) do
+    GenServer.call(server, :health_check, :infinity)
+  end
+
+  @spec stop_connection(server()) :: :ok
+  def stop_connection(server \\ __MODULE__) do
+    GenServer.call(server, :stop_connection, :infinity)
+  end
+
+  @impl true
+  def init(opts) do
+    health_interval_ms = Keyword.get(opts, :health_interval_ms, @default_health_interval_ms)
+
+    state = %__MODULE__{
+      health_api: Keyword.get(opts, :health_api, Global),
+      health_interval_ms: health_interval_ms
+    }
+
+    {:ok, schedule_health_check(state)}
+  end
+
+  @impl true
+  def handle_call({:connection, opts}, _from, state) do
+    case ensure_connection(opts, state) do
+      {:ok, connection, next_state} ->
+        {:reply, {:ok, session_connection(connection, opts)}, next_state}
+
+      {:error, reason, next_state} ->
+        {:reply, {:error, reason}, next_state}
+    end
+  end
+
+  def handle_call(:health_check, _from, state) do
+    {reply, next_state} = run_health_check(state)
+    {:reply, reply, next_state}
+  end
+
+  def handle_call(:stop_connection, _from, state) do
+    {:reply, :ok, stop_owned_connection(state)}
+  end
+
+  @impl true
+  def handle_info(:health_check, state) do
+    {_reply, next_state} = run_health_check(%{state | health_timer: nil})
+    {:noreply, schedule_health_check(next_state)}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    _state = stop_owned_connection(state)
+    :ok
+  end
+
+  defp ensure_connection(opts, %{connection: connection, connection_key: key} = state)
+       when not is_nil(connection) do
+    next_key = connection_key(opts)
+
+    if next_key == key do
+      {:ok, connection, state}
+    else
+      state
+      |> stop_owned_connection()
+      |> start_connection(opts)
+    end
+  end
+
+  defp ensure_connection(opts, state), do: start_connection(state, opts)
+
+  defp start_connection(state, opts) do
+    connection_opts = Keyword.put(opts, :allow_server_start, true)
+
+    case Connection.start(connection_opts) do
+      {:ok, connection} ->
+        {:ok, connection,
+         %{
+           state
+           | connection: connection,
+             connection_key: connection_key(opts),
+             connection_opts: connection_opts,
+             last_error: nil
+         }}
+
+      {:error, reason} ->
+        {:error, reason, %{state | connection: nil, last_error: reason}}
+    end
+  end
+
+  defp run_health_check(%{connection: nil} = state), do: {:ok, state}
+
+  defp run_health_check(%{connection: %{client: client}, health_api: health_api} = state) do
+    case health_api.global_health(client) do
+      {:ok, %{healthy: true}} ->
+        {:ok, %{state | last_error: nil}}
+
+      {:ok, %{"healthy" => true}} ->
+        {:ok, %{state | last_error: nil}}
+
+      {:ok, response} ->
+        restart_unhealthy_connection({:unhealthy, response}, state)
+
+      {:error, reason} ->
+        restart_unhealthy_connection(reason, state)
+    end
+  end
+
+  defp restart_unhealthy_connection(reason, state) do
+    Logger.warning("OpenCode health check failed; restarting shared server: #{inspect(reason)}")
+
+    restart_opts = state.connection_opts
+    stopped_state = stop_owned_connection(state)
+
+    case restart_opts do
+      nil ->
+        {{:error, reason}, %{stopped_state | last_error: reason}}
+
+      opts ->
+        case start_connection(stopped_state, opts) do
+          {:ok, _connection, next_state} -> {:ok, next_state}
+          {:error, start_reason, next_state} -> {{:error, start_reason}, next_state}
+        end
+    end
+  end
+
+  defp stop_owned_connection(%{connection: nil} = state) do
+    %{state | connection_key: nil, connection_opts: nil}
+  end
+
+  defp stop_owned_connection(%{connection: connection} = state) do
+    Connection.stop(connection)
+    %{state | connection: nil, connection_key: nil, connection_opts: nil}
+  end
+
+  defp session_connection(%{client: client} = connection, opts) do
+    %{
+      connection
+      | client: session_client(client, opts)
+    }
+    |> Map.put(:shared_server_owner, __MODULE__)
+  end
+
+  defp session_client(shared_client, opts) do
+    base_url = Keyword.fetch!(shared_client, :base_url)
+    client_opts = Keyword.get(opts, :client_opts, [])
+
+    auth =
+      Keyword.get(opts, :auth, Keyword.get(client_opts, :auth, Keyword.get(shared_client, :auth)))
+
+    client_opts
+    |> Keyword.put(:base_url, base_url)
+    |> Keyword.put(:auth, auth)
+  end
+
+  defp schedule_health_check(%{health_interval_ms: interval_ms} = state)
+       when is_integer(interval_ms) and interval_ms > 0 do
+    %{state | health_timer: Process.send_after(self(), :health_check, interval_ms)}
+  end
+
+  defp schedule_health_check(state), do: state
+
+  defp connection_key(opts) do
+    {
+      Keyword.get(opts, :server_module),
+      Keyword.get(opts, :server_opts, []),
+      Keyword.get(opts, :server_config, %{}),
+      Keyword.get(opts, :auth)
+    }
+  end
+
+  defp ensure_default_manager_started(__MODULE__) do
+    case Process.whereis(__MODULE__) do
+      nil ->
+        case start_link([]) do
+          {:ok, _pid} -> :ok
+          {:error, {:already_started, _pid}} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      _pid ->
+        :ok
+    end
+  end
+
+  defp ensure_default_manager_started(_server), do: :ok
+end

--- a/elixir/symphony_elixir/mix.exs
+++ b/elixir/symphony_elixir/mix.exs
@@ -32,6 +32,7 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixir.HttpServer,
           SymphonyElixir.StatusDashboard,
           SymphonyElixir.LogFile,
+          SymphonyElixir.Opencode.ConnectionManager,
           SymphonyElixir.Workspace,
           SymphonyElixirWeb.DashboardLive,
           SymphonyElixirWeb.Endpoint,

--- a/elixir/symphony_elixir/test/symphony_elixir/opencode_app_server_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/opencode_app_server_test.exs
@@ -7,6 +7,7 @@ defmodule SymphonyElixir.OpencodeAppServerTest do
   use SymphonyElixir.TestSupport
 
   alias SymphonyElixir.Opencode.AppServer
+  alias SymphonyElixir.Opencode.ConnectionManager
   alias SymphonyElixir.OpencodeFakes.{EventStream, Server, SessionApi}
 
   test "app server uses opencode_client server, session API, event stream, and cleanup lifecycle" do
@@ -31,9 +32,12 @@ defmodule SymphonyElixir.OpencodeAppServerTest do
         state: "In Progress"
       }
 
+      manager = start_connection_manager!()
+
       assert {:ok, %{session_id: "ses_lifecycle"}} =
                AppServer.run(workspace, "Use OpenCode", issue,
                  client_opts: [test_pid: self(), session_id: "ses_lifecycle"],
+                 connection_manager: manager,
                  event_stream: EventStream,
                  server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4999"],
@@ -54,7 +58,122 @@ defmodule SymphonyElixir.OpencodeAppServerTest do
       assert prompt_body == %{parts: [%{type: "text", text: "Use OpenCode"}]}
 
       assert_received {:opencode_session_delete, "ses_lifecycle", _client}
-      assert_received {:opencode_server_stop, %{url: "http://127.0.0.1:4999"}}
+      refute_received {:opencode_server_stop, %{url: "http://127.0.0.1:4999"}}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server reuses one local server across multiple sessions and does not stop it per session" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-opencode-app-server-shared-server-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-OC-SHARED")
+      File.mkdir_p!(workspace)
+
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+      manager = start_connection_manager!()
+
+      assert {:ok, session1} =
+               AppServer.start_session(workspace,
+                 client_opts: [test_pid: self(), session_id: "ses_shared_1"],
+                 connection_manager: manager,
+                 event_stream: EventStream,
+                 server_module: Server,
+                 server_opts: [test_pid: self(), url: "http://127.0.0.1:4997"],
+                 session_api: SessionApi
+               )
+
+      assert_received {:opencode_server_start, _server_opts}
+
+      assert {:ok, session2} =
+               AppServer.start_session(workspace,
+                 client_opts: [test_pid: self(), session_id: "ses_shared_2"],
+                 connection_manager: manager,
+                 event_stream: EventStream,
+                 server_module: Server,
+                 server_opts: [test_pid: self(), url: "http://127.0.0.1:4997"],
+                 session_api: SessionApi
+               )
+
+      refute_received {:opencode_server_start, _server_opts}
+
+      assert :ok = AppServer.stop_session(session1)
+      assert_received {:opencode_session_delete, "ses_shared_1", _client}
+      refute_received {:opencode_server_stop, _server}
+
+      assert :ok = AppServer.stop_session(session2)
+      assert_received {:opencode_session_delete, "ses_shared_2", _client}
+      refute_received {:opencode_server_stop, _server}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server preserves explicit base_url without starting a local server" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-opencode-app-server-explicit-base-url-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-OC-BASEURL")
+      File.mkdir_p!(workspace)
+
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+
+      assert {:ok, session} =
+               AppServer.start_session(workspace,
+                 base_url: "http://127.0.0.1:4996",
+                 client_opts: [test_pid: self(), session_id: "ses_base_url"],
+                 event_stream: EventStream,
+                 server_module: Server,
+                 server_opts: [test_pid: self(), url: "http://127.0.0.1:4996"],
+                 session_api: SessionApi
+               )
+
+      assert_received {:opencode_session_create, _body, client}
+      assert Keyword.get(client, :base_url) == "http://127.0.0.1:4996"
+      refute_received {:opencode_server_start, _server_opts}
+
+      assert :ok = AppServer.stop_session(session)
+
+      assert_received {:opencode_session_delete, "ses_base_url", _client}
+      refute_received {:opencode_server_stop, _server}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server rejects remote workers without a base_url" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-opencode-app-server-remote-no-base-url-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace = Path.join(test_root, "remote-workspace")
+      File.mkdir_p!(test_root)
+
+      assert {:error, {:opencode_remote_worker_requires_base_url, "worker-1"}} =
+               AppServer.start_session(workspace,
+                 client_opts: [test_pid: self()],
+                 event_stream: EventStream,
+                 session_api: SessionApi,
+                 worker_host: "worker-1"
+               )
+
+      refute_received {:opencode_session_create, _body, _client}
+      refute_received {:opencode_server_start, _server_opts}
+      refute_received {:opencode_server_stop, _server}
     after
       File.rm_rf(test_root)
     end
@@ -85,9 +204,12 @@ defmodule SymphonyElixir.OpencodeAppServerTest do
         state: "In Progress"
       }
 
+      manager = start_connection_manager!()
+
       assert {:ok, %{session_id: "ses_model"}} =
                AppServer.run(workspace, "Use configured model", issue,
                  client_opts: [test_pid: self(), session_id: "ses_model"],
+                 connection_manager: manager,
                  event_stream: EventStream,
                  server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4998"],
@@ -129,9 +251,12 @@ defmodule SymphonyElixir.OpencodeAppServerTest do
         EventStream.idle_event("ses_target")
       ]
 
+      manager = start_connection_manager!()
+
       assert {:ok, %{session_id: "ses_target"}} =
                AppServer.run(workspace, "Use OpenCode", issue,
                  client_opts: [events: events, session_id: "ses_target"],
+                 connection_manager: manager,
                  event_stream: EventStream,
                  server_module: Server,
                  server_opts: [url: "http://127.0.0.1:4999"],
@@ -178,5 +303,16 @@ defmodule SymphonyElixir.OpencodeAppServerTest do
     after
       File.rm_rf(test_root)
     end
+  end
+
+  defp start_connection_manager! do
+    name = Module.concat(__MODULE__, "Manager#{System.unique_integer([:positive])}")
+
+    start_supervised!(
+      {ConnectionManager, name: name, health_interval_ms: nil},
+      id: name
+    )
+
+    name
   end
 end

--- a/elixir/symphony_elixir/test/symphony_elixir/opencode_connection_manager_test.exs
+++ b/elixir/symphony_elixir/test/symphony_elixir/opencode_connection_manager_test.exs
@@ -1,0 +1,144 @@
+# このファイルは元のApache 2.0ライセンスのコードから新規に追加されています
+# 変更日: 2026-07-04
+# 変更者: totto2727
+# 変更内容: OpenCode 共有 ConnectionManager の再利用と health check restart のテストを追加
+
+defmodule SymphonyElixir.OpencodeConnectionManagerTest do
+  use ExUnit.Case, async: false
+
+  alias SymphonyElixir.Opencode.ConnectionManager
+  alias SymphonyElixir.OpencodeConnectionManagerTest.{ErrorHealthApi, HealthyApi, UnhealthyApi}
+  alias SymphonyElixir.OpencodeFakes.Server
+
+  test "connection starts one local server and reuses it for matching local options" do
+    manager = start_connection_manager!(health_api: HealthyApi)
+    opts = connection_opts("http://127.0.0.1:4991")
+
+    assert {:ok, connection1} = ConnectionManager.connection(opts, manager)
+    assert_received {:opencode_server_start, _server_opts}
+
+    assert {:ok, connection2} = ConnectionManager.connection(opts, manager)
+    refute_received {:opencode_server_start, _server_opts}
+
+    assert Keyword.get(connection1.client, :base_url) == "http://127.0.0.1:4991"
+    assert Keyword.get(connection2.client, :base_url) == "http://127.0.0.1:4991"
+    assert connection1.server == connection2.server
+    assert connection2.shared_server_owner == ConnectionManager
+  end
+
+  test "health_check keeps healthy shared server running" do
+    manager = start_connection_manager!(health_api: HealthyApi)
+    opts = connection_opts("http://127.0.0.1:4992")
+
+    assert {:ok, _connection} = ConnectionManager.connection(opts, manager)
+    assert_received {:opencode_server_start, _server_opts}
+
+    assert :ok = ConnectionManager.health_check(manager)
+
+    assert_received {:opencode_health_check, client}
+    assert Keyword.get(client, :base_url) == "http://127.0.0.1:4992"
+    refute_received {:opencode_server_stop, _server}
+    refute_received {:opencode_server_start, _server_opts}
+  end
+
+  test "health_check restarts shared server after unhealthy response" do
+    manager = start_connection_manager!(health_api: UnhealthyApi)
+    opts = connection_opts("http://127.0.0.1:4993")
+
+    assert {:ok, _connection} = ConnectionManager.connection(opts, manager)
+    assert_received {:opencode_server_start, _server_opts}
+
+    assert :ok = ConnectionManager.health_check(manager)
+
+    assert_received {:opencode_health_check, client}
+    assert Keyword.get(client, :base_url) == "http://127.0.0.1:4993"
+    assert_received {:opencode_server_stop, %{url: "http://127.0.0.1:4993"}}
+    assert_received {:opencode_server_start, restart_opts}
+    assert Keyword.get(restart_opts, :config) == %{}
+  end
+
+  test "health_check restarts shared server after health API error" do
+    manager = start_connection_manager!(health_api: ErrorHealthApi)
+    opts = connection_opts("http://127.0.0.1:4994")
+
+    assert {:ok, _connection} = ConnectionManager.connection(opts, manager)
+    assert_received {:opencode_server_start, _server_opts}
+
+    assert :ok = ConnectionManager.health_check(manager)
+
+    assert_received {:opencode_health_check, client}
+    assert Keyword.get(client, :base_url) == "http://127.0.0.1:4994"
+    assert_received {:opencode_server_stop, %{url: "http://127.0.0.1:4994"}}
+    assert_received {:opencode_server_start, _restart_opts}
+  end
+
+  defp start_connection_manager!(opts) do
+    name = Module.concat(__MODULE__, "Manager#{System.unique_integer([:positive])}")
+
+    start_supervised!(
+      {ConnectionManager, Keyword.merge([name: name, health_interval_ms: nil], opts)},
+      id: name
+    )
+
+    name
+  end
+
+  defp connection_opts(url) do
+    [
+      client_opts: [test_pid: self()],
+      server_module: Server,
+      server_opts: [test_pid: self(), url: url]
+    ]
+  end
+
+  defmodule HealthyApi do
+    @moduledoc false
+
+    @spec global_health(keyword()) :: {:ok, map()}
+    def global_health(client) do
+      notify(client)
+      {:ok, %{healthy: true}}
+    end
+
+    defp notify(client) do
+      case Keyword.get(client, :test_pid) do
+        pid when is_pid(pid) -> send(pid, {:opencode_health_check, client})
+        _ -> :ok
+      end
+    end
+  end
+
+  defmodule UnhealthyApi do
+    @moduledoc false
+
+    @spec global_health(keyword()) :: {:ok, map()}
+    def global_health(client) do
+      notify(client)
+      {:ok, %{healthy: false}}
+    end
+
+    defp notify(client) do
+      case Keyword.get(client, :test_pid) do
+        pid when is_pid(pid) -> send(pid, {:opencode_health_check, client})
+        _ -> :ok
+      end
+    end
+  end
+
+  defmodule ErrorHealthApi do
+    @moduledoc false
+
+    @spec global_health(keyword()) :: {:error, atom()}
+    def global_health(client) do
+      notify(client)
+      {:error, :unreachable}
+    end
+
+    defp notify(client) do
+      case Keyword.get(client, :test_pid) do
+        pid when is_pid(pid) -> send(pid, {:opencode_health_check, client})
+        _ -> :ok
+      end
+    end
+  end
+end

--- a/nix/share/packages-scripts.nix
+++ b/nix/share/packages-scripts.nix
@@ -16,6 +16,14 @@ let
       exocortex --mode proxy --ensure-server "$@"
   '';
 
+  linear-mcp = writeShellScriptBin "linear-mcp" ''
+    exec vpx mcp-remote \
+      https://mcp.linear.app/mcp \
+      --transport http-only \
+      --header "Authorization:Bearer ''${LINEAR_API_KEY}" \
+      "$@"
+  '';
+
   docker-credential-gh = writeShellScriptBin "docker-credential-gh" ''
     set -e
 
@@ -63,6 +71,7 @@ let
   );
 
   macos-o = writeShellScriptBin "o" ''
+    export LINEAR_API_KEY="$(pass-cli get linear/api-key --quiet -f password)"
     exec opencode "$@"
   '';
 
@@ -91,6 +100,7 @@ in
 {
   macos = [
     exocortex-mcp
+    linear-mcp
     docker-credential-gh
     macos-bx
     macos-bw
@@ -104,6 +114,7 @@ in
 
   sandbox = [
     exocortex-mcp
+    linear-mcp
     docker-credential-gh
     sandbox-bx
     sandbox-bw


### PR DESCRIPTION
#### Context

TOT-16 needs Symphony to share one locally owned OpenCode server across app sessions instead of starting/stopping one per local session.

#### TL;DR

_Share local OpenCode server ownership through an OTP GenServer._

#### Summary

- Add ConnectionManager GenServer for app-wide local OpenCode server ownership
- Route implicit local AppServer sessions through the shared manager
- Preserve explicit base_url and remote-worker connection behavior
- Add fake-backed reuse and health-restart coverage

#### Alternatives

- Keep per-session server ownership; rejected because it restarts OpenCode for every local session
- Move ownership into opencode_client; rejected to keep Symphony app lifecycle policy local

#### Test Plan

- [x] `make -C elixir all` (not available on this branch: no target `all`)
- [x] `mix test test/symphony_elixir/opencode_app_server_test.exs test/symphony_elixir/opencode_connection_manager_test.exs`
- [x] `mix format --check-formatted lib/symphony_elixir.ex lib/symphony_elixir/opencode/app_server.ex lib/symphony_elixir/opencode/connection_manager.ex test/symphony_elixir/opencode_app_server_test.exs test/symphony_elixir/opencode_connection_manager_test.exs mix.exs`
- [x] `mix specs.check`
- [x] `mix test`
- [x] `mix lint`
- [ ] `mix dialyzer --format short` (fails with existing Dialyzer findings; package-local `just dialyzer` also fails because Dialyxir looks for a package-local PLT while the root PLT exists)