### PR TITLE
docs(symphony): README と WORKFLOW の古い状態参照を修正

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -5,18 +5,14 @@
 # Changes: Adjusted front matter settings for this project.
 tracker:
   kind: linear
-  project_slug: 'symphony-test-7cec2162ba4c'
+  project_slug: 'monorepo-7cec2162ba4c'
   required_labels: []
   active_states:
     - Todo
     - In Progress
-    - Merging
-    - Rework
   reviewable_states:
-    - Human Review
+    - In Review
   terminal_states:
-    - Closed
-    - Cancelled
     - Canceled
     - Duplicate
     - Done
@@ -121,18 +117,17 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 - Linear access is an external prerequisite. Use either a configured Linear MCP server or Symphony's injected `linear_graphql` tool for required Linear operations.
 - Git and GitHub workflow capabilities for clean commits, branch sync, and pushes are required, but `commit`, `push`, and `pull` are external agent capabilities or optional helper skills, not repo-owned checked-in skills in this checkout.
 - Sync operations must target the current base branch: `Dependency base branch` when present, otherwise latest `origin/main`.
-- `land`: when ticket reaches `Merging`, explicitly open and follow `.agents/skills/land/SKILL.md`, the repository-owned merge skill, which includes the `land` loop.
+- `land`: only use if the workspace adds a dedicated merge-ready status and its workflow explicitly asks the agent to land the PR.
 
 ### Status map
 
 - `Backlog` -> out of scope for this workflow; do not modify.
 - `Todo` -> queued; immediately transition to `In Progress` before active work.
-  - Special case: if a PR is already attached, treat as feedback/rework loop (run full PR feedback sweep, address or explicitly push back, revalidate, return to `Human Review`).
+  - Special case: if a PR is already attached, treat as feedback/rework loop (run full PR feedback sweep, address or explicitly push back, revalidate, return to `In Review`).
 - `In Progress` -> implementation actively underway.
-- `Human Review` -> PR is attached and validated; waiting on human approval.
-- `Merging` -> approved by human; execute the `land` skill flow (do not call `gh pr merge` directly).
-- `Rework` -> reviewer requested changes; planning + implementation required.
+- `In Review` -> PR is attached and validated; waiting on human approval.
 - `Done` -> terminal state; no further action required.
+- `Canceled` / `Duplicate` -> terminal state; no further action required.
 
 ### Step 0: Determine current ticket state and route
 
@@ -143,10 +138,9 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
    - `Todo` -> immediately move to `In Progress`, then ensure bootstrap workpad comment exists (create if missing), then start execution flow.
      - If PR is already attached, start by reviewing all open PR comments and deciding required changes vs explicit pushback responses.
    - `In Progress` -> continue execution flow from current scratchpad comment.
-   - `Human Review` -> wait and poll for decision/review updates.
-   - `Merging` -> on entry, open and follow `.agents/skills/land/SKILL.md`; do not call `gh pr merge` directly.
-   - `Rework` -> run rework flow.
+   - `In Review` -> wait and poll for decision/review updates.
    - `Done` -> do nothing and shut down.
+   - `Canceled` / `Duplicate` -> do nothing and shut down.
 4. Check whether a PR already exists for the current branch and whether it is closed.
    - If a branch PR exists and is `CLOSED` or `MERGED`, treat prior branch work as non-reusable for this run.
    - Create a fresh branch from the current base branch (`Dependency base branch` when present, otherwise latest `origin/main`) and restart execution flow as a new attempt.
@@ -190,7 +184,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 
 ### PR feedback sweep protocol (required)
 
-When a ticket has an attached PR, run this protocol before moving to `Human Review`:
+When a ticket has an attached PR, run this protocol before moving to `In Review`:
 
 1. Identify the PR number from issue links/attachments.
 2. Gather feedback from all channels:
