### PR TITLE
TOT-15 bwでconfigファイル入力をサポート

### DIFF
--- a/mbt/app/bw/README.md
+++ b/mbt/app/bw/README.md
@@ -5,6 +5,33 @@ Native MoonBit implementation of the `bw` Cloudflare Browser Rendering CLI.
 ```bash
 moon run ./src --target native -- markdown --url https://example.com
 moon run ./src --target native -- screenshot --url https://example.com --output page.png
+moon run ./src --target native -- markdown --config bw-config.json
 ```
 
-Credentials are read from `--account-id` / `--api-token` or `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN`.
+Every command and crawl subcommand accepts `--config <path>` with a JSON object.
+Values are resolved with this precedence:
+
+1. CLI option
+2. Config file key
+3. Existing default or environment fallback
+
+Credentials use the same order: `--account-id` / `--api-token`, then
+`account_id` / `api_token` in the config file, then
+`CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN`.
+
+Config keys use snake_case names matching the option structs. `html` and
+`schema` are file paths, the same as their CLI options.
+
+```json
+{
+  "account_id": "your-account-id",
+  "api_token": "your-api-token",
+  "url": "https://example.com",
+  "wait_until": "networkidle",
+  "output": "page.png",
+  "full_page": true,
+  "width": 1280,
+  "height": 720,
+  "formats": ["html", "markdown"]
+}
+```

--- a/mbt/app/bw/src/command_content.mbt
+++ b/mbt/app/bw/src/command_content.mbt
@@ -92,58 +92,32 @@ fn content_command_def() -> @admiral.CommandDef {
       short='o',
       description="Output file path",
     ),
+    @admiral.string(config_option, description="Path to JSON config file"),
   ])
 }
 
 ///|
 async fn content_options(matches : @argparse.Matches) -> ContentOptions {
+  let config = load_config(matches)
   {
-    account_id: match matches.values.get(content_account_id_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_account_id_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "account-id is required. Set CLOUDFLARE_ACCOUNT_ID or pass --account-id",
-            )
-        }
-    },
-    api_token: match matches.values.get(content_api_token_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_api_token_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "api-token is required. Set CLOUDFLARE_API_TOKEN or pass --api-token",
-            )
-        }
-    },
-    url: match matches.values.get(content_url_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    html: match matches.values.get(content_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
-      _ => None
-    },
-    wait_until: match matches.values.get(content_wait_until_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    output: match matches.values.get(content_output_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
+    account_id: merged_account_id(matches, config),
+    api_token: merged_api_token(matches, config),
+    url: merge_string(cli_string(matches, content_url_option), config.url),
+    html: merged_html(matches, content_html_option, config),
+    wait_until: merge_string(
+      cli_string(matches, content_wait_until_option),
+      config.wait_until,
+    ),
+    output: merge_string(
+      cli_string(matches, content_output_option),
+      config.output,
+    ),
   }
 }
 
 ///|
 fn ContentBody::from_options(options : ContentOptions) -> ContentBody raise {
-  guard options.url is Some(_) || options.html is Some(_) else {
-    fail("Either --url or --html is required")
-  }
+  required_body_source(options.url, options.html)
   {
     url: options.url,
     html: options.html,

--- a/mbt/app/bw/src/command_crawl.mbt
+++ b/mbt/app/bw/src/command_crawl.mbt
@@ -149,6 +149,7 @@ fn crawl_command_def() -> @admiral.CommandDef {
         crawl_format_option,
         description="Output formats: html,markdown,json",
       ),
+      @admiral.string(config_option, description="Path to JSON config file"),
     ]),
     @admiral.command(name="status", description="Check crawl job status", options=[
       @admiral.string(
@@ -159,11 +160,8 @@ fn crawl_command_def() -> @admiral.CommandDef {
         crawl_api_token_option,
         description="Cloudflare API token",
       ),
-      @admiral.string(
-        crawl_id_option,
-        description="Crawl job ID",
-        required=true,
-      ),
+      @admiral.string(crawl_id_option, description="Crawl job ID"),
+      @admiral.string(config_option, description="Path to JSON config file"),
     ]),
     @admiral.command(name="results", description="Retrieve crawl results", options=[
       @admiral.string(
@@ -174,16 +172,13 @@ fn crawl_command_def() -> @admiral.CommandDef {
         crawl_api_token_option,
         description="Cloudflare API token",
       ),
-      @admiral.string(
-        crawl_id_option,
-        description="Crawl job ID",
-        required=true,
-      ),
+      @admiral.string(crawl_id_option, description="Crawl job ID"),
       @admiral.string(
         crawl_output_option,
         short='o',
         description="Output file path",
       ),
+      @admiral.string(config_option, description="Path to JSON config file"),
     ]),
   ])
 }
