### PR TITLE
Fix MoonBit Codex SDK async callback compatibility

### DIFF
--- a/mbt/package/codex-sdk/src/exec.mbt
+++ b/mbt/package/codex-sdk/src/exec.mbt
@@ -180,15 +180,15 @@ async fn CodexExec::run(
   let inherit_environment = self.env_override is None
 
   let moonbit_internal_stop_requested = Ref(false)
-  @async.with_task_group(fn(group) {
+  @async.with_task_group(async fn(group) {
     let (child_input, input_writer) = @process.write_to_process()
     let (output_reader, child_output) = @process.read_from_process()
     let (error_reader, child_error) = @process.read_from_process()
-    group.spawn_bg(fn() {
+    group.spawn_bg(async fn() {
       defer input_writer.close()
       input_writer.write(args.input)
     })
-    let stderr_task = group.spawn(fn() {
+    let stderr_task = group.spawn(async fn() {
       defer error_reader.close()
       error_reader.read_all().text()
     })
@@ -205,7 +205,7 @@ async fn CodexExec::run(
       // Upstream generator cleanup: https://github.com/openai/codex/blob/f201c30c52a35f819262865a53df94b6f4ea7a50/sdk/typescript/src/exec.ts#L235-L242
       cancel_handler=@process.hard_cancel(),
     )
-    let stdout_task = group.spawn(fn() {
+    let stdout_task = group.spawn(async fn() {
       defer output_reader.close()
       while output_reader.read_until("\n") is Some(line) {
         if !on_line(line) {

--- a/mbt/package/codex-sdk/src/output_schema_file.mbt
+++ b/mbt/package/codex-sdk/src/output_schema_file.mbt
@@ -24,18 +24,18 @@ async fn create_output_schema_file(schema : Json?) -> OutputSchemaFile {
       let schema_directory = @fs.tmpdir(prefix="codex-output-schema-")
       let schema_path = @path.Path(schema_directory)
         |> @path.Path::join(@path.Path("schema.json"))
-      let write_result = try? @fs.write_file(
-        "\{schema_path}",
-        schema.stringify(),
-        create_mode=CreateOrTruncate,
-      )
-      match write_result {
-        Ok(_) =>
-          {
-            schema_path: Some(schema_path),
-            schema_directory: Some(schema_directory),
-          }
-        Err(error) => {
+      try {
+        @fs.write_file(
+          "\{schema_path}",
+          schema.stringify(),
+          create_mode=CreateOrTruncate,
+        )
+        {
+          schema_path: Some(schema_path),
+          schema_directory: Some(schema_directory),
+        }
+      } catch {
+        error => {
           @fs.rmdir(schema_directory, recursive=true) catch {
             _ => ()
           }

--- a/mbt/package/codex-sdk/src/thread.mbt
+++ b/mbt/package/codex-sdk/src/thread.mbt
@@ -120,7 +120,7 @@ async fn Thread::run_streamed_internal(
   let normalized = normalize_input(input)
   let options = self.thread_options
   let moonbit_internal_stop_requested = Ref(false)
-  let result = try? self.exec.run(
+  let result = Ok(self.exec.run(
     {
       input: normalized.prompt,
       base_url: self.options.base_url,
@@ -155,8 +155,10 @@ async fn Thread::run_streamed_internal(
       }
       should_continue
     },
-  )
-  @async.protect_from_cancel(fn() { schema_file.cleanup() })
+  )) catch {
+    error => Err(error)
+  }
+  @async.protect_from_cancel(async fn() { schema_file.cleanup() })
   match result {
     Ok(_) => ()
     Err(error) =>
@@ -182,7 +184,7 @@ pub async fn Thread::run(
   let mut final_response = ""
   let mut usage : Usage? = None
   let mut turn_failure : ThreadError? = None
-  self.run_streamed_internal(input, turn_options, async fn(event) {
+  self.run_streamed_internal(input, turn_options, fn(event) {
     match event {
       ItemCompleted(completed) => {
         if completed.item is AgentMessage(message) {

--- a/mbt/package/codex-sdk/src/thread.mbt
+++ b/mbt/package/codex-sdk/src/thread.mbt
@@ -120,42 +120,44 @@ async fn Thread::run_streamed_internal(
   let normalized = normalize_input(input)
   let options = self.thread_options
   let moonbit_internal_stop_requested = Ref(false)
-  let result = Ok(self.exec.run(
-    {
-      input: normalized.prompt,
-      base_url: self.options.base_url,
-      api_key: self.options.api_key,
-      thread_id: self.id_value,
-      images: normalized.images,
-      model: options.model,
-      sandbox_mode: options.sandbox_mode,
-      working_directory: options.working_directory,
-      additional_directories: options.additional_directories,
-      skip_git_repo_check: options.skip_git_repo_check,
-      output_schema_file: schema_file.schema_path,
-      model_reasoning_effort: options.model_reasoning_effort,
-      network_access_enabled: options.network_access_enabled,
-      web_search_mode: options.web_search_mode,
-      web_search_enabled: options.web_search_enabled,
-      approval_policy: options.approval_policy,
-    },
-    async fn(line) {
-      let event = moonbit_internal_thread_event_from_json(@json.parse(line)) catch {
-        error =>
-          raise InvalidEvent(
-            message="Failed to parse item: \{line}; cause: \{error}",
-          )
-      }
-      if event is ThreadStarted(started) {
-        self.id_value = Some(started.thread_id)
-      }
-      let should_continue = on_event(event)
-      if !should_continue {
-        moonbit_internal_stop_requested.val = true
-      }
-      should_continue
-    },
-  )) catch {
+  let result = Ok(
+    self.exec.run(
+      {
+        input: normalized.prompt,
+        base_url: self.options.base_url,
+        api_key: self.options.api_key,
+        thread_id: self.id_value,
+        images: normalized.images,
+        model: options.model,
+        sandbox_mode: options.sandbox_mode,
+        working_directory: options.working_directory,
+        additional_directories: options.additional_directories,
+        skip_git_repo_check: options.skip_git_repo_check,
+        output_schema_file: schema_file.schema_path,
+        model_reasoning_effort: options.model_reasoning_effort,
+        network_access_enabled: options.network_access_enabled,
+        web_search_mode: options.web_search_mode,
+        web_search_enabled: options.web_search_enabled,
+        approval_policy: options.approval_policy,
+      },
+      async fn(line) {
+        let event = moonbit_internal_thread_event_from_json(@json.parse(line)) catch {
+          error =>
+            raise InvalidEvent(
+              message="Failed to parse item: \{line}; cause: \{error}",
+            )
+        }
+        if event is ThreadStarted(started) {
+          self.id_value = Some(started.thread_id)
+        }
+        let should_continue = on_event(event)
+        if !should_continue {
+          moonbit_internal_stop_requested.val = true
+        }
+        should_continue
+      },
+    ),
+  ) catch {
     error => Err(error)
   }
   @async.protect_from_cancel(async fn() { schema_file.cleanup() })


### PR DESCRIPTION
## PR概要

- MoonBit SDKの非同期コールバックを現行APIに合わせて修正
- 実行終了時のスキーマファイル cleanup をキャンセルから保護
- `multi_agent_v2` の無効化設定と不要なエージェント上限設定を削除

```mermaid
flowchart TD
  A[Thread.run] --> B[run_streamed_internal]
  B --> C[CodexExec.run]
  C --> D[非同期タスクグループで入出力処理]
  D --> E{実行結果}
  E -->|成功| F[イベント処理を継続]
  E -->|失敗| G[エラーをThreadErrorとして処理]
  F --> H[スキーマファイルをcleanup]
  G --> H
  H --> I[キャンセル保護されたcleanup完了]
```

## Testing

- Not run (not requested)