@@ -209,14 +203,14 @@ When a ticket has an attached PR, run this protocol before moving to `Human Revi
 Use this only when completion is blocked by missing required tools or missing auth/permissions that cannot be resolved in-session.
 
 - GitHub is **not** a valid blocker by default. Always try fallback strategies first (alternate remote/auth mode, then continue publish/review flow).
-- Do not move to `Human Review` for GitHub access/auth until all fallback strategies have been attempted and documented in the workpad.
-- If a non-GitHub required tool is missing, or required non-GitHub auth is unavailable, move the ticket to `Human Review` with a short blocker brief in the workpad that includes:
+- Do not move to `In Review` for GitHub access/auth until all fallback strategies have been attempted and documented in the workpad.
+- If a non-GitHub required tool is missing, or required non-GitHub auth is unavailable, move the ticket to `In Review` with a short blocker brief in the workpad that includes:
   - what is missing,
   - why it blocks required acceptance/validation,
   - exact human action needed to unblock.
 - Keep the brief concise and action-oriented; do not add extra top-level comments outside the workpad.
 
-### Step 2: Execution phase (Todo -> In Progress -> Human Review)
+### Step 2: Execution phase (Todo -> In Progress -> In Review)
 
 1.  Determine current repo state (`branch`, `git status`, `HEAD`) and verify the kickoff sync result is already recorded in the workpad before implementation continues.
 2.  If current issue state is `Todo`, move it to `In Progress`; otherwise leave the current state unchanged.
@@ -235,7 +229,7 @@ Use this only when completion is blocked by missing required tools or missing au
     - You may make temporary local proof edits to validate assumptions (for example: tweak an input used by the relevant `vp run ...` validation task, or hardcode a UI account / response path) when this increases confidence.
     - Revert every temporary proof edit before commit/push.
     - Document these temporary proof steps and outcomes in the workpad `Validation`/`Notes` sections so reviewers can follow the evidence.
-    - If app-touching, run `launch-app` validation and capture/upload media via `github-pr-media` before handoff.
+    - If app-touching, run the relevant app launch validation and capture/upload media before handoff when the repository provides that workflow.
 6.  Re-check all acceptance criteria and close any gaps.
 7.  Before every `git push` attempt, run the required validation for your scope and confirm it passes; if it fails, address issues and rerun until green, then commit and push changes.
 8.  Attach PR URL to the issue (prefer attachment; use the workpad comment only if attachment is unavailable).
@@ -248,42 +242,28 @@ Use this only when completion is blocked by missing required tools or missing au
     - Do not include PR URL in the workpad comment; keep PR linkage on the issue via attachment/link fields.
     - Add a short `### Confusions` section at the bottom when any part of task execution was unclear/confusing, with concise bullets.
     - Do not post any additional completion summary comment.
-11. Before moving to `Human Review`, poll PR feedback and checks:
+11. Before moving to `In Review`, poll PR feedback and checks:
     - Read the PR `Manual QA Plan` comment (when present) and use it to sharpen UI/runtime test coverage for the current change.
     - Run the full PR feedback sweep protocol.
     - Confirm PR checks are passing (green) after the latest changes.
     - Confirm every required ticket-provided validation/test-plan item is explicitly marked complete in the workpad.
     - Repeat this check-address-verify loop until no outstanding comments remain and checks are fully passing.
     - Re-open and refresh the workpad before state transition so `Plan`, `Acceptance Criteria`, and `Validation` exactly match completed work.
-12. Only then move issue to `Human Review`.
-    - Exception: if blocked by missing required non-GitHub tools/auth per the blocked-access escape hatch, move to `Human Review` with the blocker brief and explicit unblock actions.
+12. Only then move issue to `In Review`.
+    - Exception: if blocked by missing required non-GitHub tools/auth per the blocked-access escape hatch, move to `In Review` with the blocker brief and explicit unblock actions.
 13. For `Todo` tickets that already had a PR attached at kickoff:
     - Ensure all existing PR feedback was reviewed and resolved, including inline review comments (code changes or explicit, justified pushback response).
     - Ensure branch was pushed with any required updates.
-    - Then move to `Human Review`.
+    - Then move to `In Review`.
 
-### Step 3: Human Review and merge handling
+### Step 3: In Review handling
 
-1. When the issue is in `Human Review`, do not code or change ticket content.
+1. When the issue is in `In Review`, do not code or change ticket content.
 2. Poll for updates as needed, including GitHub PR review comments from humans and bots.