@@ -197,57 +192,29 @@ fn split_csv(value : String) -> Array[String] {
 async fn crawl_start_options(
   matches : @argparse.Matches,
 ) -> CrawlStartOptionsInput {
+  let config = load_config(matches)
   {
-    account_id: match matches.values.get(crawl_account_id_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_account_id_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "account-id is required. Set CLOUDFLARE_ACCOUNT_ID or pass --account-id",
-            )
-        }
-    },
-    api_token: match matches.values.get(crawl_api_token_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_api_token_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "api-token is required. Set CLOUDFLARE_API_TOKEN or pass --api-token",
-            )
-        }
-    },
-    url: match matches.values.get(crawl_url_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    html: match matches.values.get(crawl_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
-      _ => None
-    },
-    wait_until: match matches.values.get(crawl_wait_until_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    output: match matches.values.get(crawl_output_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    limit: match matches.values.get(crawl_limit_option) {
-      Some([value, ..]) => Some(@string.parse_int(value))
-      _ => None
-    },
-    depth: match matches.values.get(crawl_depth_option) {
-      Some([value, ..]) => Some(@string.parse_int(value))
-      _ => None
-    },
-    formats: match matches.values.get(crawl_format_option) {
-      Some([value, ..]) => Some(split_csv(value))
-      _ => None
-    },
+    account_id: merged_account_id(matches, config),
+    api_token: merged_api_token(matches, config),
+    url: merge_string(cli_string(matches, crawl_url_option), config.url),
+    html: merged_html(matches, crawl_html_option, config),
+    wait_until: merge_string(
+      cli_string(matches, crawl_wait_until_option),
+      config.wait_until,
+    ),
+    output: merge_string(
+      cli_string(matches, crawl_output_option),
+      config.output,
+    ),
+    limit: merge_int(cli_int(matches, crawl_limit_option), config.limit),
+    depth: merge_int(cli_int(matches, crawl_depth_option), config.depth),
+    formats: merge_string_array(
+      match cli_string(matches, crawl_format_option) {
+        Some(value) => Some(split_csv(value))
+        None => None
+      },
+      config.formats,
+    ),
   }
 }
 
@@ -255,9 +222,7 @@ async fn crawl_start_options(
 fn CrawlStartBody::from_options(
   options : CrawlStartOptionsInput,
 ) -> CrawlStartBody raise {
-  guard options.url is Some(_) || options.html is Some(_) else {
-    fail("Either --url or --html is required")
-  }
+  required_body_source(options.url, options.html)
   {
     url: options.url,
     html: options.html,
@@ -286,38 +251,19 @@ async fn run_crawl_start(matches : @argparse.Matches) -> Unit {
 }
 
 ///|
-fn crawl_get_options(matches : @argparse.Matches) -> CrawlGetOptionsInput raise {
+async fn crawl_get_options(matches : @argparse.Matches) -> CrawlGetOptionsInput {
+  let config = load_config(matches)
   {
-    account_id: match matches.values.get(crawl_account_id_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_account_id_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "account-id is required. Set CLOUDFLARE_ACCOUNT_ID or pass --account-id",
-            )
-        }
-    },
-    api_token: match matches.values.get(crawl_api_token_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_api_token_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "api-token is required. Set CLOUDFLARE_API_TOKEN or pass --api-token",
-            )
-        }
-    },
-    id: match matches.values.get(crawl_id_option) {
-      Some([value, ..]) => value
-      _ => fail("missing required option: id")
-    },
-    output: match matches.values.get(crawl_output_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
+    account_id: merged_account_id(matches, config),
+    api_token: merged_api_token(matches, config),
+    id: required_value(
+      "id",
+      merge_string(cli_string(matches, crawl_id_option), config.id),
+    ),
+    output: merge_string(
+      cli_string(matches, crawl_output_option),
+      config.output,
+    ),
   }
 }
 

--- a/mbt/app/bw/src/command_json.mbt
+++ b/mbt/app/bw/src/command_json.mbt
@@ -89,12 +89,9 @@ fn json_extract_command_def() -> @admiral.CommandDef {
     @admiral.string(json_url_option, description="Target URL"),
     @admiral.string(json_html_option, description="Path to local HTML file"),
     @admiral.string(json_wait_until_option, description="Page load strategy"),
-    @admiral.string(
-      json_prompt_option,
-      description="Extraction prompt",
-      required=true,
-    ),
+    @admiral.string(json_prompt_option, description="Extraction prompt"),
     @admiral.string(json_schema_option, description="Path to JSON Schema file"),
+    @admiral.string(config_option, description="Path to JSON config file"),
   ])
 }
 
