### PR TITLE
TOT-40 MoonBit CLIのパス操作を内部Pathパッケージへ抽出

### DIFF
--- a/mbt/app/bw/src/command_content.mbt
+++ b/mbt/app/bw/src/command_content.mbt
@@ -23,7 +23,7 @@ struct ContentOptions {
   url : String?
   html : String?
   wait_until : String?
-  output : String?
+  output : @path.Path?
 }
 
 ///|
@@ -125,7 +125,7 @@ async fn content_options(matches : @argparse.Matches) -> ContentOptions {
       _ => None
     },
     html: match matches.values.get(content_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
+      Some([path, ..]) => Some(@path.Path::from_cli(path).read_text())
       _ => None
     },
     wait_until: match matches.values.get(content_wait_until_option) {
@@ -133,7 +133,7 @@ async fn content_options(matches : @argparse.Matches) -> ContentOptions {
       _ => None
     },
     output: match matches.values.get(content_output_option) {
-      Some([value, ..]) => Some(value)
+      Some([value, ..]) => Some(@path.Path::from_cli(value))
       _ => None
     },
   }

--- a/mbt/app/bw/src/command_crawl.mbt
+++ b/mbt/app/bw/src/command_crawl.mbt
@@ -35,7 +35,7 @@ struct CrawlStartOptionsInput {
   url : String?
   html : String?
   wait_until : String?
-  output : String?
+  output : @path.Path?
   limit : Int?
   depth : Int?
   formats : Array[String]?
@@ -46,7 +46,7 @@ struct CrawlGetOptionsInput {
   account_id : String
   api_token : String
   id : String
-  output : String?
+  output : @path.Path?
 }
 
 ///|
@@ -225,7 +225,7 @@ async fn crawl_start_options(
       _ => None
     },
     html: match matches.values.get(crawl_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
+      Some([path, ..]) => Some(@path.Path::from_cli(path).read_text())
       _ => None
     },
     wait_until: match matches.values.get(crawl_wait_until_option) {
@@ -233,7 +233,7 @@ async fn crawl_start_options(
       _ => None
     },
     output: match matches.values.get(crawl_output_option) {
-      Some([value, ..]) => Some(value)
+      Some([value, ..]) => Some(@path.Path::from_cli(value))
       _ => None
     },
     limit: match matches.values.get(crawl_limit_option) {
@@ -315,7 +315,7 @@ fn crawl_get_options(matches : @argparse.Matches) -> CrawlGetOptionsInput raise 
       _ => fail("missing required option: id")
     },
     output: match matches.values.get(crawl_output_option) {
-      Some([value, ..]) => Some(value)
+      Some([value, ..]) => Some(@path.Path::from_cli(value))
       _ => None
     },
   }

--- a/mbt/app/bw/src/command_json.mbt
+++ b/mbt/app/bw/src/command_json.mbt
@@ -130,7 +130,7 @@ async fn json_extract_options(
       _ => None
     },
     html: match matches.values.get(json_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
+      Some([path, ..]) => Some(@path.Path::from_cli(path).read_text())
       _ => None
     },
     wait_until: match matches.values.get(json_wait_until_option) {
@@ -143,7 +143,7 @@ async fn json_extract_options(
     },
     response_format: match matches.values.get(json_schema_option) {
       Some([path, ..]) => {
-        let schema = @json.parse(@fs.read_file(path).text()) catch {
+        let schema = @json.parse(@path.Path::from_cli(path).read_text()) catch {
           error => fail("Invalid JSON schema file: \{error}")
         }
         Some(

--- a/mbt/app/bw/src/command_links.mbt
+++ b/mbt/app/bw/src/command_links.mbt
@@ -144,7 +144,7 @@ async fn links_options(matches : @argparse.Matches) -> LinksOptionsInput {
       _ => None
     },
     html: match matches.values.get(links_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
+      Some([path, ..]) => Some(@path.Path::from_cli(path).read_text())
       _ => None
     },
     wait_until: match matches.values.get(links_wait_until_option) {

--- a/mbt/app/bw/src/command_markdown.mbt
+++ b/mbt/app/bw/src/command_markdown.mbt
@@ -23,7 +23,7 @@ struct MarkdownOptions {
   url : String?
   html : String?
   wait_until : String?
-  output : String?
+  output : @path.Path?
 }
 
 ///|
@@ -128,7 +128,7 @@ async fn markdown_options(matches : @argparse.Matches) -> MarkdownOptions {
       _ => None
     },
     html: match matches.values.get(markdown_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
+      Some([path, ..]) => Some(@path.Path::from_cli(path).read_text())
       _ => None
     },
     wait_until: match matches.values.get(markdown_wait_until_option) {
@@ -136,7 +136,7 @@ async fn markdown_options(matches : @argparse.Matches) -> MarkdownOptions {
       _ => None
     },
     output: match matches.values.get(markdown_output_option) {
-      Some([value, ..]) => Some(value)
+      Some([value, ..]) => Some(@path.Path::from_cli(value))
       _ => None
     },
   }

--- a/mbt/app/bw/src/command_pdf.mbt
+++ b/mbt/app/bw/src/command_pdf.mbt
@@ -29,7 +29,7 @@ struct PdfOptionsInput {
   url : String?
   html : String?
   wait_until : String?
-  output : String
+  output : @path.Path
   landscape : Bool
   format : String?
 }
@@ -167,7 +167,7 @@ async fn pdf_options(matches : @argparse.Matches) -> PdfOptionsInput {
       _ => None
     },
     html: match matches.values.get(pdf_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
+      Some([path, ..]) => Some(@path.Path::from_cli(path).read_text())
       _ => None
     },
     wait_until: match matches.values.get(pdf_wait_until_option) {
@@ -175,7 +175,7 @@ async fn pdf_options(matches : @argparse.Matches) -> PdfOptionsInput {
       _ => None
     },
     output: match matches.values.get(pdf_output_option) {
-      Some([value, ..]) => value
+      Some([value, ..]) => @path.Path::from_cli(value)
       _ => fail("missing required option: output")
     },
     landscape: matches.flags.get(pdf_landscape_option).unwrap_or(false),

--- a/mbt/app/bw/src/command_scrape.mbt
+++ b/mbt/app/bw/src/command_scrape.mbt
@@ -134,7 +134,7 @@ async fn scrape_options(matches : @argparse.Matches) -> ScrapeOptionsInput {
       _ => None
     },
     html: match matches.values.get(scrape_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
+      Some([path, ..]) => Some(@path.Path::from_cli(path).read_text())
       _ => None
     },
     wait_until: match matches.values.get(scrape_wait_until_option) {

--- a/mbt/app/bw/src/command_screenshot.mbt
+++ b/mbt/app/bw/src/command_screenshot.mbt
@@ -32,7 +32,7 @@ struct ScreenshotOptionsInput {
   url : String?
   html : String?
   wait_until : String?
-  output : String
+  output : @path.Path
   full_page : Bool
   width : Int?
   height : Int?
@@ -208,7 +208,7 @@ async fn screenshot_options(
       _ => None
     },
     html: match matches.values.get(screenshot_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
+      Some([path, ..]) => Some(@path.Path::from_cli(path).read_text())
       _ => None
     },
     wait_until: match matches.values.get(screenshot_wait_until_option) {
@@ -216,7 +216,7 @@ async fn screenshot_options(
       _ => None
     },
     output: match matches.values.get(screenshot_output_option) {
-      Some([value, ..]) => value
+      Some([value, ..]) => @path.Path::from_cli(value)
       _ => fail("missing required option: output")
     },
     full_page: matches.flags.get(screenshot_full_page_option).unwrap_or(false),

--- a/mbt/app/bw/src/command_snapshot.mbt
+++ b/mbt/app/bw/src/command_snapshot.mbt
@@ -26,7 +26,7 @@ struct SnapshotOptionsInput {
   url : String?
   html : String?
   wait_until : String?
-  output : String
+  output : @path.Path
   full_page : Bool
 }
 
@@ -163,7 +163,7 @@ async fn snapshot_options(matches : @argparse.Matches) -> SnapshotOptionsInput {
       _ => None
     },
     html: match matches.values.get(snapshot_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
+      Some([path, ..]) => Some(@path.Path::from_cli(path).read_text())
       _ => None
     },
     wait_until: match matches.values.get(snapshot_wait_until_option) {
@@ -171,7 +171,7 @@ async fn snapshot_options(matches : @argparse.Matches) -> SnapshotOptionsInput {
       _ => None
     },
     output: match matches.values.get(snapshot_output_option) {
-      Some([value, ..]) => value
+      Some([value, ..]) => @path.Path::from_cli(value)
       _ => fail("missing required option: output")
     },
     full_page: matches.flags.get(snapshot_full_page_option).unwrap_or(false),

--- a/mbt/app/bw/src/moon.pkg
+++ b/mbt/app/bw/src/moon.pkg
@@ -9,6 +9,7 @@ import {
   "moonbitlang/async/http",
   "moonbitlang/async/io",
   "gmlewis/base64",
+  "totto2727/bw/path",
 }
 
 supported_targets = "native"

--- a/mbt/app/bw/src/output.mbt
+++ b/mbt/app/bw/src/output.mbt
@@ -1,44 +1,39 @@
 ///|
-async fn write_text_or_stdout(output : String?, text : String) -> Unit {
+async fn write_text_or_stdout(output : @path.Path?, text : String) -> Unit {
   match output {
     Some(path) => {
-      @fs.write_file(path, text, create_mode=CreateOrTruncate)
-      println("Written to \{path}")
+      let file_path = path.to_string()
+      @fs.write_file(file_path, text, create_mode=CreateOrTruncate)
+      println("Written to \{file_path}")
     }
     None => println(text)
   }
 }
 
 ///|
-async fn write_binary(path : String, data : &@io.Data, label : String) -> Unit {
-  @fs.write_file(path, data, create_mode=CreateOrTruncate)
-  println("\{label} saved to \{path}")
-}
-
-///|
-fn snapshot_base_name(output : String) -> String {
-  let base = output.trim_end(chars="/").to_owned()
-  if base == "" {
-    "snapshot"
-  } else {
-    match base.rev_find("/") {
-      Some(index) => base[index + 1:].to_owned()
-      None => base
-    }
-  }
+async fn write_binary(
+  path : @path.Path,
+  data : &@io.Data,
+  label : String,
+) -> Unit {
+  let file_path = path.to_string()
+  @fs.write_file(file_path, data, create_mode=CreateOrTruncate)
+  println("\{label} saved to \{file_path}")
 }
 
 ///|
 async fn write_snapshot(
-  output : String,
+  output : @path.Path,
   content : String,
   screenshot : Bytes,
 ) -> Unit {
-  let dir = output.trim_end(chars="/").to_owned()
-  let dir = if dir == "" { "snapshot" } else { dir }
-  let name = snapshot_base_name(output)
-  @fs.mkdir(dir, recursive=true)
-  @fs.write_file("\{dir}/\{name}.html", content, create_mode=CreateOrTruncate)
-  @fs.write_file("\{dir}/\{name}.png", screenshot, create_mode=CreateOrTruncate)
-  println("Snapshot saved to \{dir}/")
+  let dir = output.snapshot_dir()
+  let name = output.snapshot_base_name()
+  let html_path = dir.join("\{name}.html").to_string()
+  let screenshot_path = dir.join("\{name}.png").to_string()
+  let dir_path = dir.to_string()
+  @fs.mkdir(dir_path, recursive=true)
+  @fs.write_file(html_path, content, create_mode=CreateOrTruncate)
+  @fs.write_file(screenshot_path, screenshot, create_mode=CreateOrTruncate)
+  println("Snapshot saved to \{dir_path}/")
 }

--- a/mbt/app/bw/src/path/moon.pkg
+++ b/mbt/app/bw/src/path/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "moonbitlang/async/fs",
+  "moonbitlang/core/env",
+  "moonbitlang/core/test",
+}

--- a/mbt/app/bw/src/path/path.mbt
+++ b/mbt/app/bw/src/path/path.mbt
@@ -1,0 +1,127 @@
+///|
+pub struct Path {
+  value : String
+} derive(Eq, Debug)
+
+///|
+pub fn Path::from_cli(value : String) -> Path {
+  Path::{ value: expand_home(value, @env.get_env_var("HOME")) }
+}
+
+///|
+pub fn Path::from_cli_with_home(value : String, home : String) -> Path {
+  Path::{ value: expand_home(value, Some(home)) }
+}
+
+///|
+pub fn Path::to_string(self : Path) -> String {
+  self.value
+}
+
+///|
+pub async fn Path::read_text(self : Path) -> String {
+  @fs.read_file(self.value).text()
+}
+
+///|
+pub fn Path::snapshot_dir(self : Path) -> Path {
+  let dir = self.value.trim_end(chars="/").to_owned()
+  Path::{ value: if dir == "" { "snapshot" } else { dir } }
+}
+
+///|
+pub fn Path::snapshot_base_name(self : Path) -> String {
+  let base = self.value.trim_end(chars="/").to_owned()
+  if base == "" {
+    "snapshot"
+  } else {
+    match base.rev_find("/") {
+      Some(index) => base[index + 1:].to_owned()
+      None => base
+    }
+  }
+}
+
+///|
+pub fn Path::join(self : Path, name : String) -> Path {
+  Path::{ value: "\{self.value}/\{name}" }
+}
+
+///|
+fn expand_home(value : String, home : String?) -> String {
+  match home {
+    Some(home) =>
+      if value == "~" {
+        home
+      } else if value.length() >= 2 && value[0:2] == "~/" {
+        "\{home}\{value[1:]}"
+      } else {
+        value
+      }
+    None => value
+  }
+}
+
+///|
+test "Path::from_cli_with_home - expands exact tilde" {
+  @test.assert_eq(
+    Path::from_cli_with_home("~", "/Users/example").to_string(),
+    "/Users/example",
+  )
+}
+
+///|
+test "Path::from_cli_with_home - expands leading tilde slash" {
+  @test.assert_eq(
+    Path::from_cli_with_home("~/page.html", "/Users/example").to_string(),
+    "/Users/example/page.html",
+  )
+}
+
+///|
+test "Path::from_cli_with_home - leaves other tilde forms unchanged" {
+  @test.assert_eq(
+    Path::from_cli_with_home("~other/page.html", "/Users/example").to_string(),
+    "~other/page.html",
+  )
+  @test.assert_eq(
+    Path::from_cli_with_home("tmp/~/page.html", "/Users/example").to_string(),
+    "tmp/~/page.html",
+  )
+}
+
+///|
+test "Path::from_cli_with_home - leaves relative and absolute paths unchanged" {
+  @test.assert_eq(
+    Path::from_cli_with_home("tmp/page.html", "/Users/example").to_string(),
+    "tmp/page.html",
+  )
+  @test.assert_eq(
+    Path::from_cli_with_home("/tmp/page.html", "/Users/example").to_string(),
+    "/tmp/page.html",
+  )
+}
+
+///|
+test "expand_home - leaves paths unchanged when home is missing" {
+  @test.assert_eq(expand_home("~", None), "~")
+  @test.assert_eq(expand_home("~/page.html", None), "~/page.html")
+}
+
+///|
+test "Path snapshot helpers - preserve directory output behavior" {
+  let path = Path::from_cli_with_home("reports/page/", "/Users/example")
+  @test.assert_eq(path.snapshot_dir().to_string(), "reports/page")
+  @test.assert_eq(path.snapshot_base_name(), "page")
+  @test.assert_eq(
+    path.snapshot_dir().join("page.html").to_string(),
+    "reports/page/page.html",
+  )
+}
+
+///|
+test "Path snapshot helpers - empty trimmed output uses snapshot" {
+  let path = Path::from_cli_with_home("/", "/Users/example")
+  @test.assert_eq(path.snapshot_dir().to_string(), "snapshot")
+  @test.assert_eq(path.snapshot_base_name(), "snapshot")
+}


### PR DESCRIPTION
## 概要
- `mbt/app/bw/src/path` に内部 `Path` パッケージを追加
- CLI入力のHTML/schemaパスと出力パスを `@path.Path` 経由に変更
- `~` / `~/...` 展開とsnapshot出力用のパス補助処理を集約

## 検証
- `vp run mbt:fix`
- `vp run mbt:check`
- `vp run mbt:test`
- `vp run --filter @totto2727/bw build`

## CI status
- Latest commit SHA: `2723282c`
- Latest `check` job: success (run id: `29089103715`, attempt: 1)
- Retry history: none