-3. If review feedback requires changes, move the issue to `Rework` and follow the rework flow.
-4. If approved, human moves the issue to `Merging`.
-5. When the issue is in `Merging`, open and follow `.agents/skills/land/SKILL.md`, then run the `land` skill in a loop until the PR is merged. Do not call `gh pr merge` directly.
-6. After merge is complete, move the issue to `Done`.
+3. If review feedback requires changes, move the issue to `In Progress`, update the existing workpad, and continue the execution flow.
+4. After merge is complete, move the issue to `Done`.
 
-### Step 4: Rework handling
-
-1. Treat `Rework` as a full approach reset, not incremental patching.
-2. Re-read the full issue body and all human comments; explicitly identify what will be done differently this attempt.
-3. Close the existing PR tied to the issue.
-4. Remove the existing `## OpenCode Workpad` comment from the issue.
-5. Create a fresh branch from the current base branch (`Dependency base branch` when present, otherwise `origin/main`).
-6. Start over from the normal kickoff flow:
-   - If current issue state is `Todo`, move it to `In Progress`; otherwise keep the current state.
-   - Create a new bootstrap `## OpenCode Workpad` comment.
-   - Build a fresh plan/checklist and execute end-to-end.
-
-### Completion bar before Human Review
+### Completion bar before In Review
 
 - Step 1/2 checklist is fully complete and accurately reflected in the single workpad comment.
 - Acceptance criteria and required ticket-provided validation items are complete.
@@ -291,7 +271,7 @@ Use this only when completion is blocked by missing required tools or missing au
 - PR feedback sweep is complete and no actionable comments remain.
 - PR checks are green, branch is pushed, and PR is linked on the issue.
 - Required PR metadata is present (`symphony` label).
-- If app-touching, runtime validation/media requirements from `App runtime validation (required)` are complete.
+- If app-touching, runtime validation/media requirements are complete when the repository provides that workflow.
 
 ### Guardrails
 
@@ -307,8 +287,8 @@ Use this only when completion is blocked by missing required tools or missing au
   title/description/acceptance criteria, same-project assignment, a `related`
   link to the current issue, and `blockedBy` when the follow-up depends on the
   current issue.
-- Do not move to `Human Review` unless the `Completion bar before Human Review` is satisfied.
-- In `Human Review`, do not make changes; wait and poll.
+- Do not move to `In Review` unless the `Completion bar before In Review` is satisfied.
+- In `In Review`, do not make changes; wait and poll.
 - If state is terminal (`Done`), do nothing and shut down.
 - Keep issue text concise, specific, and reviewer-oriented.
 - If blocked and no workpad exists yet, add one blocker comment describing blocker, impact, and next unblock action.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -117,7 +117,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 - Linear access is an external prerequisite. Use either a configured Linear MCP server or Symphony's injected `linear_graphql` tool for required Linear operations.
 - Git and GitHub workflow capabilities for clean commits, branch sync, and pushes are required, but `commit`, `push`, and `pull` are external agent capabilities or optional helper skills, not repo-owned checked-in skills in this checkout.
 - Sync operations must target the current base branch: `Dependency base branch` when present, otherwise latest `origin/main`.
-- `land`: only use if the workspace adds a dedicated merge-ready status and its workflow explicitly asks the agent to land the PR.
+- `land`: only use if the workspace adds a dedicated merge-ready status and its workflow explicitly asks the agent to land the PR; in that case, open and follow `.agents/skills/land/SKILL.md`. Do not call `gh pr merge` directly.
 
 ### Status map
 