@@ -102,55 +99,24 @@ fn json_extract_command_def() -> @admiral.CommandDef {
 async fn json_extract_options(
   matches : @argparse.Matches,
 ) -> JsonExtractOptionsInput {
+  let config = load_config(matches)
   {
-    account_id: match matches.values.get(json_account_id_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_account_id_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "account-id is required. Set CLOUDFLARE_ACCOUNT_ID or pass --account-id",
-            )
-        }
-    },
-    api_token: match matches.values.get(json_api_token_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_api_token_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "api-token is required. Set CLOUDFLARE_API_TOKEN or pass --api-token",
-            )
-        }
-    },
-    url: match matches.values.get(json_url_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    html: match matches.values.get(json_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
-      _ => None
-    },
-    wait_until: match matches.values.get(json_wait_until_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    prompt: match matches.values.get(json_prompt_option) {
-      Some([value, ..]) => value
-      _ => fail("missing required option: prompt")
-    },
-    response_format: match matches.values.get(json_schema_option) {
-      Some([path, ..]) => {
-        let schema = @json.parse(@fs.read_file(path).text()) catch {
-          error => fail("Invalid JSON schema file: \{error}")
-        }
-        Some(
-          Json::object({ "schema": schema, "type": "json_schema".to_json() }),
-        )
-      }
-      _ => None
+    account_id: merged_account_id(matches, config),
+    api_token: merged_api_token(matches, config),
+    url: merge_string(cli_string(matches, json_url_option), config.url),
+    html: merged_html(matches, json_html_option, config),
+    wait_until: merge_string(
+      cli_string(matches, json_wait_until_option),
+      config.wait_until,
+    ),
+    prompt: required_value(
+      "prompt",
+      merge_string(cli_string(matches, json_prompt_option), config.prompt),
+    ),
+    response_format: match
+      merge_string(cli_string(matches, json_schema_option), config.schema) {
+      Some(path) => Some(schema_response_format(path))
+      None => None
     },
   }
 }
@@ -159,9 +125,7 @@ async fn json_extract_options(
 fn JsonExtractBody::from_options(
   options : JsonExtractOptionsInput,
 ) -> JsonExtractBody raise {
-  guard options.url is Some(_) || options.html is Some(_) else {
-    fail("Either --url or --html is required")
-  }
+  required_body_source(options.url, options.html)
   {
     url: options.url,
     html: options.html,

--- a/mbt/app/bw/src/command_links.mbt
+++ b/mbt/app/bw/src/command_links.mbt
@@ -111,58 +111,38 @@ fn links_command_def() -> @admiral.CommandDef {
       links_internal_only_option,
       description="Only same-domain links",
     ),
+    @admiral.string(config_option, description="Path to JSON config file"),
   ])
 }
 
 ///|
 async fn links_options(matches : @argparse.Matches) -> LinksOptionsInput {
+  let config = load_config(matches)
   {
-    account_id: match matches.values.get(links_account_id_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_account_id_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "account-id is required. Set CLOUDFLARE_ACCOUNT_ID or pass --account-id",
-            )
-        }
-    },
-    api_token: match matches.values.get(links_api_token_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_api_token_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "api-token is required. Set CLOUDFLARE_API_TOKEN or pass --api-token",
-            )
-        }
-    },
-    url: match matches.values.get(links_url_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    html: match matches.values.get(links_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
-      _ => None
-    },
-    wait_until: match matches.values.get(links_wait_until_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    visible_only: matches.flags.get(links_visible_only_option).unwrap_or(false),
-    internal_only: matches.flags
-    .get(links_internal_only_option)
-    .unwrap_or(false),
+    account_id: merged_account_id(matches, config),
+    api_token: merged_api_token(matches, config),
+    url: merge_string(cli_string(matches, links_url_option), config.url),
+    html: merged_html(matches, links_html_option, config),
+    wait_until: merge_string(
+      cli_string(matches, links_wait_until_option),
+      config.wait_until,
+    ),
+    visible_only: merge_bool(
+      matches.flags.get(links_visible_only_option).unwrap_or(false),
+      config.visible_only,
+      false,
+    ),
+    internal_only: merge_bool(
+      matches.flags.get(links_internal_only_option).unwrap_or(false),
+      config.internal_only,
+      false,
+    ),
   }
 }
 
 ///|
 fn LinksBody::from_options(options : LinksOptionsInput) -> LinksBody raise {
-  guard options.url is Some(_) || options.html is Some(_) else {
-    fail("Either --url or --html is required")
-  }
+  required_body_source(options.url, options.html)
   {
     url: options.url,
     html: options.html,

--- a/mbt/app/bw/src/command_markdown.mbt
+++ b/mbt/app/bw/src/command_markdown.mbt
@@ -95,58 +95,32 @@ fn markdown_command_def() -> @admiral.CommandDef {
       short='o',
       description="Output file path",
     ),
+    @admiral.string(config_option, description="Path to JSON config file"),
   ])
 }
 
 ///|
 async fn markdown_options(matches : @argparse.Matches) -> MarkdownOptions {
+  let config = load_config(matches)
   {
-    account_id: match matches.values.get(markdown_account_id_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_account_id_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "account-id is required. Set CLOUDFLARE_ACCOUNT_ID or pass --account-id",
-            )
-        }
-    },
-    api_token: match matches.values.get(markdown_api_token_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_api_token_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "api-token is required. Set CLOUDFLARE_API_TOKEN or pass --api-token",
-            )
-        }
-    },
-    url: match matches.values.get(markdown_url_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    html: match matches.values.get(markdown_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
-      _ => None
-    },
-    wait_until: match matches.values.get(markdown_wait_until_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    output: match matches.values.get(markdown_output_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
+    account_id: merged_account_id(matches, config),
+    api_token: merged_api_token(matches, config),
+    url: merge_string(cli_string(matches, markdown_url_option), config.url),
+    html: merged_html(matches, markdown_html_option, config),
+    wait_until: merge_string(
+      cli_string(matches, markdown_wait_until_option),
+      config.wait_until,
+    ),
+    output: merge_string(
+      cli_string(matches, markdown_output_option),
+      config.output,
+    ),
   }
 }
 
 ///|
 fn MarkdownBody::from_options(options : MarkdownOptions) -> MarkdownBody raise {
-  guard options.url is Some(_) || options.html is Some(_) else {
-    fail("Either --url or --html is required")
-  }
+  required_body_source(options.url, options.html)
   {
     url: options.url,
     html: options.html,

--- a/mbt/app/bw/src/command_pdf.mbt
+++ b/mbt/app/bw/src/command_pdf.mbt
@@ -130,67 +130,41 @@ fn pdf_command_def() -> @admiral.CommandDef {
       pdf_output_option,
       short='o',
       description="Output file path",
-      required=true,
     ),
     @admiral.bool(pdf_landscape_option, description="Landscape orientation"),
     @admiral.string(pdf_format_option, description="Page format"),
+    @admiral.string(config_option, description="Path to JSON config file"),
   ])
 }
 
 ///|
 async fn pdf_options(matches : @argparse.Matches) -> PdfOptionsInput {
+  let config = load_config(matches)
   {
-    account_id: match matches.values.get(pdf_account_id_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_account_id_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "account-id is required. Set CLOUDFLARE_ACCOUNT_ID or pass --account-id",
-            )
-        }
-    },
-    api_token: match matches.values.get(pdf_api_token_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_api_token_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "api-token is required. Set CLOUDFLARE_API_TOKEN or pass --api-token",
-            )
-        }
-    },
-    url: match matches.values.get(pdf_url_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    html: match matches.values.get(pdf_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
-      _ => None
-    },
-    wait_until: match matches.values.get(pdf_wait_until_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    output: match matches.values.get(pdf_output_option) {
-      Some([value, ..]) => value
-      _ => fail("missing required option: output")
-    },
-    landscape: matches.flags.get(pdf_landscape_option).unwrap_or(false),
-    format: match matches.values.get(pdf_format_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
+    account_id: merged_account_id(matches, config),
+    api_token: merged_api_token(matches, config),
+    url: merge_string(cli_string(matches, pdf_url_option), config.url),
+    html: merged_html(matches, pdf_html_option, config),
+    wait_until: merge_string(
+      cli_string(matches, pdf_wait_until_option),
+      config.wait_until,
+    ),
+    output: required_value(
+      "output",
+      merge_string(cli_string(matches, pdf_output_option), config.output),
+    ),
+    landscape: merge_bool(
+      matches.flags.get(pdf_landscape_option).unwrap_or(false),
+      config.landscape,
+      false,
+    ),
+    format: merge_string(cli_string(matches, pdf_format_option), config.format),
   }
 }
 
 ///|
 fn PdfBody::from_options(options : PdfOptionsInput) -> PdfBody raise {
-  guard options.url is Some(_) || options.html is Some(_) else {
-    fail("Either --url or --html is required")
-  }
+  required_body_source(options.url, options.html)
   {
     url: options.url,
     html: options.html,

--- a/mbt/app/bw/src/command_scrape.mbt
+++ b/mbt/app/bw/src/command_scrape.mbt
@@ -96,63 +96,33 @@ fn scrape_command_def() -> @admiral.CommandDef {
     @admiral.string(scrape_url_option, description="Target URL"),
     @admiral.string(scrape_html_option, description="Path to local HTML file"),
     @admiral.string(scrape_wait_until_option, description="Page load strategy"),
-    @admiral.string(
-      scrape_selector_option,
-      description="CSS selector",
-      required=true,
-    ),
+    @admiral.string(scrape_selector_option, description="CSS selector"),
+    @admiral.string(config_option, description="Path to JSON config file"),
   ])
 }
 
 ///|
 async fn scrape_options(matches : @argparse.Matches) -> ScrapeOptionsInput {
+  let config = load_config(matches)
   {
-    account_id: match matches.values.get(scrape_account_id_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_account_id_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "account-id is required. Set CLOUDFLARE_ACCOUNT_ID or pass --account-id",
-            )
-        }
-    },
-    api_token: match matches.values.get(scrape_api_token_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_api_token_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "api-token is required. Set CLOUDFLARE_API_TOKEN or pass --api-token",
-            )
-        }
-    },
-    url: match matches.values.get(scrape_url_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    html: match matches.values.get(scrape_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
-      _ => None
-    },
-    wait_until: match matches.values.get(scrape_wait_until_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    selector: match matches.values.get(scrape_selector_option) {
-      Some([value, ..]) => value
-      _ => fail("missing required option: selector")
-    },
+    account_id: merged_account_id(matches, config),
+    api_token: merged_api_token(matches, config),
+    url: merge_string(cli_string(matches, scrape_url_option), config.url),
+    html: merged_html(matches, scrape_html_option, config),
+    wait_until: merge_string(
+      cli_string(matches, scrape_wait_until_option),
+      config.wait_until,
+    ),
+    selector: required_value(
+      "selector",
+      merge_string(cli_string(matches, scrape_selector_option), config.selector),
+    ),
   }
 }
 
 ///|
 fn ScrapeBody::from_options(options : ScrapeOptionsInput) -> ScrapeBody raise {
-  guard options.url is Some(_) || options.html is Some(_) else {
-    fail("Either --url or --html is required")
-  }
+  required_body_source(options.url, options.html)
   {
     url: options.url,
     html: options.html,

--- a/mbt/app/bw/src/command_screenshot.mbt
+++ b/mbt/app/bw/src/command_screenshot.mbt
@@ -165,7 +165,6 @@ fn screenshot_command_def() -> @admiral.CommandDef {
       screenshot_output_option,
       short='o',
       description="Output file path",
-      required=true,
     ),
     @admiral.bool(
       screenshot_full_page_option,
@@ -173,6 +172,7 @@ fn screenshot_command_def() -> @admiral.CommandDef {
     ),
     @admiral.int(screenshot_width_option, description="Viewport width"),
     @admiral.int(screenshot_height_option, description="Viewport height"),
+    @admiral.string(config_option, description="Path to JSON config file"),
   ])
 }
 
