### PR TITLE
fix(symphony): dispose opencode instances on session stop

### DIFF
--- a/elixir/symphony/lib/symphony.ex
+++ b/elixir/symphony/lib/symphony.ex
@@ -41,8 +41,21 @@ defmodule Symphony.Application do
   end
 
   @impl true
+  def prep_stop(state) do
+    stop_opencode_connection()
+    state
+  end
+
+  @impl true
   def stop(_state) do
     Symphony.StatusDashboard.render_offline_status()
     :ok
+  end
+
+  defp stop_opencode_connection do
+    case Process.whereis(Symphony.Opencode.ConnectionManager) do
+      nil -> :ok
+      _pid -> Symphony.Opencode.ConnectionManager.stop_connection()
+    end
   end
 end

--- a/elixir/symphony/lib/symphony/agent_runner.ex
+++ b/elixir/symphony/lib/symphony/agent_runner.ex
@@ -18,6 +18,7 @@ defmodule Symphony.AgentRunner do
     :base_url,
     :client_opts,
     :event_stream,
+    :instance_api,
     :receive_timeout,
     :server_config,
     :server_module,

--- a/elixir/symphony/lib/symphony/opencode/app_server.ex
+++ b/elixir/symphony/lib/symphony/opencode/app_server.ex
@@ -21,7 +21,7 @@ defmodule Symphony.Opencode.AppServer do
   require Logger
 
   alias OpencodeClient.{Connection, EventStream}
-  alias OpencodeClient.Generated.Session
+  alias OpencodeClient.Generated.{Instance, Session}
   alias Symphony.{Config, Linear.Issue, PathSafety}
   alias Symphony.Opencode.ConnectionManager
 
@@ -31,6 +31,7 @@ defmodule Symphony.Opencode.AppServer do
           client: keyword(),
           connection: Connection.t(),
           event_stream: module(),
+          instance_api: module(),
           session_id: String.t(),
           session_api: module(),
           workspace: Path.t(),
@@ -143,9 +144,62 @@ defmodule Symphony.Opencode.AppServer do
 
   @spec stop_session(session()) :: :ok
   def stop_session(
-        %{client: client, session_api: session_api, session_id: session_id, workspace: workspace} =
-          session
+        %{
+          connection: connection,
+          session_id: _session_id
+        } = session
       ) do
+    delete_session(session)
+    dispose_instance(session)
+    :ok
+  after
+    stop_connection(connection)
+  end
+
+  defp create_session(workspace, opts, %{client: client} = connection) do
+    session_api = Keyword.get(opts, :session_api, Session)
+    instance_api = Keyword.get(opts, :instance_api, Instance)
+    event_stream = Keyword.get(opts, :event_stream, EventStream)
+    title = Keyword.get(opts, :title, "Symphony agent run")
+    body = %{title: title}
+
+    case session_api.session_create(body, session_opts(client, workspace)) do
+      {:ok, body_json} when is_map(body_json) ->
+        case get_field(body_json, :id) do
+          session_id when is_binary(session_id) and session_id != "" ->
+            {:ok,
+             %{
+               client: client,
+               connection: connection,
+               event_stream: event_stream,
+               instance_api: instance_api,
+               session_api: session_api,
+               session_id: session_id,
+               workspace: workspace,
+               metadata: session_metadata(session_id, client, connection)
+             }}
+
+          _ ->
+            stop_connection(connection)
+            {:error, {:invalid_session_response, body_json}}
+        end
+
+      {:ok, body} ->
+        stop_connection(connection)
+        {:error, {:session_create_failed, body}}
+
+      {:error, reason} ->
+        stop_connection(connection)
+        {:error, {:session_create_error, reason}}
+    end
+  end
+
+  defp delete_session(%{
+         client: client,
+         session_api: session_api,
+         session_id: session_id,
+         workspace: workspace
+       }) do
     case session_api.session_delete(session_id, session_opts(client, workspace)) do
       {:ok, _} ->
         :ok
@@ -167,44 +221,35 @@ defmodule Symphony.Opencode.AppServer do
       )
 
       :ok
-  after
-    stop_connection(session.connection)
   end
 
-  defp create_session(workspace, opts, %{client: client} = connection) do
-    session_api = Keyword.get(opts, :session_api, Session)
-    event_stream = Keyword.get(opts, :event_stream, EventStream)
-    title = Keyword.get(opts, :title, "Symphony agent run")
-    body = %{title: title}
+  defp dispose_instance(%{
+         client: client,
+         instance_api: instance_api,
+         session_id: session_id,
+         workspace: workspace
+       }) do
+    case instance_api.instance_dispose(session_opts(client, workspace)) do
+      {:ok, _} ->
+        :ok
 