--- a/elixir/symphony/README.md
+++ b/elixir/symphony/README.md
@@ -31,7 +31,7 @@ This project is a port of the original [OpenAI Symphony](https://github.com/open
 During app-server sessions, Symphony also serves a client-side `linear_graphql` tool so agents,
 external helper skills, or workflow prompts can make raw Linear GraphQL calls.
 
-If a claimed issue moves to a terminal state (`Done`, `Closed`, `Cancelled`, or `Duplicate`),
+If a claimed issue moves to a terminal state (`Done`, `Canceled`, or `Duplicate`),
 Symphony stops the active agent for that issue and cleans up matching workspaces.
 
 If OpenCode reports that operator input or permission is required, Symphony keeps the
@@ -55,30 +55,31 @@ Linear issue can become a dispatch candidate again after restart.
 5. Customize the copied `WORKFLOW.md` file for your project.
    - To get your project's slug, right-click the project and copy its URL. The slug is part of the
      URL.
-   - When creating a workflow based on this repo, note that it depends on non-standard Linear
-     issue statuses: "Rework", "Human Review", and "Merging". You can customize them in
-     Team Settings → Workflow in Linear.
+   - When creating a workflow based on this repo, note that it expects Linear issues to move from
+     `In Progress` to `In Review` for human approval. You can customize statuses in Team Settings
+     -> Workflow in Linear.
 6. Follow the instructions below to install the required runtime dependencies and start the service.
 
 ## Prerequisites
 
-We recommend using [mise](https://mise.jdx.dev/) to manage Elixir/Erlang versions.
+Use the repository [Devbox](https://www.jetify.com/devbox) environment to provide the required
+Elixir/Erlang versions.
 
 ```bash
-mise install
-mise exec -- elixir --version
+devbox shell
+elixir --version
 ```
 
 ## Run
 
 ```bash
-git clone https://github.com/openai/symphony
-cd symphony/elixir
-mise trust
-mise install
-mise exec -- mix setup
-mise exec -- mix build
-mise exec -- ./bin/symphony ../../WORKFLOW.md
+git clone https://github.com/totto2727-org/monorepo
+cd monorepo
+devbox shell
+cd elixir/symphony
+mix setup
+mix build
+./bin/symphony ../../WORKFLOW.md
 ```
 
 ## Configuration
@@ -132,7 +133,7 @@ Notes:
   configured label to dispatch or continue running. Label matching ignores
   case and surrounding whitespace. A blank configured label matches no issue.
 - `tracker.reviewable_states` controls dependency unblocking for Todo issues blocked by Linear
-  blockers. It defaults to `["Human Review"]`. Todo issues blocked by non-terminal,
+  blockers. It defaults to `["In Review"]`. Todo issues blocked by non-terminal,
   non-reviewable blockers stay claimed in the retry/backoff queue with dependency-wait metadata;
   when blockers become reviewable or terminal, Symphony dispatches the issue and uses an eligible
   blocker `branchName` as `issue.base_branch_name` for prompt templates and hooks.
@@ -149,8 +150,9 @@ Notes:
   environment. The base branch is blank unless Symphony derived it from an eligible dependency
   blocker. Treat these tracker-derived values as untrusted input in hook scripts: quote them,
   validate branch syntax before use, and pass them after `--` where supported by the invoked tool.
-- If a hook needs `mise exec` inside a freshly cloned workspace, trust the repo config and fetch
-  the project dependencies in `hooks.after_create` before invoking `mise` later from other hooks.
+- If a hook needs project tooling inside a freshly cloned workspace, enter the repo's Devbox
+  environment and fetch the project dependencies in `hooks.after_create` before invoking that
+  tooling later from other hooks.
 - `tracker.api_key` reads from `LINEAR_API_KEY` when unset or when value is `$LINEAR_API_KEY`.
 - For path values, `~` is expanded to the home directory.
 - For env-backed path values, use `$VAR`. `workspace.root` resolves `$VAR` before path handling.


### PR DESCRIPTION
#### Context

TOT-34 と PR #189 の review feedback に対応し、Devbox 前提を維持しつつ古い Linear status / project slug 参照を現状に合わせます。

#### TL;DR

README と WORKFLOW の古い Symphony/Linear 参照を現行 monorepo workflow に合わせます。

#### Summary

- README の Devbox 手順を維持し、clone path と status 説明を更新
- WORKFLOW の project slug と status map を現行 Linear team に合わせて更新
- PR #189 に残っていた vite.config.ts 差分を replacement branch で除外

#### Alternatives

- PR #189 上で vite.config.ts revert commit を試したが pre-commit が staged config で失敗したため、hooks をスキップせず replacement branch にした。

#### Test Plan

- [x] `vp run --no-cache ex:check`
- [x] `rg -n "Human Review|Rework|Merging|Closed|Cancelled|mise|vite\.config" WORKFLOW.md elixir/symphony/README.md`
- [x] `git diff --name-only origin/main...HEAD` が README と WORKFLOW のみであることを確認