@@ -180,54 +180,27 @@ fn screenshot_command_def() -> @admiral.CommandDef {
 async fn screenshot_options(
   matches : @argparse.Matches,
 ) -> ScreenshotOptionsInput {
+  let config = load_config(matches)
   {
-    account_id: match matches.values.get(screenshot_account_id_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_account_id_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "account-id is required. Set CLOUDFLARE_ACCOUNT_ID or pass --account-id",
-            )
-        }
-    },
-    api_token: match matches.values.get(screenshot_api_token_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_api_token_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "api-token is required. Set CLOUDFLARE_API_TOKEN or pass --api-token",
-            )
-        }
-    },
-    url: match matches.values.get(screenshot_url_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    html: match matches.values.get(screenshot_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
-      _ => None
-    },
-    wait_until: match matches.values.get(screenshot_wait_until_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    output: match matches.values.get(screenshot_output_option) {
-      Some([value, ..]) => value
-      _ => fail("missing required option: output")
-    },
-    full_page: matches.flags.get(screenshot_full_page_option).unwrap_or(false),
-    width: match matches.values.get(screenshot_width_option) {
-      Some([value, ..]) => Some(@string.parse_int(value))
-      _ => None
-    },
-    height: match matches.values.get(screenshot_height_option) {
-      Some([value, ..]) => Some(@string.parse_int(value))
-      _ => None
-    },
+    account_id: merged_account_id(matches, config),
+    api_token: merged_api_token(matches, config),
+    url: merge_string(cli_string(matches, screenshot_url_option), config.url),
+    html: merged_html(matches, screenshot_html_option, config),
+    wait_until: merge_string(
+      cli_string(matches, screenshot_wait_until_option),
+      config.wait_until,
+    ),
+    output: required_value(
+      "output",
+      merge_string(cli_string(matches, screenshot_output_option), config.output),
+    ),
+    full_page: merge_bool(
+      matches.flags.get(screenshot_full_page_option).unwrap_or(false),
+      config.full_page,
+      false,
+    ),
+    width: merge_int(cli_int(matches, screenshot_width_option), config.width),
+    height: merge_int(cli_int(matches, screenshot_height_option), config.height),
   }
 }
 
