### PR TITLE
TOT-14 bw json出力にMarkdown/Text形式を追加

### DIFF
--- a/mbt/app/bw/README.md
+++ b/mbt/app/bw/README.md
@@ -4,7 +4,12 @@ Native MoonBit implementation of the `bw` Cloudflare Browser Rendering CLI.
 
 ```bash
 moon run ./src --target native -- markdown --url https://example.com
+moon run ./src --target native -- json --url https://example.com --prompt "Extract the title"
+moon run ./src --target native -- json --url https://example.com --prompt "Extract the title" --format markdown > result.md
+moon run ./src --target native -- json --url https://example.com --prompt "Extract the title" --format text > result.txt
 moon run ./src --target native -- screenshot --url https://example.com --output page.png
 ```
+
+`json` prints the Cloudflare JSON response by default. Use `--format markdown` or `--format text` to print the extracted `result` as unstyled plain text for redirection.
 
 Credentials are read from `--account-id` / `--api-token` or `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN`.

--- a/mbt/app/bw/src/command_json.mbt
+++ b/mbt/app/bw/src/command_json.mbt
@@ -20,6 +20,16 @@ let json_prompt_option = "prompt"
 let json_schema_option = "schema"
 
 ///|
+let json_format_option = "format"
+
+///|
+enum JsonExtractOutputFormat {
+  RawJson
+  Markdown
+  Text
+}
+
+///|
 struct JsonExtractOptionsInput {
   account_id : String
   api_token : String
@@ -28,6 +38,7 @@ struct JsonExtractOptionsInput {
   wait_until : String?
   prompt : String
   response_format : Json?
+  output_format : JsonExtractOutputFormat
 }
 
 ///|
@@ -95,7 +106,24 @@ fn json_extract_command_def() -> @admiral.CommandDef {
       required=true,
     ),
     @admiral.string(json_schema_option, description="Path to JSON Schema file"),
+    @admiral.string(
+      json_format_option,
+      description="Output format: json, markdown, text",
+    ),
   ])
+}
+
+///|
+fn parse_json_extract_output_format(
+  value : String,
+) -> JsonExtractOutputFormat raise {
+  match value {
+    "json" => RawJson
+    "markdown" => Markdown
+    "text" => Text
+    _ =>
+      fail("Invalid --format value: \{value}. Expected json, markdown, or text")
+  }
 }
 
 ///|
@@ -152,6 +180,49 @@ async fn json_extract_options(
       }
       _ => None
     },
+    output_format: match matches.values.get(json_format_option) {
+      Some([value, ..]) => parse_json_extract_output_format(value)
+      _ => RawJson
+    },
+  }
+}
+
+///|
+fn json_extract_result(raw : String) -> Json raise {
+  let parsed = @json.parse(raw) catch {
+    error => fail("Invalid json response JSON: \{error}")
+  }
+  match parsed {
+    Object({ "success": True, "result": result, .. }) => result
+    _ => fail("Invalid json response")
+  }
+}
+
+///|
+fn json_extract_result_text(raw : String) -> String raise {
+  match json_extract_result(raw) {
+    String(value) => value
+    result => result.stringify()
+  }
+}
+
+///|
+fn json_extract_result_markdown(raw : String) -> String raise {
+  match json_extract_result(raw) {
+    String(value) => value
+    result => "```json\n\{result.stringify()}\n```"
+  }
+}
+
+///|
+fn format_json_extract_response(
+  raw : String,
+  output_format : JsonExtractOutputFormat,
+) -> String raise {
+  match output_format {
+    RawJson => raw
+    Markdown => json_extract_result_markdown(raw)
+    Text => json_extract_result_text(raw)
   }
 }
 
@@ -185,5 +256,5 @@ async fn run_json_extract(matches : @argparse.Matches) -> Unit {
     body.to_json(),
   )
   ensure_success(code, reason, data)
-  println(data.text())
+  println(format_json_extract_response(data.text(), options.output_format))
 }

--- a/mbt/app/bw/src/command_json_wbtest.mbt
+++ b/mbt/app/bw/src/command_json_wbtest.mbt
@@ -1,0 +1,32 @@
+///|
+test "format_json_extract_response keeps raw JSON by default" {
+  let raw = "{\"success\":true,\"result\":\"# Title\\n\\nBody\"}"
+  inspect(
+    try! format_json_extract_response(raw, RawJson),
+    content="{\"success\":true,\"result\":\"# Title\\n\\nBody\"}",
+  )
+}
+
+///|
+test "format_json_extract_response renders markdown string result" {
+  let raw = "{\"success\":true,\"result\":\"# Title\\n\\nBody\"}"
+  inspect(
+    try! format_json_extract_response(raw, Markdown),
+    content="# Title\n\nBody",
+  )
+}
+
+///|
+test "format_json_extract_response renders text string result" {
+  let raw = "{\"success\":true,\"result\":\"plain output\"}"
+  inspect(try! format_json_extract_response(raw, Text), content="plain output")
+}
+
+///|
+test "format_json_extract_response renders structured markdown as fenced JSON" {
+  let raw = "{\"success\":true,\"result\":{\"title\":\"Example\"}}"
+  inspect(
+    try! format_json_extract_response(raw, Markdown),
+    content="```json\n{\"title\":\"Example\"}\n```",
+  )
+}


### PR DESCRIPTION
## 概要
- `bw json` に `--format json|markdown|text` を追加しました
- 既定値は従来どおり raw JSON 出力です
- Markdown/Text は Cloudflare JSON response の `result` を色なし PlainText として標準出力します
- README にリダイレクト保存例を追加しました

## 検証
- `moon test`
- `moon check`
- `vp run --filter @totto2727/bw build`
- `vp run mbt:check`
- `vp run mbt:test`
- `mbt/app/bw/dist/bw json --help`
