### PR TITLE
ユーザー作成時に初期ユーザー名を設定する

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -6,5 +6,12 @@ plan_mode_reasoning_effort = "xhigh"
 command = "linear-mcp"
 args = []
 
+# Managed by LazyCodex: multi_agent_v2 is re-disabled on every Codex session start
+# because enabling it fails every turn with HTTP 400 (openai/codex#26753).
+# Opt out: LAZYCODEX_CONFIG_MIGRATION_DISABLED=1 (or OMO_CODEX_CONFIG_MIGRATION_DISABLED=1).
 [features.multi_agent_v2]
+enabled = false
 max_concurrent_threads_per_session = 16
+
+[agents]
+max_threads = 1000

--- a/js/app/identity-provider/app/feature/auth/better-auth.ts
+++ b/js/app/identity-provider/app/feature/auth/better-auth.ts
@@ -4,6 +4,7 @@ import { betterAuth } from 'better-auth'
 import { jwt, magicLink } from 'better-auth/plugins'
 import { Context, Effect, Layer, Predicate } from 'effect'
 
+import { initialUserName } from '#@/feature/auth/user-name.ts'
 import * as BetterAuthDB from '#@/feature/db/better-auth-kysely.ts'
 import * as EmailSender from '#@/feature/email/sender.ts'
 import * as Env from '#@/feature/env.ts'
@@ -32,6 +33,13 @@ const makeInstance = (db: BetterAuthDB.Instance, env: Env.Type, emailSender: Ema
     basePath: '/api/v1/auth',
     baseURL: origin,
     database: { db, type: 'sqlite' },
+    databaseHooks: {
+      user: {
+        create: {
+          before: (user) => Promise.resolve({ data: { ...user, name: initialUserName(user) } }),
+        },
+      },
+    },
     plugins: [
       passkey({
         origin,

--- a/js/app/identity-provider/app/feature/auth/user-name.test.ts
+++ b/js/app/identity-provider/app/feature/auth/user-name.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vite-plus/test'
+
+import { initialUserName } from './user-name.ts'
+
+describe('initialUserName', () => {
+  test('uses the email local part when the supplied name is blank', () => {
+    const user = { email: 'alice@example.com', name: '' }
+
+    const name = initialUserName(user)
+
+    expect(name).toBe('alice')
+  })
+
+  test('keeps a supplied non-blank name', () => {
+    const user = { email: 'alice@example.com', name: 'Alice Example' }
+
+    const name = initialUserName(user)
+
+    expect(name).toBe('Alice Example')
+  })
+})

--- a/js/app/identity-provider/app/feature/auth/user-name.ts
+++ b/js/app/identity-provider/app/feature/auth/user-name.ts
@@ -1,0 +1,15 @@
+import { String } from 'effect'
+
+interface UserNameSource {
+  readonly email: string
+  readonly name: string
+}
+
+export const initialUserName = ({ email, name }: UserNameSource): string => {
+  if (String.isNonEmpty(name.trim())) {
+    return name
+  }
+
+  const separatorIndex = email.lastIndexOf('@')
+  return separatorIndex > 0 ? email.slice(0, separatorIndex) : email
+}


### PR DESCRIPTION
## 概要

- ユーザー作成時に、入力された名前が空白の場合はメールアドレスのローカル部を初期ユーザー名として設定
- 空白でない名前はそのまま保持

```mermaid
flowchart TD
  A[ユーザー作成] --> B{名前が空白か}
  B -->|Yes| C[メールアドレスのローカル部を設定]
  B -->|No| D[入力された名前を保持]
```

## Testing

- `initialUserName` の単体テストを追加
- 空白の名前からメールアドレスのローカル部を生成するケースを検証
- 入力済みの名前を保持するケースを検証