### PR TITLE
feat(symphony): add changed file report

### DIFF
--- a/elixir/symphony/priv/static/dashboard.css
+++ b/elixir/symphony/priv/static/dashboard.css
@@ -1,3 +1,10 @@
+/*
+このファイルは元のApache 2.0ライセンスのコードから新規に追加されています
+変更日: 2026-07-07
+変更者: totto2727
+変更内容: Phoenix observability dashboard の静的 CSS を追加
+*/
+
 :root {
   color-scheme: light;
   --page: #f7f7f8;

--- a/elixir/symphony/scripts/changed-files-report.sh
+++ b/elixir/symphony/scripts/changed-files-report.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# このファイルは元のApache 2.0ライセンスのコードから新規に追加されています
+# 変更日: 2026-07-07
+# 変更者: totto2727
+# 変更内容: upstream OpenAI Symphony とローカル Symphony の変更ファイル Markdown レポート script を追加
+
+set -euo pipefail
+
+upstream="${SYMPHONY_UPSTREAM_REPO:-https://github.com/openai/symphony.git}"
+local_repo="$(pwd)"
+ref="main"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --upstream)
+      upstream="$2"
+      shift 2
+      ;;
+    --local-repo)
+      local_repo="$2"
+      shift 2
+      ;;
+    --ref)
+      ref="$2"
+      shift 2
+      ;;
+    --help | -h)
+      cat <<'USAGE'
+Usage: changed-files-report.sh [--upstream PATH_OR_URL] [--local-repo PATH] [--ref REF]
+
+Print a Markdown report comparing upstream OpenAI Symphony's elixir/ tree with
+this repository's elixir/symphony tree. Generated directories such as _build,
+deps, and node_modules are ignored.
+USAGE
+      exit 0
+      ;;
+    *)
+      printf 'unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+temp_root="$(mktemp -d "${TMPDIR:-/tmp}/symphony-changed-files.XXXXXXXXXX")"
+trap 'rm -rf "$temp_root"' EXIT
+
+if [[ "$upstream" =~ ^(https?://|git@) ]]; then
+  upstream_repo="$temp_root/upstream-repo"
+  git clone --depth 1 --branch "$ref" "$upstream" "$upstream_repo" >/dev/null 2>&1
+else
+  upstream_repo="$upstream"
+fi
+
+if [[ -d "$upstream_repo/elixir" ]]; then
+  upstream_elixir="$upstream_repo/elixir"
+elif [[ -d "$upstream_repo" ]]; then
+  upstream_elixir="$upstream_repo"
+else
+  printf 'could not find upstream directory: %s\n' "$upstream_repo" >&2
+  exit 1
+fi
+
+if [[ -d "$local_repo/elixir/symphony" ]]; then
+  local_symphony="$local_repo/elixir/symphony"
+elif [[ -d "$local_repo" ]]; then
+  local_symphony="$local_repo"
+else
+  printf 'could not find local Symphony directory: %s\n' "$local_repo" >&2
+  exit 1
+fi
+
+snapshot_root="$temp_root/snapshots"
+upstream_snapshot="$snapshot_root/upstream-elixir"
+local_snapshot="$snapshot_root/local-symphony"
+mkdir -p "$snapshot_root"
+rsync -a --exclude .git --exclude _build --exclude deps --exclude node_modules "$upstream_elixir/" "$upstream_snapshot/"
+rsync -a --exclude .git --exclude _build --exclude deps --exclude node_modules "$local_symphony/" "$local_snapshot/"
+
+name_status="$(git diff --no-index --find-renames --find-copies --name-status "$upstream_snapshot" "$local_snapshot" || true)"
+diff_output="$(git diff --no-index --find-renames --find-copies "$upstream_snapshot" "$local_snapshot" || true)"
+
+normalize_paths() {
+  perl \
+    -pe "s|\Q$upstream_snapshot\E|upstream/elixir|g; s|\Q$local_snapshot\E|elixir/symphony|g; s|aupstream/|a/upstream/|g; s|aelixir/|a/elixir/|g; s|belixir/|b/elixir/|g"
+}
+
+printf '# Symphony Changed Files Report\n\n'
+printf 'Upstream: `%s`\n' "$upstream"
+printf 'Upstream ref: `%s`\n' "$ref"
+printf 'Local repository: `%s`\n\n' "$local_repo"
+printf 'Compared paths:\n'
+printf -- '- Upstream: `elixir/`\n'
+printf -- '- Local: `elixir/symphony/`\n\n'
+printf 'Ignored directories: `_build`, `deps`, `node_modules`, `.git`\n\n'
+printf '## Changed Files\n\n'
+
+if [[ -z "$name_status" ]]; then
+  printf 'No Symphony files changed.\n'
+else
+  printf '| Status | Path | New Path |\n| --- | --- | --- |\n'
+  printf '%s\n' "$name_status" | normalize_paths | while IFS=$'\t' read -r status path new_path; do
+    printf '| `%s` | `%s` | `%s` |\n' "$status" "$path" "${new_path:-}"
+  done
+fi
+
+cat <<'MARKDOWN'
+
+## Diff
+
+MARKDOWN
+
+if [[ -z "$diff_output" ]]; then
+  printf 'No diff.\n'
+else
+  printf '```diff\n'
+  printf '%s\n' "$diff_output" | normalize_paths
+  printf '```\n'
+fi

--- a/elixir/symphony/test/support/test_support.exs
+++ b/elixir/symphony/test/support/test_support.exs
@@ -1,7 +1,9 @@
 # このファイルは元のApache 2.0ライセンスのコードから変更されています
 # 変更日: 2026-07-01
 # 変更者: totto2727
-# 変更内容: 旧バックエンド関連処理を削除し、OpenCode 前提の設定・状態名へ更新
+# 変更内容:
+# - 旧バックエンド関連処理を削除し、OpenCode 前提の設定・状態名へ更新
+# - テスト setup 時に Symphony アプリを起動済みにして supervisor 依存テストの順序依存を解消
 
 defmodule Symphony.TestSupport do
   @workflow_prompt "You are an agent for this repository."
@@ -44,6 +46,7 @@ defmodule Symphony.TestSupport do
         workflow_file = Path.join(workflow_root, "WORKFLOW.md")
         write_workflow_file!(workflow_file)
         Workflow.set_workflow_file_path(workflow_file)
+        {:ok, _apps} = Application.ensure_all_started(:symphony)
 
         if Process.whereis(Symphony.WorkflowStore),
           do: Symphony.WorkflowStore.force_reload()

--- a/elixir/symphony/test/symphony/orchestrator_status_test.exs
+++ b/elixir/symphony/test/symphony/orchestrator_status_test.exs
@@ -1,7 +1,9 @@
 # このファイルは元のApache 2.0ライセンスのコードから変更されています
 # 変更日: 2026-07-01
 # 変更者: totto2727
-# 変更内容: 旧バックエンド関連処理を削除し、OpenCode 前提の設定・状態名へ更新
+# 変更内容:
+# - 旧バックエンド関連処理を削除し、OpenCode 前提の設定・状態名へ更新
+# - application stop 表示テスト後に Symphony アプリを再起動し、後続テストの supervisor 依存を保護
 
 defmodule Symphony.OrchestratorStatusTest do
   use Symphony.TestSupport
@@ -1917,6 +1919,11 @@ defmodule Symphony.OrchestratorStatusTest do
   end
 
   test "application stop renders offline status" do
+    on_exit(fn ->
+      {:ok, _apps} = Application.ensure_all_started(:symphony)
+      stop_default_http_server()
+    end)
+
     rendered =
       ExUnit.CaptureIO.capture_io(fn ->
         assert :ok = Symphony.Application.stop(:normal)


### PR DESCRIPTION
## Summary

- Add required Symphony change notices to the changed dashboard/test files.
- Add a Bash Markdown report script comparing upstream OpenAI Symphony's elixir tree to local elixir/symphony.
- Fix Symphony test setup ordering so temporary WORKFLOW.md is configured before starting the app during tests.

## Validation

- `elixir/symphony/scripts/changed-files-report.sh > /var/folders/r1/mcw7zp1x7_s6r3fw9bclshcm0000gn/T/opencode/tot-21-report-final.md`
- `vp run js:check`
- `mix compile` from `elixir/symphony`
- `mix format --check-formatted test/support/test_support.exs test/symphony/orchestrator_status_test.exs` from `elixir/symphony`
- `mix test` from `elixir/symphony`: 219 passed, 2 skipped

## CI status

- Latest commit SHA: 5950d0f
- Latest `check` job: success (run id: 28836598681, attempt: 1)
- Retry history: none

Linear: TOT-21