-    case session_api.session_create(body, session_opts(client, workspace)) do
-      {:ok, body_json} when is_map(body_json) ->
-        case get_field(body_json, :id) do
-          session_id when is_binary(session_id) and session_id != "" ->
-            {:ok,
-             %{
-               client: client,
-               connection: connection,
-               event_stream: event_stream,
-               session_api: session_api,
-               session_id: session_id,
-               workspace: workspace,
-               metadata: session_metadata(session_id, client, connection)
-             }}
-
-          _ ->
-            stop_connection(connection)
-            {:error, {:invalid_session_response, body_json}}
-        end
-
-      {:ok, body} ->
-        stop_connection(connection)
-        {:error, {:session_create_failed, body}}
+      :ok ->
+        :ok
 
       {:error, reason} ->
-        stop_connection(connection)
-        {:error, {:session_create_error, reason}}
+        Logger.warning(
+          "OpenCode instance dispose failed for session_id=#{session_id}: #{inspect(reason)}"
+        )
+
+        :ok
     end
+  catch
+    kind, reason ->
+      Logger.warning(
+        "OpenCode instance dispose raised for session_id=#{session_id}: #{inspect({kind, reason})}"
+      )
+
+      :ok
   end
 
   defp start_connection(opts, worker_host) do

--- a/elixir/symphony/test/support/opencode_fakes.exs
+++ b/elixir/symphony/test/support/opencode_fakes.exs
@@ -22,7 +22,11 @@ defmodule Symphony.OpencodeFakes.SessionApi do
   @spec session_delete(String.t(), keyword()) :: {:ok, boolean()}
   def session_delete(session_id, opts) do
     notify(opts, {:opencode_session_delete, session_id, opts})
-    {:ok, true}
+
+    case Keyword.get(opts, :session_delete_result, {:ok, true}) do
+      {:raise, reason} -> raise inspect(reason)
+      result -> result
+    end
   end
 
   defp maybe_verify_git_toplevel(opts) do
@@ -37,6 +41,23 @@ defmodule Symphony.OpencodeFakes.SessionApi do
     case Keyword.get(opts, :test_pid) do
       pid when is_pid(pid) -> send(pid, message)
       _ -> :ok
+    end
+  end
+end
+
+defmodule Symphony.OpencodeFakes.InstanceApi do
+  @moduledoc false
+
+  @spec instance_dispose(keyword()) :: {:ok, boolean()}
+  def instance_dispose(opts) do
+    case Keyword.get(opts, :test_pid) do
+      pid when is_pid(pid) -> send(pid, {:opencode_instance_dispose, opts})
+      _ -> :ok
+    end
+
+    case Keyword.get(opts, :instance_dispose_result, {:ok, true}) do
+      {:raise, reason} -> raise inspect(reason)
+      result -> result
     end
   end
 end

--- a/elixir/symphony/test/symphony/core_test.exs
+++ b/elixir/symphony/test/symphony/core_test.exs
@@ -6,6 +6,8 @@
 defmodule Symphony.CoreTest do
   use Symphony.TestSupport
 
+  alias Symphony.OpencodeFakes.InstanceApi
+
   test "config defaults and validation checks" do
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_api_token: nil,
@@ -1429,6 +1431,12 @@ defmodule Symphony.CoreTest do
                        _client}
 
       assert_received {:opencode_session_delete, "ses_continue", _client}
+      assert_received {:opencode_instance_dispose, dispose_opts}
+
+      assert {:ok, canonical_workspace} =
+               Symphony.PathSafety.canonicalize(Path.join(workspace_root, "MT-247"))
+
+      assert Keyword.get(dispose_opts, :directory) == canonical_workspace
 
       assert first_prompt =~ "You are an agent for this repository."
       refute second_prompt =~ "You are an agent for this repository."
@@ -1510,6 +1518,7 @@ defmodule Symphony.CoreTest do
       base_url: "http://opencode.test",
       client_opts: [test_pid: test_pid, session_id: session_id],
       event_stream: Symphony.OpencodeFakes.EventStream,
+      instance_api: InstanceApi,
       session_api: Symphony.OpencodeFakes.SessionApi,
       turn_timeout_ms: 1_000
     ]

--- a/elixir/symphony/test/symphony/opencode_app_server_test.exs
+++ b/elixir/symphony/test/symphony/opencode_app_server_test.exs
@@ -8,7 +8,7 @@ defmodule Symphony.OpencodeAppServerTest do
 
   alias Symphony.Opencode.AppServer
   alias Symphony.Opencode.ConnectionManager