@@ -235,9 +208,7 @@ async fn screenshot_options(
 fn ScreenshotBody::from_options(
   options : ScreenshotOptionsInput,
 ) -> ScreenshotBody raise {
-  guard options.url is Some(_) || options.html is Some(_) else {
-    fail("Either --url or --html is required")
-  }
+  required_body_source(options.url, options.html)
   {
     url: options.url,
     html: options.html,

--- a/mbt/app/bw/src/command_snapshot.mbt
+++ b/mbt/app/bw/src/command_snapshot.mbt
@@ -123,58 +123,37 @@ fn snapshot_command_def() -> @admiral.CommandDef {
         snapshot_output_option,
         short='o',
         description="Output directory",
-        required=true,
       ),
       @admiral.bool(
         snapshot_full_page_option,
         description="Capture entire page",
       ),
+      @admiral.string(config_option, description="Path to JSON config file"),
     ],
   )
 }
 
 ///|
 async fn snapshot_options(matches : @argparse.Matches) -> SnapshotOptionsInput {
+  let config = load_config(matches)
   {
-    account_id: match matches.values.get(snapshot_account_id_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_account_id_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "account-id is required. Set CLOUDFLARE_ACCOUNT_ID or pass --account-id",
-            )
-        }
-    },
-    api_token: match matches.values.get(snapshot_api_token_option) {
-      Some([value, ..]) => value
-      _ =>
-        match @env.get_env_var(cloudflare_api_token_env) {
-          Some(value) => value
-          None =>
-            fail(
-              "api-token is required. Set CLOUDFLARE_API_TOKEN or pass --api-token",
-            )
-        }
-    },
-    url: match matches.values.get(snapshot_url_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    html: match matches.values.get(snapshot_html_option) {
-      Some([path, ..]) => Some(@fs.read_file(path).text())
-      _ => None
-    },
-    wait_until: match matches.values.get(snapshot_wait_until_option) {
-      Some([value, ..]) => Some(value)
-      _ => None
-    },
-    output: match matches.values.get(snapshot_output_option) {
-      Some([value, ..]) => value
-      _ => fail("missing required option: output")
-    },
-    full_page: matches.flags.get(snapshot_full_page_option).unwrap_or(false),
+    account_id: merged_account_id(matches, config),
+    api_token: merged_api_token(matches, config),
+    url: merge_string(cli_string(matches, snapshot_url_option), config.url),
+    html: merged_html(matches, snapshot_html_option, config),
+    wait_until: merge_string(
+      cli_string(matches, snapshot_wait_until_option),
+      config.wait_until,
+    ),
+    output: required_value(
+      "output",
+      merge_string(cli_string(matches, snapshot_output_option), config.output),
+    ),
+    full_page: merge_bool(
+      matches.flags.get(snapshot_full_page_option).unwrap_or(false),
+      config.full_page,
+      false,
+    ),
   }
 }
 
