### PR TITLE
Add a native MoonBit SDK for managing OpenCode servers

### DIFF
--- a/mbt/package/admiral/moon.mod
+++ b/mbt/package/admiral/moon.mod
@@ -13,7 +13,7 @@ keywords = [ "cli", "argparse", "moonbit" ]
 description = "Async-first declarative CLI builder for MoonBit, inspired by gunshi"
 
 import {
-  "moonbitlang/async@0.19.2",
+  "moonbitlang/async@0.20.1",
 }
 
 preferred_target = "native"

--- a/mbt/package/opencode-sdk/README.md
+++ b/mbt/package/opencode-sdk/README.md
@@ -1,0 +1,26 @@
+# opencode-sdk
+
+Native MoonBit SDK for starting and managing an [OpenCode server](https://opencode.ai/docs/server/).
+
+The server lifecycle follows the handwritten TypeScript SDK contract. The SDK returns a configured [`DC-Z-lab/moonllm`](https://mooncakes.io/docs/DC-Z-lab/moonllm@0.1.0) builder when an application needs to communicate with the managed server, but it does not own or wrap the HTTP client.
+
+## Usage
+
+```mbt
+@async.with_task_group() <| group => {
+  let server = @opencode.create_opencode_server(group)
+  try {
+    let client = server.moonllm_config().build()
+    let health = client.get_json("/global/health")
+    println(@debug.to_string(health))
+  } catch {
+    err => {
+      server.close()
+      raise err
+    }
+  }
+  server.close()
+}
+```
+
+The task group must outlive the returned server. Call `Server::close` inside the task-group body on both success and failure; task-group defers run only after child tasks finish, while the managed server is itself a long-lived child task.

--- a/mbt/package/opencode-sdk/README.md
+++ b/mbt/package/opencode-sdk/README.md
@@ -24,3 +24,21 @@ The server lifecycle follows the handwritten TypeScript SDK contract. The SDK re
 ```
 
 The task group must outlive the returned server. Call `Server::close` inside the task-group body on both success and failure; task-group defers run only after child tasks finish, while the managed server is itself a long-lived child task.
+
+## CLI examples
+
+The example executable starts a managed OpenCode server, uses the SDK's `moonllm_config` builder, and closes the server before its task group exits. OpenCode uses the provider and model configured in the user's environment.
+
+Translate text into English without allowing any tools:
+
+```bash
+moon run --target native mbt/package/opencode-sdk/src/examples/cli -- translate 'MoonBitでOpenCode SDKを実装しています。'
+```
+
+Fetch an HTTP or HTTPS page with OpenCode's `webfetch` tool and summarize it as Markdown:
+
+```bash
+moon run --target native mbt/package/opencode-sdk/src/examples/cli -- summarize-url https://example.com
+```
+
+The translation session denies every tool. The URL summarization session also denies every tool by default, then allows only `webfetch` through OpenCode's [permission rules](https://opencode.ai/docs/permissions/).

--- a/mbt/package/opencode-sdk/moon.mod
+++ b/mbt/package/opencode-sdk/moon.mod
@@ -1,0 +1,26 @@
+name = "totto2727/opencode-sdk"
+
+version = "0.1.0"
+
+readme = "README.md"
+
+repository = "https://github.com/totto2727-org/monorepo"
+
+license = "MIT"
+
+keywords = [ "opencode", "sdk", "server", "process" ]
+
+description = "Native MoonBit SDK for starting and managing an OpenCode server"
+
+import {
+  "DC-Z-lab/moonllm@0.1.0",
+  "moonbitlang/async@0.20.1",
+}
+
+preferred_target = "native"
+
+source = "src"
+
+options(
+  exclude: [ "package.json", "vite.config.ts" ],
+)

--- a/mbt/package/opencode-sdk/moon.mod
+++ b/mbt/package/opencode-sdk/moon.mod
@@ -15,6 +15,7 @@ description = "Native MoonBit SDK for starting and managing an OpenCode server"
 import {
   "DC-Z-lab/moonllm@0.1.0",
   "moonbitlang/async@0.20.1",
+  "totto2727/admiral@0.4.0",
 }
 
 preferred_target = "native"

--- a/mbt/package/opencode-sdk/package.json
+++ b/mbt/package/opencode-sdk/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@totto2727/opencode-sdk",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "vite-plus": "catalog:"
+  }
+}

--- a/mbt/package/opencode-sdk/src/examples/cli/command_summarize_url.mbt
+++ b/mbt/package/opencode-sdk/src/examples/cli/command_summarize_url.mbt
@@ -1,0 +1,55 @@
+///|
+let summarize_url_argument : @admiral.PositionDef[String] = @admiral.position_string(
+  "url",
+  description="HTTP or HTTPS URL to summarize",
+  required=true,
+)
+
+///|
+struct SummarizeUrlOptions {
+  url : String
+}
+
+///|
+fn validated_http_url(url : String) -> String raise {
+  guard url.has_prefix("https://") || url.has_prefix("http://") else {
+    fail("url must start with http:// or https://")
+  }
+  url
+}
+
+///|
+fn summarize_url_options(
+  context : @admiral.Context,
+) -> SummarizeUrlOptions raise {
+  let url = context
+    .get_string_required(summarize_url_argument)
+    |> validated_http_url
+  { url, }
+}
+
+///|
+fn summarize_url_command_def(
+  run : async (@admiral.Context) -> Unit,
+) -> @admiral.CommandDef {
+  @admiral.command(
+    name="summarize-url",
+    description="Fetch a web page and summarize it as Markdown",
+    positionals=[summarize_url_argument],
+    examples=["opencode-example summarize-url https://example.com"],
+    run=Some(run),
+  )
+}
+
+///|
+async fn run_summarize_url(context : @admiral.Context) -> Unit {
+  let options = summarize_url_options(context)
+  let output = run_prompt({
+    title: "URL summary",
+    tool_access: WebFetchOnly,
+    system:
+      "Use the webfetch tool to fetch the URL supplied by the user. Summarize the page accurately as Markdown with a title, a concise overview, key points, and a source link. Do not use any tool other than webfetch. Return only Markdown.",
+    text: "Fetch and summarize this URL: \{options.url}",
+  })
+  println(output)
+}

--- a/mbt/package/opencode-sdk/src/examples/cli/command_translate.mbt
+++ b/mbt/package/opencode-sdk/src/examples/cli/command_translate.mbt
@@ -1,0 +1,42 @@
+///|
+let translate_text_argument : @admiral.PositionDef[String] = @admiral.position_string(
+  "text",
+  description="Text to translate into English",
+  required=true,
+)
+
+///|
+struct TranslateOptions {
+  text : String
+}
+
+///|
+fn translate_options(context : @admiral.Context) -> TranslateOptions raise {
+  { text: context.get_string_required(translate_text_argument) }
+}
+
+///|
+fn translate_command_def(
+  run : async (@admiral.Context) -> Unit,
+) -> @admiral.CommandDef {
+  @admiral.command(
+    name="translate",
+    description="Translate text into English without tools",
+    positionals=[translate_text_argument],
+    examples=["opencode-example translate 'MoonBitでSDKを実装しています。'"],
+    run=Some(run),
+  )
+}
+
+///|
+async fn run_translate(context : @admiral.Context) -> Unit {
+  let options = translate_options(context)
+  let output = run_prompt({
+    title: "English translation",
+    tool_access: NoTools,
+    system:
+      "You are a professional translator. Translate the user's text into natural English. Preserve its meaning, tone, names, and formatting. Return only the English translation with no commentary.",
+    text: options.text,
+  })
+  println(output)
+}

--- a/mbt/package/opencode-sdk/src/examples/cli/main.mbt
+++ b/mbt/package/opencode-sdk/src/examples/cli/main.mbt
@@ -1,0 +1,12 @@
+///|
+async fn main {
+  let app = @admiral.cli(
+    name="opencode-example",
+    description="OpenCode server management SDK examples",
+    commands=[
+      translate_command_def(run_translate),
+      summarize_url_command_def(run_summarize_url),
+    ],
+  )
+  app.run()
+}

--- a/mbt/package/opencode-sdk/src/examples/cli/moon.pkg
+++ b/mbt/package/opencode-sdk/src/examples/cli/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "DC-Z-lab/moonllm",
+  "moonbitlang/async",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+  "totto2727/admiral",
+  "totto2727/opencode-sdk" @opencode,
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")

--- a/mbt/package/opencode-sdk/src/examples/cli/session.mbt
+++ b/mbt/package/opencode-sdk/src/examples/cli/session.mbt
@@ -1,0 +1,182 @@
+///|
+enum ToolAccess {
+  NoTools
+  WebFetchOnly
+}
+
+///|
+struct PermissionRule {
+  permission : String
+  pattern : String
+  action : String
+}
+
+///|
+impl ToJson for PermissionRule with fn to_json(self) -> Json {
+  Json::object({
+    "permission": self.permission.to_json(),
+    "pattern": self.pattern.to_json(),
+    "action": self.action.to_json(),
+  })
+}
+
+///|
+fn ToolAccess::permission_rules(self : ToolAccess) -> Array[PermissionRule] {
+  // OpenCode evaluates the last matching permission rule. Deny everything
+  // first, then allow only webfetch for the URL summarizer:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/opencode/src/permission/index.ts#L28-L37
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/opencode/src/tool/webfetch.ts#L13-L26
+  let deny_all : PermissionRule = {
+    permission: "*",
+    pattern: "*",
+    action: "deny",
+  }
+  match self {
+    NoTools => [deny_all]
+    WebFetchOnly => [
+      deny_all,
+      { permission: "webfetch", pattern: "*", action: "allow" },
+    ]
+  }
+}
+
+///|
+struct SessionCreateBody {
+  title : String
+  tool_access : ToolAccess
+}
+
+///|
+impl ToJson for SessionCreateBody with fn to_json(self) -> Json {
+  // OpenCode session creation accepts title and a permission ruleset:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/v2/gen/types.gen.ts#L9469-L9507
+  Json::object({
+    "title": self.title.to_json(),
+    "permission": self.tool_access.permission_rules().to_json(),
+  })
+}
+
+///|
+extend SessionCreateBody with ToJson::{to_json}
+
+///|
+struct PromptBody {
+  system : String
+  text : String
+}
+
+///|
+impl ToJson for PromptBody with fn to_json(self) -> Json {
+  // OpenCode's prompt endpoint accepts a system prompt, output format, and
+  // typed input parts:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/v2/gen/types.gen.ts#L9790-L9837
+  Json::object({
+    "format": Json::object({ "type": "text".to_json() }),
+    "system": self.system.to_json(),
+    "parts": Json::array([
+      Json::object({
+        "type": "text".to_json(),
+        "text": self.text.to_json(),
+      }),
+    ]),
+  })
+}
+
+///|
+extend PromptBody with ToJson::{to_json}
+
+///|
+struct PromptRequest {
+  title : String
+  tool_access : ToolAccess
+  system : String
+  text : String
+}
+
+///|
+fn decode_session_id(response : Json) -> String raise {
+  // OpenCode returns the created Session directly:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/v2/gen/types.gen.ts#L9469-L9507
+  guard response is Json::Object(fields) else {
+    fail("OpenCode returned a non-object session response")
+  }
+  match fields.get("id") {
+    Some(Json::String(id)) => id
+    _ => fail("OpenCode session response is missing a string id")
+  }
+}
+
+///|
+fn decode_assistant_text(response : Json) -> String raise {
+  // OpenCode returns a message info object and typed output parts:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/v2/gen/types.gen.ts#L9790-L9837
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/v2/gen/types.gen.ts#L378-L393
+  guard response is Json::Object(fields) else {
+    fail("OpenCode returned a non-object prompt response")
+  }
+  guard fields.get("info") is Some(Json::Object(info)) else {
+    fail("OpenCode prompt response is missing message info")
+  }
+  match info.get("error") {
+    None | Some(Json::Null) => ()
+    Some(error) =>
+      fail("OpenCode assistant failed: \{@debug.to_string(error)}")
+  }
+  guard fields.get("parts") is Some(Json::Array(parts)) else {
+    fail("OpenCode prompt response is missing message parts")
+  }
+  let texts : Array[String] = []
+  for part in parts {
+    match part {
+      Json::Object(part_fields) =>
+        match (part_fields.get("type"), part_fields.get("text")) {
+          (Some(Json::String(kind)), Some(Json::String(text))) =>
+            if kind == "text" {
+              texts.push(text)
+            }
+          _ => ()
+        }
+      _ => ()
+    }
+  }
+  guard !texts.is_empty() else {
+    fail("OpenCode assistant returned no text")
+  }
+  texts.join("")
+}
+
+///|
+async fn run_prompt(request : PromptRequest) -> String raise {
+  @async.with_task_group() <| group => {
+    let server = @opencode.create_opencode_server(group)
+    let result = try {
+      let client = server
+        .moonllm_config()
+        .timeout_ms(180000)
+        .build()
+      // These paths mirror the OpenCode SDK session create and prompt calls:
+      // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/v2/gen/sdk.gen.ts#L3410-L3457
+      // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/v2/gen/sdk.gen.ts#L3742-L3794
+      let session = client.post_json(
+        "/session",
+        SessionCreateBody::{
+          title: request.title,
+          tool_access: request.tool_access,
+        }.to_json(),
+      )
+      let session_id = decode_session_id(session)
+      client.post_json(
+        "/session/\{session_id}/message",
+        PromptBody::{ system: request.system, text: request.text }.to_json(),
+      )
+      |> decode_assistant_text
+    } catch {
+      err => {
+        server.close()
+        raise err
+      }
+    }
+    server.close()
+    result
+  }
+}

--- a/mbt/package/opencode-sdk/src/examples/cli/session_wbtest.mbt
+++ b/mbt/package/opencode-sdk/src/examples/cli/session_wbtest.mbt
@@ -1,0 +1,114 @@
+///|
+// OpenCode session and prompt wire contracts:
+// https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/v2/gen/types.gen.ts#L9469-L9507
+// https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/v2/gen/types.gen.ts#L9790-L9837
+test "SessionCreateBody ToJson 1 - disables every tool" {
+  let body : SessionCreateBody = {
+    title: "English translation",
+    tool_access: NoTools,
+  }
+  json_inspect(ToJson::to_json(body), content={
+    "title": "English translation",
+    "permission": [
+      { "permission": "*", "pattern": "*", "action": "deny" },
+    ],
+  })
+}
+
+///|
+test "SessionCreateBody ToJson 2 - permits only web fetch" {
+  let body : SessionCreateBody = {
+    title: "URL summary",
+    tool_access: WebFetchOnly,
+  }
+  json_inspect(ToJson::to_json(body), content={
+    "title": "URL summary",
+    "permission": [
+      { "permission": "*", "pattern": "*", "action": "deny" },
+      { "permission": "webfetch", "pattern": "*", "action": "allow" },
+    ],
+  })
+}
+
+///|
+test "PromptBody ToJson 1 - sends one text part" {
+  let body : PromptBody = { system: "System", text: "User input" }
+  json_inspect(ToJson::to_json(body), content={
+    "format": { "type": "text" },
+    "system": "System",
+    "parts": [{ "type": "text", "text": "User input" }],
+  })
+}
+
+///|
+test "decode_session_id 1 - extracts the created session ID" {
+  inspect(
+    decode_session_id(Json::object({ "id": "ses_example".to_json() })),
+    content="ses_example",
+  )
+}
+
+///|
+test "decode_assistant_text 1 - concatenates text parts only" {
+  inspect(
+    decode_assistant_text(
+      Json::object({
+        "info": Json::empty_object(),
+        "parts": Json::array([
+          Json::object({
+            "type": "tool".to_json(),
+            "text": "ignored".to_json(),
+          }),
+          Json::object({
+            "type": "text".to_json(),
+            "text": "Hello ".to_json(),
+          }),
+          Json::object({
+            "type": "text".to_json(),
+            "text": "world".to_json(),
+          }),
+        ]),
+      }),
+    ),
+    content="Hello world",
+  )
+}
+
+///|
+test "panic_decode_assistant_text 2 - rejects assistant errors" {
+  try! (
+    decode_assistant_text(
+      Json::object({
+        "info": Json::object({
+          "error": Json::object({
+            "name": "UnknownError".to_json(),
+            "data": Json::object({ "message": "failed".to_json() }),
+          }),
+        }),
+        "parts": Json::array([]),
+      }),
+    )
+    |> ignore
+  )
+}
+
+///|
+test "validated_http_url 1 - accepts HTTPS" {
+  inspect(
+    validated_http_url("https://example.com"),
+    content="https://example.com",
+  )
+}
+
+///|
+test "validated_http_url 2 - accepts HTTP" {
+  inspect(
+    validated_http_url("http://example.com"),
+    content="http://example.com",
+  )
+}
+
+///|
+test "panic_validated_http_url 3 - rejects non-HTTP schemes" {
+  try! (validated_http_url("file:///tmp/page.html") |> ignore)
+}

--- a/mbt/package/opencode-sdk/src/examples/health/main.mbt
+++ b/mbt/package/opencode-sdk/src/examples/health/main.mbt
@@ -1,0 +1,17 @@
+///|
+async fn main {
+  @async.with_task_group() <| group => {
+    let server = @opencode.create_opencode_server(group)
+    try {
+      let client = server.moonllm_config().build()
+      let health = client.get_json("/global/health")
+      println(@debug.to_string(health))
+    } catch {
+      err => {
+        server.close()
+        raise err
+      }
+    }
+    server.close()
+  }
+}

--- a/mbt/package/opencode-sdk/src/examples/health/moon.pkg
+++ b/mbt/package/opencode-sdk/src/examples/health/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "DC-Z-lab/moonllm",
+  "totto2727/opencode-sdk" @opencode,
+  "moonbitlang/async",
+  "moonbitlang/core/debug",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")

--- a/mbt/package/opencode-sdk/src/moon.pkg
+++ b/mbt/package/opencode-sdk/src/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "DC-Z-lab/moonllm",
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/async/process",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+  "moonbitlang/core/string",
+}
+
+import {
+  "moonbitlang/core/test",
+} for "test"
+
+supported_targets = "native"

--- a/mbt/package/opencode-sdk/src/options.mbt
+++ b/mbt/package/opencode-sdk/src/options.mbt
@@ -1,0 +1,29 @@
+///|
+fn config_log_level(config : Json) -> String? {
+  // Copied from the OpenCode TypeScript SDK log-level selection:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L32-L33
+  match config {
+    Json::Object(object) =>
+      match object.get("logLevel") {
+        Some(Json::String(value)) => Some(value)
+        _ => None
+      }
+    _ => None
+  }
+}
+
+///|
+fn server_args(options : ServerOptions) -> Array[String] {
+  // Copied from the OpenCode TypeScript SDK argument construction:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L32-L33
+  let args = [
+    "serve",
+    "--hostname=\{options.hostname}",
+    "--port=\{options.port}",
+  ]
+  match config_log_level(options.config) {
+    Some(log_level) => args.push("--log-level=\{log_level}")
+    None => ()
+  }
+  args
+}

--- a/mbt/package/opencode-sdk/src/server.mbt
+++ b/mbt/package/opencode-sdk/src/server.mbt
@@ -1,0 +1,310 @@
+///|
+// Copied from the OpenCode TypeScript SDK defaults and option shape:
+// https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L5-L30
+let server_listening_prefix = "opencode server listening"
+
+///|
+let startup_poll_interval_ms = 10
+
+///|
+/// Options for starting an OpenCode server.
+///
+/// Defaults match the official TypeScript SDK.
+pub struct ServerOptions {
+  hostname : String
+  port : Int
+  timeout_ms : Int
+  config : Json
+} derive(Debug)
+
+///|
+/// Construct server options using the official SDK defaults.
+pub fn ServerOptions::ServerOptions(
+  hostname? : String = "127.0.0.1",
+  port? : Int = 4096,
+  timeout_ms? : Int = 5000,
+  config? : Json = Json::empty_object(),
+) -> ServerOptions {
+  // Copied from the OpenCode TypeScript SDK defaults:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L22-L30
+  { hostname, port, timeout_ms, config }
+}
+
+///|
+/// Failures that can occur while starting or stopping an OpenCode server.
+pub(all) suberror ServerError {
+  /// The server process or its log files could not be created.
+  StartFailed(String)
+  /// The server did not announce readiness before the configured timeout.
+  StartTimeout(timeout_ms~ : Int, output~ : String)
+  /// The server emitted the readiness prefix without a valid HTTP URL.
+  MalformedOutput(line~ : String)
+  /// The server exited before announcing readiness.
+  ServerExited(code~ : Int, output~ : String)
+  /// A started server could not be stopped or cleaned up.
+  CleanupFailed(String)
+} derive(Debug)
+
+///|
+/// A running OpenCode server owned by the task group passed at creation.
+pub struct Server {
+  url : String
+  process : @process.Process
+  log_dir : String
+  mut closed : Bool
+}
+
+///|
+/// Return the HTTP base URL announced by the OpenCode server.
+pub fn Server::url(self : Server) -> String {
+  self.url
+}
+
+///|
+fn parse_server_url(output : String) -> String? raise ServerError {
+  // Copied from the OpenCode TypeScript SDK readiness parser:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L49-L71
+  for line_view in output.split("\n") {
+    let line = line_view.trim().to_owned()
+    if line.has_prefix(server_listening_prefix) {
+      match line.find(" on ") {
+        Some(index) => {
+          let url = line[index + 4:].trim().to_owned()
+          guard (url.has_prefix("http://") || url.has_prefix("https://")) &&
+            url.find(" ") is None else {
+            raise MalformedOutput(line~)
+          }
+          return Some(url)
+        }
+        None => raise MalformedOutput(line~)
+      }
+    }
+  }
+  None
+}
+
+///|
+async fn read_log(path : String) -> String raise ServerError {
+  @fs.read_file(path).text() catch {
+    err =>
+      raise StartFailed(
+        "failed to read server output: \{@debug.to_string(err)}",
+      )
+  }
+}
+
+///|
+async fn combined_output(
+  stdout_path : String,
+  stderr_path : String,
+) -> String raise ServerError {
+  let stdout = read_log(stdout_path)
+  let stderr = read_log(stderr_path)
+  match (stdout.trim(), stderr.trim()) {
+    ("", "") => ""
+    (_, "") => stdout
+    ("", _) => stderr
+    _ => stdout + "\n" + stderr
+  }
+}
+
+///|
+async fn remove_log_dir(log_dir : String) -> Unit raise ServerError {
+  @fs.rmdir(log_dir, recursive=true) catch {
+    err =>
+      raise CleanupFailed(
+        "failed to remove server logs: \{@debug.to_string(err)}",
+      )
+  }
+}
+
+///|
+async fn stop_process(process : @process.Process) -> Unit raise ServerError {
+  // Adapted from the OpenCode TypeScript SDK process-stop behavior:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/process.ts#L3-L12
+  let process_result = process.try_wait() catch {
+    err if @async.is_cancellation_error(err) => None
+    err =>
+      raise CleanupFailed(
+        "failed to inspect server process: \{@debug.to_string(err)}",
+      )
+  }
+  if process_result is None {
+    process.cancel()
+  }
+  (process.wait() |> ignore) catch {
+    err if @async.is_cancellation_error(err) => ()
+    err =>
+      raise CleanupFailed(
+        "failed to wait for server process: \{@debug.to_string(err)}",
+      )
+  }
+}
+
+///|
+async fn cleanup_start_failure(
+  process : @process.Process,
+  log_dir : String,
+) -> Unit raise ServerError {
+  stop_process(process)
+  remove_log_dir(log_dir)
+}
+
+///|
+async fn wait_for_server(
+  process : @process.Process,
+  stdout_path : String,
+  stderr_path : String,
+  timeout_ms : Int,
+) -> String raise ServerError {
+  // Adapted from the OpenCode TypeScript SDK timeout, output, and early-exit
+  // handling:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L43-L91
+  let mut elapsed_ms = 0
+  for ;; {
+    let stdout = read_log(stdout_path)
+    match parse_server_url(stdout) {
+      Some(url) => return url
+      None => ()
+    }
+    match (process.try_wait() catch {
+      err =>
+        raise StartFailed(
+          "failed to inspect server process: \{@debug.to_string(err)}",
+        )
+    }) {
+      Some(code) => {
+        let output = combined_output(stdout_path, stderr_path)
+        raise ServerExited(code~, output~)
+      }
+      None => ()
+    }
+    if elapsed_ms >= timeout_ms {
+      let output = combined_output(stdout_path, stderr_path)
+      raise StartTimeout(timeout_ms~, output~)
+    }
+    @async.sleep(startup_poll_interval_ms) catch {
+      err =>
+        raise StartFailed(
+          "startup wait was interrupted: \{@debug.to_string(err)}",
+        )
+    }
+    elapsed_ms = elapsed_ms + startup_poll_interval_ms
+  }
+}
+
+///|
+async fn[X] create_opencode_server_with_command(
+  group : @async.TaskGroup[X],
+  options : ServerOptions,
+  command : String,
+  extra_env : Map[String, String],
+) -> Server raise ServerError {
+  let log_dir = @fs.tmpdir(prefix="opencode-sdk-") catch {
+    err =>
+      raise StartFailed(
+        "failed to create server log directory: \{@debug.to_string(err)}",
+      )
+  }
+  let stdout_path = "\{log_dir}/stdout.log"
+  let stderr_path = "\{log_dir}/stderr.log"
+  let stdout = @process.redirect_to_file(
+    stdout_path,
+    create_mode=CreateOrTruncate,
+  ) catch {
+    err => {
+      remove_log_dir(log_dir)
+      raise StartFailed(
+        "failed to redirect server stdout: \{@debug.to_string(err)}",
+      )
+    }
+  }
+  let stderr = @process.redirect_to_file(
+    stderr_path,
+    create_mode=CreateOrTruncate,
+  ) catch {
+    err => {
+      remove_log_dir(log_dir)
+      raise StartFailed(
+        "failed to redirect server stderr: \{@debug.to_string(err)}",
+      )
+    }
+  }
+  let env : Map[String, String] = Map([])
+  for key, value in extra_env {
+    env[key] = value
+  }
+  // Copied from the OpenCode TypeScript SDK process environment:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L35-L40
+  env["OPENCODE_CONFIG_CONTENT"] = options.config.stringify()
+  let process = @process.spawn(
+    group,
+    command,
+    server_args(options),
+    extra_env=env,
+    stdout~,
+    stderr~,
+    cancel_handler=@process.hard_cancel(),
+  ) catch {
+    err => {
+      remove_log_dir(log_dir)
+      raise StartFailed(
+        "failed to start OpenCode server: \{@debug.to_string(err)}",
+      )
+    }
+  }
+  let url = wait_for_server(
+    process,
+    stdout_path,
+    stderr_path,
+    options.timeout_ms,
+  ) catch {
+    err => {
+      cleanup_start_failure(process, log_dir)
+      raise err
+    }
+  }
+  { url, process, log_dir, closed: false }
+}
+
+///|
+/// Start an OpenCode server in `group`.
+///
+/// The task group must outlive the returned server. The process is started as
+/// `opencode serve`, receives `OPENCODE_CONFIG_CONTENT`, and is hard-cancelled
+/// when startup fails or `close` is called.
+pub async fn[X] create_opencode_server(
+  group : @async.TaskGroup[X],
+  options? : ServerOptions = ServerOptions::ServerOptions(),
+) -> Server raise ServerError {
+  // Copied from the OpenCode TypeScript SDK executable selection:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L32-L40
+  create_opencode_server_with_command(group, options, "opencode", Map([]))
+}
+
+///|
+/// Return moonllm client configuration for this server.
+///
+/// The builder is bound to the announced server URL and uses no automatic
+/// authentication. Callers may add timeout or header settings before `build`.
+pub fn Server::moonllm_config(self : Server) -> @moonllm.ClientBuilder {
+  // Adapted from the OpenCode TypeScript SDK's URL-bound client composition:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/index.ts#L8-L20
+  @moonllm.ClientBuilder::new()
+    .base_url(self.url)
+    .auth(@moonllm.NoAuth)
+}
+
+///|
+/// Stop the server, wait for its process, and remove its temporary logs.
+///
+/// Calling `close` again after a successful close has no effect.
+pub async fn Server::close(self : Server) -> Unit raise ServerError {
+  // Adapted from the OpenCode TypeScript SDK close and process-stop behavior:
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L93-L99
+  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/process.ts#L3-L12
+  guard !self.closed else { return }
+  stop_process(self.process)
+  remove_log_dir(self.log_dir)
+  self.closed = true
+}

--- a/mbt/package/opencode-sdk/src/server_wbtest.mbt
+++ b/mbt/package/opencode-sdk/src/server_wbtest.mbt
@@ -1,0 +1,216 @@
+///|
+async fn write_fake_opencode(root : String) -> String {
+  let path = "\{root}/opencode"
+  let script =
+    #|#!/bin/sh
+    #|printf '%s\n' "$$" > "$OPENCODE_TEST_PID_FILE"
+    #|printf '%s\n' "$@" > "$OPENCODE_TEST_ARGS_FILE"
+    #|printf '%s' "$OPENCODE_CONFIG_CONTENT" > "$OPENCODE_TEST_CONFIG_FILE"
+    #|case "$OPENCODE_TEST_MODE" in
+    #|  ready)
+    #|    printf 'noise before readiness\n'
+    #|    printf 'opencode server listening on http://127.0.0.1:43210\n'
+    #|    while :; do sleep 1; done
+    #|    ;;
+    #|  malformed)
+    #|    printf 'opencode server listening without a url\n'
+    #|    while :; do sleep 1; done
+    #|    ;;
+    #|  timeout)
+    #|    while :; do sleep 1; done
+    #|    ;;
+    #|  exit)
+    #|    printf 'fake startup failure\n' >&2
+    #|    exit 23
+    #|    ;;
+    #|esac
+  @fs.write_file(path, script, create_mode=CreateOrTruncate, permission=0o755)
+  @fs.chmod(path, 0o755)
+  path
+}
+
+///|
+fn fixture_env(root : String, mode : String) -> Map[String, String] {
+  {
+    "OPENCODE_TEST_MODE": mode,
+    "OPENCODE_TEST_PID_FILE": "\{root}/pid",
+    "OPENCODE_TEST_ARGS_FILE": "\{root}/args",
+    "OPENCODE_TEST_CONFIG_FILE": "\{root}/config",
+  }
+}
+
+///|
+async fn fixture_pid(root : String) -> Int {
+  @string.parse_int(@fs.read_file("\{root}/pid").text().trim(), base=10)
+}
+
+///|
+async fn process_is_running(pid : Int) -> Bool {
+  let (code, _, _) = @process.collect_output(
+    "kill",
+    ["-0", pid.to_string()],
+  )
+  code == 0
+}
+
+///|
+// Upstream contract:
+// https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L22-L99
+test "ServerOptions ServerOptions 1 - applies TypeScript SDK defaults" {
+  debug_inspect(
+    ServerOptions::ServerOptions(),
+    content=(
+      #|{
+      #|  hostname: "127.0.0.1",
+      #|  port: 4096,
+      #|  timeout_ms: 5000,
+      #|  config: Object({}),
+      #|}
+    ),
+  )
+}
+
+///|
+test "Server server_args 1 - forwards config log level" {
+  let options = ServerOptions::ServerOptions(
+    hostname="0.0.0.0",
+    port=8080,
+    config=Json::object({ "logLevel": "debug".to_json() }),
+  )
+  json_inspect(server_args(options), content=[
+    "serve", "--hostname=0.0.0.0", "--port=8080", "--log-level=debug",
+  ])
+}
+
+///|
+test "Server parse_server_url 1 - accepts accumulated readiness output" {
+  debug_inspect(
+    parse_server_url(
+      "noise\nopencode server listening on http://127.0.0.1:43210\n",
+    ),
+    content="Some(\"http://127.0.0.1:43210\")",
+  )
+}
+
+///|
+test "panic_Server parse_server_url 2 - rejects malformed readiness output" {
+  try! (
+    parse_server_url("opencode server listening without a url") |> ignore
+  )
+}
+
+///|
+async test "Server create 1 - starts from readiness and closes idempotently" {
+  let root = @fs.tmpdir(prefix="opencode-sdk-ready-")
+  @async.with_task_group() <| group => {
+    group.add_defer(() => @fs.rmdir(root, recursive=true))
+    let command = write_fake_opencode(root)
+    let config = Json::object({
+      "logLevel": "debug".to_json(),
+      "model": "test/model".to_json(),
+    })
+    let server = create_opencode_server_with_command(
+      group,
+      ServerOptions::ServerOptions(timeout_ms=1000, config~),
+      command,
+      fixture_env(root, "ready"),
+    )
+    inspect(server.url(), content="http://127.0.0.1:43210")
+    let moonllm_config : @moonllm.ClientBuilder = server.moonllm_config()
+    moonllm_config.build() |> ignore
+    inspect(
+      @fs.read_file("\{root}/args").text(),
+      content=(
+        #|serve
+        #|--hostname=127.0.0.1
+        #|--port=4096
+        #|--log-level=debug
+        #|
+      ),
+    )
+    json_inspect(
+      @json.parse(@fs.read_file("\{root}/config").text()),
+      content={ "logLevel": "debug", "model": "test/model" },
+    )
+    let pid = fixture_pid(root)
+    assert_true(process_is_running(pid))
+    server.close()
+    server.close()
+    assert_false(process_is_running(pid))
+  }
+}
+
+///|
+async test "Server create 2 - rejects malformed readiness and stops child" {
+  let root = @fs.tmpdir(prefix="opencode-sdk-malformed-")
+  @async.with_task_group() <| group => {
+    group.add_defer(() => @fs.rmdir(root, recursive=true))
+    let command = write_fake_opencode(root)
+    let result = try {
+      create_opencode_server_with_command(
+        group,
+        ServerOptions::ServerOptions(timeout_ms=1000),
+        command,
+        fixture_env(root, "malformed"),
+      )
+      |> ignore
+      "missing error"
+    } catch {
+      MalformedOutput(line~) => "malformed: \{line}"
+      err => "unexpected: \{@debug.to_string(err)}"
+    }
+    inspect(
+      result,
+      content="malformed: opencode server listening without a url",
+    )
+    assert_false(process_is_running(fixture_pid(root)))
+  }
+}
+
+///|
+async test "Server create 3 - times out and stops child" {
+  let root = @fs.tmpdir(prefix="opencode-sdk-timeout-")
+  @async.with_task_group() <| group => {
+    group.add_defer(() => @fs.rmdir(root, recursive=true))
+    let command = write_fake_opencode(root)
+    let result = try {
+      create_opencode_server_with_command(
+        group,
+        ServerOptions::ServerOptions(timeout_ms=1000),
+        command,
+        fixture_env(root, "timeout"),
+      )
+      |> ignore
+      "missing error"
+    } catch {
+      StartTimeout(timeout_ms~, ..) => "timeout: \{timeout_ms}"
+      err => "unexpected: \{@debug.to_string(err)}"
+    }
+    inspect(result, content="timeout: 1000")
+    assert_false(process_is_running(fixture_pid(root)))
+  }
+}
+
+///|
+async test "Server create 4 - reports early exit and leaves no child" {
+  let root = @fs.tmpdir(prefix="opencode-sdk-exit-")
+  @async.with_task_group() <| group => {
+    group.add_defer(() => @fs.rmdir(root, recursive=true))
+    let command = write_fake_opencode(root)
+    let result = try {
+      create_opencode_server_with_command(
+        group,
+        ServerOptions::ServerOptions(timeout_ms=1000),
+        command,
+        fixture_env(root, "exit"),
+      )
+      |> ignore
+      "missing error"
+    } catch {
+      ServerExited(code~, output~) => "exit \{code}: \{output.trim()}"
+      err => "unexpected: \{@debug.to_string(err)}"
+    }
+    inspect(result, content="exit 23: fake startup failure")
+    assert_false(process_is_running(fixture_pid(root)))
+  }
+}

--- a/mbt/package/opencode-sdk/vite.config.ts
+++ b/mbt/package/opencode-sdk/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite-plus'
+
+export default defineConfig({
+  run: {
+    tasks: {
+      build: {
+        command: 'moon build --target native',
+        input: ['moon.mod', '**/*.mbt'],
+      },
+    },
+  },
+})

--- a/mbt/package/opencode-sdk/vite.config.ts
+++ b/mbt/package/opencode-sdk/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     tasks: {
       build: {
         command: 'moon build --target native',
-        input: ['moon.mod', '**/*.mbt'],
+        input: ['moon.mod', '**/moon.pkg', '**/*.mbt'],
       },
     },
   },

--- a/moon.work
+++ b/moon.work
@@ -1,5 +1,6 @@
 members = [
   "./mbt/package/admiral",
+  "./mbt/package/opencode-sdk",
   "./mbt/package/geo-mbt",
   "./mbt/package/target-file-discovery",
   "./mbt/app/bw",


### PR DESCRIPTION
## Summary

- Add `totto2727/opencode-sdk` as a native MoonBit package.
- Implement OpenCode server startup, readiness detection, timeout and exit handling, cleanup, and idempotent shutdown.
- Expose a `moonllm` client builder bound to the managed server URL.
- Register the package in the MoonBit workspace and document usage.

```mermaid
flowchart TD
  A[Create server] --> B[Create temporary logs]
  B --> C[Spawn opencode serve]
  C --> D{Readiness announced?}
  D -->|Yes| E[Return Server and moonllm builder]
  D -->|Malformed| F[Stop process and clean logs]
  D -->|Timeout or early exit| F
  E --> G[Server.close]
  G --> H[Stop process and remove logs]
```

## Testing

- Not run (not requested).
- Unit test coverage includes default options, argument and config forwarding, readiness parsing, successful startup and idempotent close, malformed output, startup timeout, and early process exit.

```mermaid
flowchart TD
  A[Run SDK unit tests] --> B{Startup result}
  B -->|Ready| C[Verify URL, args, config, process, and idempotent close]
  B -->|Malformed output| D[Verify MalformedOutput and child cleanup]
  B -->|Timeout| E[Verify StartTimeout and child cleanup]
  B -->|Early exit| F[Verify ServerExited, output, and child cleanup]
```