### PR TITLE
fix(symphony): pass OpenCode workspace directory as query parameter

### DIFF
--- a/elixir/symphony/lib/symphony/opencode/app_server.ex
+++ b/elixir/symphony/lib/symphony/opencode/app_server.ex
@@ -93,7 +93,7 @@ defmodule Symphony.Opencode.AppServer do
     sse_pid = spawn_link(fn -> sse_listener(event_stream, client, parent) end)
 
     try do
-      case session_api.session_prompt_async(session_id, body, client) do
+      case session_api.session_prompt_async(session_id, body, session_opts(client, workspace)) do
         :ok ->
           Logger.info(
             "OpenCode prompt accepted for #{issue_context(issue)} session_id=#{session_id} workspace=#{workspace}"
@@ -140,8 +140,11 @@ defmodule Symphony.Opencode.AppServer do
   end
 
   @spec stop_session(session()) :: :ok
-  def stop_session(%{client: client, session_api: session_api, session_id: session_id} = session) do
-    case session_api.session_delete(session_id, client) do
+  def stop_session(
+        %{client: client, session_api: session_api, session_id: session_id, workspace: workspace} =
+          session
+      ) do
+    case session_api.session_delete(session_id, session_opts(client, workspace)) do
       {:ok, _} ->
         :ok
 
@@ -170,9 +173,9 @@ defmodule Symphony.Opencode.AppServer do
     session_api = Keyword.get(opts, :session_api, Session)
     event_stream = Keyword.get(opts, :event_stream, EventStream)
     title = Keyword.get(opts, :title, "Symphony agent run")
-    body = %{title: title, directory: workspace}
+    body = %{title: title}
 
-    case session_api.session_create(body, client) do
+    case session_api.session_create(body, session_opts(client, workspace)) do
       {:ok, body_json} when is_map(body_json) ->
         case get_field(body_json, :id) do
           session_id when is_binary(session_id) and session_id != "" ->
@@ -220,17 +223,15 @@ defmodule Symphony.Opencode.AppServer do
       |> Keyword.put(:server_config, server_config)
       |> Keyword.put(:allow_server_start, is_nil(worker_host))
 
-    cond do
-      shared_local_connection?(opts, worker_host) ->
-        manager = Keyword.get(opts, :connection_manager, ConnectionManager)
+    if shared_local_connection?(opts, worker_host) do
+      manager = Keyword.get(opts, :connection_manager, ConnectionManager)
 
-        case ConnectionManager.connection(opts, manager) do
-          {:ok, connection} -> {:ok, Map.put(connection, :worker_host, worker_host)}
-          {:error, reason} -> {:error, reason}
-        end
-
-      true ->
-        start_direct_connection(opts, worker_host)
+      case ConnectionManager.connection(opts, manager) do
+        {:ok, connection} -> {:ok, Map.put(connection, :worker_host, worker_host)}
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      start_direct_connection(opts, worker_host)
     end
   end
 
@@ -265,6 +266,8 @@ defmodule Symphony.Opencode.AppServer do
 
   defp stop_connection(%{shared_server_owner: ConnectionManager}), do: :ok
   defp stop_connection(connection), do: Connection.stop(connection)
+
+  defp session_opts(client, workspace), do: Keyword.put(client, :directory, workspace)
 
   defp session_metadata(session_id, client, connection) do
     connection

--- a/elixir/symphony/test/support/opencode_fakes.exs
+++ b/elixir/symphony/test/support/opencode_fakes.exs
@@ -7,25 +7,34 @@ defmodule Symphony.OpencodeFakes.SessionApi do
   @moduledoc false
 
   @spec session_create(map(), keyword()) :: {:ok, map()}
-  def session_create(body, client) do
-    notify(client, {:opencode_session_create, body, client})
-    {:ok, %{"id" => Keyword.get(client, :session_id, "ses_test")}}
+  def session_create(body, opts) do
+    notify(opts, {:opencode_session_create, body, opts})
+    {:ok, %{"id" => Keyword.get(opts, :session_id, "ses_test")}}
   end
 
   @spec session_prompt_async(String.t(), map(), keyword()) :: :ok
-  def session_prompt_async(session_id, body, client) do
-    notify(client, {:opencode_prompt_async, session_id, body, client})
+  def session_prompt_async(session_id, body, opts) do
+    maybe_verify_git_toplevel(opts)
+    notify(opts, {:opencode_prompt_async, session_id, body, opts})
     :ok
   end
 
   @spec session_delete(String.t(), keyword()) :: {:ok, boolean()}
-  def session_delete(session_id, client) do
-    notify(client, {:opencode_session_delete, session_id, client})
+  def session_delete(session_id, opts) do
+    notify(opts, {:opencode_session_delete, session_id, opts})
     {:ok, true}
   end
 
-  defp notify(client, message) do
-    case Keyword.get(client, :test_pid) do
+  defp maybe_verify_git_toplevel(opts) do
+    if Keyword.get(opts, :assert_git_toplevel, false) do
+      directory = Keyword.fetch!(opts, :directory)
+      {top_level, 0} = System.cmd("git", ["-C", directory, "rev-parse", "--show-toplevel"])
+      notify(opts, {:opencode_git_toplevel, String.trim(top_level), directory})
+    end
+  end
+
+  defp notify(opts, message) do
+    case Keyword.get(opts, :test_pid) do
       pid when is_pid(pid) -> send(pid, message)
       _ -> :ok
     end

--- a/elixir/symphony/test/symphony/opencode_app_server_test.exs
+++ b/elixir/symphony/test/symphony/opencode_app_server_test.exs
@@ -35,11 +35,11 @@ defmodule Symphony.OpencodeAppServerTest do
       manager = start_connection_manager!()
 
       assert {:ok, %{session_id: "ses_lifecycle"}} =
-                AppServer.run(workspace, "Use OpenCode", issue,
-                  client_opts: [test_pid: self(), session_id: "ses_lifecycle"],
-                  connection_manager: manager,
-                  event_stream: EventStream,
-                  server_module: Server,
+               AppServer.run(workspace, "Use OpenCode", issue,
+                 client_opts: [test_pid: self(), session_id: "ses_lifecycle"],
+                 connection_manager: manager,
+                 event_stream: EventStream,
+                 server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4999"],
                  session_api: SessionApi,
                  turn_timeout_ms: 1_000
@@ -48,16 +48,18 @@ defmodule Symphony.OpencodeAppServerTest do
       assert_received {:opencode_server_start, server_opts}
       assert Keyword.get(server_opts, :config) == %{}
 
-      assert_received {:opencode_session_create, body, client}
+      assert_received {:opencode_session_create, body, create_opts}
       assert {:ok, canonical_workspace} = Symphony.PathSafety.canonicalize(workspace)
-      assert body.title == "Symphony agent run"
-      assert body.directory == canonical_workspace
-      assert Keyword.get(client, :base_url) == "http://127.0.0.1:4999"
+      assert body == %{title: "Symphony agent run"}
+      assert Keyword.get(create_opts, :directory) == canonical_workspace
+      assert Keyword.get(create_opts, :base_url) == "http://127.0.0.1:4999"
 
-      assert_received {:opencode_prompt_async, "ses_lifecycle", prompt_body, _client}
+      assert_received {:opencode_prompt_async, "ses_lifecycle", prompt_body, prompt_opts}
       assert prompt_body == %{parts: [%{type: "text", text: "Use OpenCode"}]}
+      assert Keyword.get(prompt_opts, :directory) == canonical_workspace
 
-      assert_received {:opencode_session_delete, "ses_lifecycle", _client}
+      assert_received {:opencode_session_delete, "ses_lifecycle", delete_opts}
+      assert Keyword.get(delete_opts, :directory) == canonical_workspace
       refute_received {:opencode_server_stop, %{url: "http://127.0.0.1:4999"}}
     after
       File.rm_rf(test_root)
@@ -80,11 +82,11 @@ defmodule Symphony.OpencodeAppServerTest do
       manager = start_connection_manager!()
 
       assert {:ok, session1} =
-                AppServer.start_session(workspace,
-                  client_opts: [test_pid: self(), session_id: "ses_shared_1"],
-                  connection_manager: manager,
-                  event_stream: EventStream,
-                  server_module: Server,
+               AppServer.start_session(workspace,
+                 client_opts: [test_pid: self(), session_id: "ses_shared_1"],
+                 connection_manager: manager,
+                 event_stream: EventStream,
+                 server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4997"],
                  session_api: SessionApi
                )
@@ -92,11 +94,11 @@ defmodule Symphony.OpencodeAppServerTest do
       assert_received {:opencode_server_start, _server_opts}
 
       assert {:ok, session2} =
-                AppServer.start_session(workspace,
-                  client_opts: [test_pid: self(), session_id: "ses_shared_2"],
-                  connection_manager: manager,
-                  event_stream: EventStream,
-                  server_module: Server,
+               AppServer.start_session(workspace,
+                 client_opts: [test_pid: self(), session_id: "ses_shared_2"],
+                 connection_manager: manager,
+                 event_stream: EventStream,
+                 server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4997"],
                  session_api: SessionApi
                )
@@ -110,6 +112,62 @@ defmodule Symphony.OpencodeAppServerTest do
       assert :ok = AppServer.stop_session(session2)
       assert_received {:opencode_session_delete, "ses_shared_2", _client}
       refute_received {:opencode_server_stop, _server}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server prompt opts make git operations target the issue workspace" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-opencode-app-server-git-cwd-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-OC-GIT")
+      File.mkdir_p!(workspace)
+
+      assert {_, 0} = System.cmd("git", ["-C", workspace, "init", "-b", "main"])
+      assert {_, 0} = System.cmd("git", ["-C", workspace, "config", "user.name", "Test User"])
+
+      assert {_, 0} =
+               System.cmd("git", ["-C", workspace, "config", "user.email", "test@example.com"])
+
+      File.write!(Path.join(workspace, "README.md"), "# workspace\n")
+      assert {_, 0} = System.cmd("git", ["-C", workspace, "add", "README.md"])
+      assert {_, 0} = System.cmd("git", ["-C", workspace, "commit", "-m", "initial"])
+
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+
+      issue = %Issue{
+        id: "issue-opencode-git-cwd",
+        identifier: "MT-OC-GIT",
+        title: "Validate OpenCode git cwd",
+        description: "Exercise generated OpenCode directory query opts",
+        state: "In Progress"
+      }
+
+      manager = start_connection_manager!()
+
+      assert {:ok, %{session_id: "ses_git_cwd"}} =
+               AppServer.run(workspace, "Check git cwd", issue,
+                 client_opts: [
+                   test_pid: self(),
+                   session_id: "ses_git_cwd",
+                   assert_git_toplevel: true
+                 ],
+                 connection_manager: manager,
+                 event_stream: EventStream,
+                 server_module: Server,
+                 server_opts: [test_pid: self(), url: "http://127.0.0.1:4995"],
+                 session_api: SessionApi,
+                 turn_timeout_ms: 1_000
+               )
+
+      assert {:ok, canonical_workspace} = Symphony.PathSafety.canonicalize(workspace)
+      assert_received {:opencode_git_toplevel, ^canonical_workspace, ^canonical_workspace}
     after
       File.rm_rf(test_root)
     end
@@ -207,11 +265,11 @@ defmodule Symphony.OpencodeAppServerTest do
       manager = start_connection_manager!()
 
       assert {:ok, %{session_id: "ses_model"}} =
-                AppServer.run(workspace, "Use configured model", issue,
-                  client_opts: [test_pid: self(), session_id: "ses_model"],
-                  connection_manager: manager,
-                  event_stream: EventStream,
-                  server_module: Server,
+               AppServer.run(workspace, "Use configured model", issue,
+                 client_opts: [test_pid: self(), session_id: "ses_model"],
+                 connection_manager: manager,
+                 event_stream: EventStream,
+                 server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4998"],
                  session_api: SessionApi,
                  turn_timeout_ms: 1_000
@@ -254,11 +312,11 @@ defmodule Symphony.OpencodeAppServerTest do
       manager = start_connection_manager!()
 
       assert {:ok, %{session_id: "ses_target"}} =
-                AppServer.run(workspace, "Use OpenCode", issue,
-                  client_opts: [events: events, session_id: "ses_target"],
-                  connection_manager: manager,
-                  event_stream: EventStream,
-                  server_module: Server,
+               AppServer.run(workspace, "Use OpenCode", issue,
+                 client_opts: [events: events, session_id: "ses_target"],
+                 connection_manager: manager,
+                 event_stream: EventStream,
+                 server_module: Server,
                  server_opts: [url: "http://127.0.0.1:4999"],
                  session_api: SessionApi,
                  turn_timeout_ms: 1_000


### PR DESCRIPTION
#### Context

OpenCode sessions launched by Symphony need the issue workspace in query opts, not request bodies.

#### TL;DR

_Pass the workspace directory through OpenCode session query options._

#### Summary

- Send `directory: workspace` to OpenCode session create, prompt async, and delete calls
- Stop placing `directory` in the session create JSON body
- Add fake regression coverage for directory opts and workspace-scoped git operations

#### Alternatives

- Editing generated opencode_client was unnecessary because it already supports directory query opts.

#### Test Plan

- [x] `mix test test/symphony/opencode_app_server_test.exs`
- [x] `mix lint`
- [x] `mix test`
- [x] `make all` attempted, but this checkout has no Makefile/`all` target