-  alias Symphony.OpencodeFakes.{EventStream, Server, SessionApi}
+  alias Symphony.OpencodeFakes.{EventStream, InstanceApi, Server, SessionApi}
 
   test "app server uses opencode_client server, session API, event stream, and cleanup lifecycle" do
     test_root =
@@ -39,6 +39,7 @@ defmodule Symphony.OpencodeAppServerTest do
                  client_opts: [test_pid: self(), session_id: "ses_lifecycle"],
                  connection_manager: manager,
                  event_stream: EventStream,
+                 instance_api: InstanceApi,
                  server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4999"],
                  session_api: SessionApi,
@@ -63,6 +64,8 @@ defmodule Symphony.OpencodeAppServerTest do
 
       assert_received {:opencode_session_delete, "ses_lifecycle", delete_opts}
       assert Keyword.get(delete_opts, :directory) == canonical_workspace
+      assert_received {:opencode_instance_dispose, dispose_opts}
+      assert Keyword.get(dispose_opts, :directory) == canonical_workspace
       refute_received {:opencode_server_stop, %{url: "http://127.0.0.1:4999"}}
     after
       File.rm_rf(test_root)
@@ -89,6 +92,7 @@ defmodule Symphony.OpencodeAppServerTest do
                  client_opts: [test_pid: self(), session_id: "ses_shared_1"],
                  connection_manager: manager,
                  event_stream: EventStream,
+                 instance_api: InstanceApi,
                  server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4997"],
                  session_api: SessionApi
@@ -101,6 +105,7 @@ defmodule Symphony.OpencodeAppServerTest do
                  client_opts: [test_pid: self(), session_id: "ses_shared_2"],
                  connection_manager: manager,
                  event_stream: EventStream,
+                 instance_api: InstanceApi,
                  server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4997"],
                  session_api: SessionApi
@@ -110,11 +115,95 @@ defmodule Symphony.OpencodeAppServerTest do
 
       assert :ok = AppServer.stop_session(session1)
       assert_received {:opencode_session_delete, "ses_shared_1", _client}
+      assert_received {:opencode_instance_dispose, _dispose_opts}
       refute_received {:opencode_server_stop, _server}
 
       assert :ok = AppServer.stop_session(session2)
       assert_received {:opencode_session_delete, "ses_shared_2", _client}
+      assert_received {:opencode_instance_dispose, _dispose_opts}
       refute_received {:opencode_server_stop, _server}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server disposes the instance when session deletion fails" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-opencode-app-server-delete-failure-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-OC-DELETE-FAILURE")
+      File.mkdir_p!(workspace)
+
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+      manager = start_connection_manager!()
+
+      assert {:ok, session} =
+               AppServer.start_session(workspace,
+                 client_opts: [
+                   test_pid: self(),
+                   session_id: "ses_delete_failure",
+                   session_delete_result: {:error, :delete_failed}
+                 ],
+                 connection_manager: manager,
+                 event_stream: EventStream,
+                 instance_api: InstanceApi,
+                 server_module: Server,
+                 server_opts: [test_pid: self(), url: "http://127.0.0.1:4994"],
+                 session_api: SessionApi
+               )
+
+      assert :ok = AppServer.stop_session(session)
+
+      assert_received {:opencode_session_delete, "ses_delete_failure", _delete_opts}
+      assert {:ok, canonical_workspace} = Symphony.PathSafety.canonicalize(workspace)
+      assert_received {:opencode_instance_dispose, dispose_opts}
+      assert Keyword.get(dispose_opts, :directory) == canonical_workspace
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server treats instance disposal failures as nonfatal cleanup" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-opencode-app-server-dispose-failure-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-OC-DISPOSE-FAILURE")
+      File.mkdir_p!(workspace)
+
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+      manager = start_connection_manager!()
+
+      assert {:ok, session} =
+               AppServer.start_session(workspace,
+                 client_opts: [
+                   test_pid: self(),
+                   session_id: "ses_dispose_failure",
+                   instance_dispose_result: {:raise, :dispose_failed}
+                 ],
+                 connection_manager: manager,
+                 event_stream: EventStream,
+                 instance_api: InstanceApi,
+                 server_module: Server,
+                 server_opts: [test_pid: self(), url: "http://127.0.0.1:4993"],
+                 session_api: SessionApi
+               )
+
+      assert :ok = AppServer.stop_session(session)
+
+      assert_received {:opencode_session_delete, "ses_dispose_failure", _delete_opts}
+      assert {:ok, canonical_workspace} = Symphony.PathSafety.canonicalize(workspace)
+      assert_received {:opencode_instance_dispose, dispose_opts}
+      assert Keyword.get(dispose_opts, :directory) == canonical_workspace
     after
       File.rm_rf(test_root)
     end