@@ -182,9 +161,7 @@ async fn snapshot_options(matches : @argparse.Matches) -> SnapshotOptionsInput {
 fn SnapshotBody::from_options(
   options : SnapshotOptionsInput,
 ) -> SnapshotBody raise {
-  guard options.url is Some(_) || options.html is Some(_) else {
-    fail("Either --url or --html is required")
-  }
+  required_body_source(options.url, options.html)
   {
     url: options.url,
     html: options.html,

--- a/mbt/app/bw/src/config.mbt
+++ b/mbt/app/bw/src/config.mbt
@@ -1,0 +1,266 @@
+///|
+let config_option = "config"
+
+///|
+struct BwConfig {
+  account_id : String?
+  api_token : String?
+  url : String?
+  html : String?
+  wait_until : String?
+  output : String?
+  full_page : Bool?
+  width : Int?
+  height : Int?
+  landscape : Bool?
+  format : String?
+  selector : String?
+  prompt : String?
+  schema : String?
+  id : String?
+  limit : Int?
+  depth : Int?
+  formats : Array[String]?
+  visible_only : Bool?
+  internal_only : Bool?
+}
+
+///|
+fn empty_config() -> BwConfig {
+  {
+    account_id: None,
+    api_token: None,
+    url: None,
+    html: None,
+    wait_until: None,
+    output: None,
+    full_page: None,
+    width: None,
+    height: None,
+    landscape: None,
+    format: None,
+    selector: None,
+    prompt: None,
+    schema: None,
+    id: None,
+    limit: None,
+    depth: None,
+    formats: None,
+    visible_only: None,
+    internal_only: None,
+  }
+}
+
+///|
+fn config_string(object : Map[String, Json], key : String) -> String? raise {
+  match object.get(key) {
+    Some(String(value)) => Some(value)
+    Some(_) => fail("config key '\{key}' must be a string")
+    None => None
+  }
+}
+
+///|
+fn config_bool(object : Map[String, Json], key : String) -> Bool? raise {
+  match object.get(key) {
+    Some(True) => Some(true)
+    Some(False) => Some(false)
+    Some(_) => fail("config key '\{key}' must be a boolean")
+    None => None
+  }
+}
+
+///|
+fn config_int(object : Map[String, Json], key : String) -> Int? raise {
+  match object.get(key) {
+    Some(Number(value, ..)) => Some(value.to_int())
+    Some(_) => fail("config key '\{key}' must be a number")
+    None => None
+  }
+}
+
+///|
+fn config_string_array(
+  object : Map[String, Json],
+  key : String,
+) -> Array[String]? raise {
+  match object.get(key) {
+    Some(Array(items)) => {
+      let values : Array[String] = []
+      for item in items {
+        match item {
+          String(value) => values.push(value)
+          _ => fail("config key '\{key}' must contain only strings")
+        }
+      }
+      Some(values)
+    }
+    Some(_) => fail("config key '\{key}' must be an array of strings")
+    None => None
+  }
+}
+
+///|
+fn parse_config_object(object : Map[String, Json]) -> BwConfig raise {
+  {
+    account_id: config_string(object, "account_id"),
+    api_token: config_string(object, "api_token"),
+    url: config_string(object, "url"),
+    html: config_string(object, "html"),
+    wait_until: config_string(object, "wait_until"),
+    output: config_string(object, "output"),
+    full_page: config_bool(object, "full_page"),
+    width: config_int(object, "width"),
+    height: config_int(object, "height"),
+    landscape: config_bool(object, "landscape"),
+    format: config_string(object, "format"),
+    selector: config_string(object, "selector"),
+    prompt: config_string(object, "prompt"),
+    schema: config_string(object, "schema"),
+    id: config_string(object, "id"),
+    limit: config_int(object, "limit"),
+    depth: config_int(object, "depth"),
+    formats: config_string_array(object, "formats"),
+    visible_only: config_bool(object, "visible_only"),
+    internal_only: config_bool(object, "internal_only"),
+  }
+}
+
+///|
+async fn load_config(matches : @argparse.Matches) -> BwConfig {
+  match matches.values.get(config_option) {
+    Some([path, ..]) => {
+      let parsed = @json.parse(@fs.read_file(path).text()) catch {
+        error => fail("Invalid config JSON: \{error}")
+      }
+      match parsed {
+        Object(object) => parse_config_object(object)
+        _ => fail("config file must contain a JSON object")
+      }
+    }
+    _ => empty_config()
+  }
+}
+
+///|
+fn cli_string(matches : @argparse.Matches, option : String) -> String? {
+  match matches.values.get(option) {
+    Some([value, ..]) => Some(value)
+    _ => None
+  }
+}
+
+///|
+fn cli_int(matches : @argparse.Matches, option : String) -> Int? raise {
+  match cli_string(matches, option) {
+    Some(value) => Some(@string.parse_int(value))
+    None => None
+  }
+}
+
+///|
+fn merge_string(cli : String?, config : String?) -> String? {
+  match cli {
+    Some(value) => Some(value)
+    None => config
+  }
+}
+
+///|
+fn merge_bool(cli : Bool, config : Bool?, default : Bool) -> Bool {
+  if cli {
+    true
+  } else {
+    config.unwrap_or(default)
+  }
+}
+
+///|
+fn merge_int(cli : Int?, config : Int?) -> Int? {
+  match cli {
+    Some(value) => Some(value)
+    None => config
+  }
+}
+
+///|
+fn merge_string_array(
+  cli : Array[String]?,
+  config : Array[String]?,
+) -> Array[String]? {
+  match cli {
+    Some(value) => Some(value)
+    None => config
+  }
+}
+
+///|
+fn required_value(name : String, value : String?) -> String raise {
+  match value {
+    Some(value) => value
+    None => fail("missing required option: \{name}")
+  }
+}
+
+///|
+fn required_body_source(url : String?, html : String?) -> Unit raise {
+  guard url is Some(_) || html is Some(_) else {
+    fail("Either --url or --html is required")
+  }
+}
+
+///|
+fn merged_account_id(
+  matches : @argparse.Matches,
+  config : BwConfig,
+) -> String raise {
+  match merge_string(cli_string(matches, "account-id"), config.account_id) {
+    Some(value) => value
+    None =>
+      match @env.get_env_var(cloudflare_account_id_env) {
+        Some(value) => value
+        None =>
+          fail(
+            "account-id is required. Set CLOUDFLARE_ACCOUNT_ID, pass --account-id, or set account_id in --config",
+          )
+      }
+  }
+}
+
+///|
+fn merged_api_token(
+  matches : @argparse.Matches,
+  config : BwConfig,
+) -> String raise {
+  match merge_string(cli_string(matches, "api-token"), config.api_token) {
+    Some(value) => value
+    None =>
+      match @env.get_env_var(cloudflare_api_token_env) {
+        Some(value) => value
+        None =>
+          fail(
+            "api-token is required. Set CLOUDFLARE_API_TOKEN, pass --api-token, or set api_token in --config",
+          )
+      }
+  }
+}
+
+///|
+async fn merged_html(
+  matches : @argparse.Matches,
+  option : String,
+  config : BwConfig,
+) -> String? {
+  match merge_string(cli_string(matches, option), config.html) {
+    Some(path) => Some(@fs.read_file(path).text())
+    None => None
+  }
+}
+
+///|
+async fn schema_response_format(path : String) -> Json {
+  let schema = @json.parse(@fs.read_file(path).text()) catch {
+    error => fail("Invalid JSON schema file: \{error}")
+  }
+  Json::object({ "schema": schema, "type": "json_schema".to_json() })
+}

--- a/mbt/app/bw/src/config_wbtest.mbt
+++ b/mbt/app/bw/src/config_wbtest.mbt
@@ -1,0 +1,38 @@
+///|
+test "parse_config_object reads snake_case config keys" {
+  let raw =
+    #|{
+    #|  "account_id": "acct",
+    #|  "api_token": "token",
+    #|  "url": "https://example.com",
+    #|  "wait_until": "networkidle",
+    #|  "output": "out.png",
+    #|  "full_page": true,
+    #|  "width": 1024,
+    #|  "height": 768,
+    #|  "formats": ["html", "markdown"]
+    #|}
+  let parsed = @json.parse(raw)
+  let config = match parsed {
+    Object(object) => parse_config_object(object)
+    _ => fail("expected object")
+  }
+  assert_eq(config.account_id, Some("acct"))
+  assert_eq(config.api_token, Some("token"))
+  assert_eq(config.url, Some("https://example.com"))
+  assert_eq(config.wait_until, Some("networkidle"))
+  assert_eq(config.output, Some("out.png"))
+  assert_eq(config.full_page, Some(true))
+  assert_eq(config.width, Some(1024))
+  assert_eq(config.height, Some(768))
+  assert_eq(config.formats, Some(["html", "markdown"]))
+}
+
+///|
+test "merge helpers prefer cli over config over default" {
+  assert_eq(merge_string(Some("cli"), Some("config")), Some("cli"))
+  assert_eq(merge_string(None, Some("config")), Some("config"))
+  assert_eq(merge_bool(true, Some(false), false), true)
+  assert_eq(merge_bool(false, Some(true), false), true)
+  assert_eq(merge_bool(false, None, false), false)
+}


### PR DESCRIPTION
## 概要

- bw の全コマンド/サブコマンドに `--config <path>` を追加
- 入力値を `CLI option > config > default/env` の順で解決
- `output` / `selector` / `prompt` / crawl `id` の必須判定を config 結合後に移動
- README に config の使い方と JSON 例を追加

## 検証

- `moon check --target native`（`mbt/app/bw`）
- `moon test --target native`（`mbt/app/bw`）
- `moon build --target native`（`mbt/app/bw`）
- `moon fmt`（`mbt/app/bw`）
- `vp run --filter @totto2727/bw build`
- `vp run mbt:test`
- `git diff --check`
- config smoke: screenshot/markdown/crawl status の `--config` 受理と parser-level required 解除を確認

Linear: TOT-15