### PR TITLE
docs(symphony): replace make commands with vp workflow

### DIFF
--- a/elixir/symphony/README.md
+++ b/elixir/symphony/README.md
@@ -178,17 +178,29 @@ The observability UI now runs on a minimal Phoenix stack:
 
 ## Testing
 
+Use Vite+ for the normal repository validation path, choosing the narrowest language or project
+scope that covers your change. For this Symphony package, the usual scoped checks are:
+
 ```bash
-make all
+vp run ex:check
+vp run ex:test
+```
+
+Run tool-specific or expensive checks only when the change requires them. For example, Symphony's
+package-local Dialyzer check is:
+
+```bash
+cd elixir/symphony
+just dialyzer
 ```
 
 Run the real external end-to-end test only when you want Symphony to create disposable Linear
 resources and launch a real OpenCode session:
 
 ```bash
-cd elixir
+cd elixir/symphony
 export LINEAR_API_KEY=...
-make e2e
+just e2e
 ```
 
 Optional environment variables:
@@ -196,7 +208,7 @@ Optional environment variables:
 - `SYMPHONY_LIVE_LINEAR_TEAM_KEY` defaults to `SYME2E`
 - `SYMPHONY_LIVE_SSH_WORKER_HOSTS` uses those SSH hosts when set, as a comma-separated list
 
-`make e2e` runs two live scenarios:
+`just e2e` runs two live scenarios:
 
 - one with a local worker
 - one with SSH workers
@@ -207,7 +219,7 @@ verifies that Symphony can talk to them over real SSH, then runs the same orches
 against those worker addresses. This keeps the transport representative without depending on
 long-lived external machines.
 
-Set `SYMPHONY_LIVE_SSH_WORKER_HOSTS` if you want `make e2e` to target real SSH hosts instead.
+Set `SYMPHONY_LIVE_SSH_WORKER_HOSTS` if you want `just e2e` to target real SSH hosts instead.
 
 The live test creates a temporary Linear project and issue, writes a temporary `WORKFLOW.md`, runs
 a real agent turn, verifies the workspace side effect, requires the agent to comment on and close

--- a/elixir/symphony/WORKFLOW.md
+++ b/elixir/symphony/WORKFLOW.md
@@ -209,7 +209,7 @@ Use this only when completion is blocked by missing required tools or missing au
 5.  Run validation/tests required for the scope.
     - Mandatory gate: execute all ticket-provided `Validation`/`Test Plan`/ `Testing` requirements when present; treat unmet items as incomplete work.
     - Prefer a targeted proof that directly demonstrates the behavior you changed.
-    - You may make temporary local proof edits to validate assumptions (for example: tweak a local build input for `make`, or hardcode a UI account / response path) when this increases confidence.
+    - You may make temporary local proof edits to validate assumptions (for example: tweak an input used by the relevant `vp run ...` validation task, or hardcode a UI account / response path) when this increases confidence.
     - Revert every temporary proof edit before commit/push.
     - Document these temporary proof steps and outcomes in the workpad `Validation`/`Notes` sections so reviewers can follow the evidence.
     - If app-touching, run `launch-app` validation and capture/upload media via `github-pr-media` before handoff.

--- a/elixir/symphony/docs/pull_request_template.md
+++ b/elixir/symphony/docs/pull_request_template.md
@@ -25,5 +25,6 @@ _<!-- A short description of what we are changing. Use simple language. Assume r
 
 #### Test Plan
 
-- [ ] `make -C elixir all`
-- [ ] <!-- Additional targeted checks (list below) -->
+- [ ] <!-- Vite+ scoped check, such as `vp run <language-or-project>:check` -->
+- [ ] <!-- Vite+ scoped test, such as `vp run <language-or-project>:test` -->
+- [ ] <!-- Optional targeted checks, such as Dialyzer or e2e, only when required by the change -->


### PR DESCRIPTION
## Summary
- replace stale Symphony Makefile-era validation commands with Vite+ scoped validation guidance
- document Dialyzer and live e2e as optional targeted checks only when required
- keep workflow and PR template language applicable across the monorepo instead of Elixir-only

## Test Plan
- rg -n "make all|make -C elixir all|make e2e|cd elixir$|Makefile" elixir/symphony/README.md elixir/symphony/WORKFLOW.md elixir/symphony/docs/pull_request_template.md
- rg -n "vp run|just (dialyzer|e2e)|Dialyzer|e2e" elixir/symphony/README.md elixir/symphony/WORKFLOW.md elixir/symphony/docs/pull_request_template.md

Docs-only change; Dialyzer and live e2e were not run.