@@ -163,6 +252,7 @@ defmodule Symphony.OpencodeAppServerTest do
                  ],
                  connection_manager: manager,
                  event_stream: EventStream,
+                 instance_api: InstanceApi,
                  server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4995"],
                  session_api: SessionApi,
@@ -195,6 +285,7 @@ defmodule Symphony.OpencodeAppServerTest do
                  base_url: "http://127.0.0.1:4996",
                  client_opts: [test_pid: self(), session_id: "ses_base_url"],
                  event_stream: EventStream,
+                 instance_api: InstanceApi,
                  server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4996"],
                  session_api: SessionApi
@@ -272,6 +363,7 @@ defmodule Symphony.OpencodeAppServerTest do
                  client_opts: [test_pid: self(), session_id: "ses_model"],
                  connection_manager: manager,
                  event_stream: EventStream,
+                 instance_api: InstanceApi,
                  server_module: Server,
                  server_opts: [test_pid: self(), url: "http://127.0.0.1:4998"],
                  session_api: SessionApi,
@@ -319,6 +411,7 @@ defmodule Symphony.OpencodeAppServerTest do
                  client_opts: [events: events, session_id: "ses_target"],
                  connection_manager: manager,
                  event_stream: EventStream,
+                 instance_api: InstanceApi,
                  server_module: Server,
                  server_opts: [url: "http://127.0.0.1:4999"],
                  session_api: SessionApi,

--- a/elixir/symphony/test/symphony/opencode_connection_manager_test.exs
+++ b/elixir/symphony/test/symphony/opencode_connection_manager_test.exs
@@ -72,6 +72,21 @@ defmodule Symphony.OpencodeConnectionManagerTest do
     assert_received {:opencode_server_start, _restart_opts}
   end
 
+  test "application prep_stop stops the default shared OpenCode connection" do
+    stop_default_connection()
+    on_exit(&stop_default_connection/0)
+
+    opts = connection_opts("http://127.0.0.1:4990")
+
+    assert {:ok, _connection} = ConnectionManager.connection(opts, ConnectionManager)
+    assert_received {:opencode_server_start, _server_opts}
+
+    state = %{shutdown_ref: make_ref()}
+
+    assert Symphony.Application.prep_stop(state) == state
+    assert_received {:opencode_server_stop, %{url: "http://127.0.0.1:4990"}}
+  end
+
   defp start_connection_manager!(opts) do
     name = Module.concat(__MODULE__, "Manager#{System.unique_integer([:positive])}")
 
@@ -89,6 +104,13 @@ defmodule Symphony.OpencodeConnectionManagerTest do
       server_module: Server,
       server_opts: [test_pid: self(), url: url]
     ]
+  end
+
+  defp stop_default_connection do
+    case Process.whereis(ConnectionManager) do
+      nil -> :ok
+      _pid -> ConnectionManager.stop_connection(ConnectionManager)
+    end
   end
 
   defmodule HealthyApi do


### PR DESCRIPTION
#### Context

Symphony stopped OpenCode sessions but did not dispose the session-scoped OpenCode instance/workspace.

#### TL;DR

_Dispose OpenCode instances during session cleanup and stop shared server on app shutdown._

#### Summary

- Add directory-scoped OpenCode instance disposal after session deletion.
- Keep delete, dispose, and connection cleanup independently nonfatal.
- Stop the default shared OpenCode connection during application prep_stop.
- Add fake-backed lifecycle tests for happy path and failure handling.

#### Alternatives

- Did not use global dispose because the local OpenCode server can be shared across sessions.

#### Test Plan

- [x] mix test test/symphony/opencode_app_server_test.exs test/symphony/opencode_connection_manager_test.exs test/symphony/core_test.exs
- [x] mix format --check-formatted lib/symphony.ex lib/symphony/agent_runner.ex lib/symphony/opencode/app_server.ex test/support/opencode_fakes.exs test/symphony/core_test.exs test/symphony/opencode_app_server_test.exs test/symphony/opencode_connection_manager_test.exs
- [x] mix specs.check
- [x] mix test
- [x] CI check passed (run 28833730536)
- [x] GitHub PR checks passed (CI + CodeQL)
- [ ] vp run ex:check (blocked locally: env reports missing /nix/store/.../elixir-1.20.2/b after task graph setup)
- [ ] vp run ex:test (blocked locally: same Elixir runner path issue)

#### CI status

- Latest commit SHA: f39a586
- Latest check job: success (run id: 28833730536, attempt: 1)
- Retry history: none
