### PR TITLE
Align OpenCode SDK port selection with upstream behavior

### DIFF
--- a/mbt/app/mdt/moon.mod
+++ b/mbt/app/mdt/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/mdt"
 
-version = "0.1.2"
+version = "0.1.3"
 
 preferred_target = "native"
 
@@ -11,7 +11,7 @@ import {
   "moonbitlang/async@0.20.1",
   "moonbitlang/x@0.4.38",
   "totto2727/admiral@0.5.0",
-  "totto2727/opencode-sdk@0.1.0",
+  "totto2727/opencode-sdk@0.1.1",
 }
 
 readme = "README.md"

--- a/mbt/app/mdt/package.nix
+++ b/mbt/app/mdt/package.nix
@@ -31,7 +31,7 @@ let
   moonModJson = builtins.toFile "mdt-moon.mod.json" (
     builtins.toJSON {
       name = "totto2727/mdt";
-      version = "0.1.2";
+      version = "0.1.3";
       deps = {
         "DC-Z-lab/moonllm" = "0.1.0";
         "moonbitlang/async" = "0.20.1";

--- a/mbt/package/opencode-sdk/moon.mod
+++ b/mbt/package/opencode-sdk/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/opencode-sdk"
 
-version = "0.1.0"
+version = "0.1.1"
 
 readme = "README.md"
 

--- a/mbt/package/opencode-sdk/src/server.mbt
+++ b/mbt/package/opencode-sdk/src/server.mbt
@@ -9,7 +9,7 @@ let startup_poll_interval_ms = 10
 ///|
 /// Options for starting an OpenCode server.
 ///
-/// Defaults match the official TypeScript SDK.
+/// When `port` is omitted, OpenCode selects an available port.
 pub struct ServerOptions {
   hostname : String
   port : Int
@@ -18,15 +18,15 @@ pub struct ServerOptions {
 } derive(Debug)
 
 ///|
-/// Construct server options using the official SDK defaults.
+/// Construct server options.
 pub fn ServerOptions::ServerOptions(
   hostname? : String = "127.0.0.1",
-  port? : Int = 4096,
+  port? : Int = 0,
   timeout_ms? : Int = 5000,
   config? : Json = Json::empty_object(),
 ) -> ServerOptions {
-  // Copied from the OpenCode TypeScript SDK defaults:
-  // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L22-L30
+  // OpenCode treats port 0 as automatic port selection:
+  // https://github.com/anomalyco/opencode/blob/7565e03536d19e850f9996c407f9bf5e932b5f7a/packages/opencode/src/server/server.ts#L117-L122
   { hostname, port, timeout_ms, config }
 }
 

--- a/mbt/package/opencode-sdk/src/server_wbtest.mbt
+++ b/mbt/package/opencode-sdk/src/server_wbtest.mbt
@@ -51,15 +51,15 @@ async fn process_is_running(pid : Int) -> Bool {
 }
 
 ///|
-// Upstream contract:
-// https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L22-L99
-test "ServerOptions ServerOptions 1 - applies TypeScript SDK defaults" {
+// OpenCode automatic port selection:
+// https://github.com/anomalyco/opencode/blob/7565e03536d19e850f9996c407f9bf5e932b5f7a/packages/opencode/src/server/server.ts#L117-L122
+test "ServerOptions ServerOptions 1 - selects an available port by default" {
   debug_inspect(
     ServerOptions::ServerOptions(),
     content=(
       #|{
       #|  hostname: "127.0.0.1",
-      #|  port: 4096,
+      #|  port: 0,
       #|  timeout_ms: 5000,
       #|  config: Object({}),
       #|}
@@ -118,7 +118,7 @@ async test "Server create 1 - starts from readiness and closes idempotently" {
       content=(
         #|serve
         #|--hostname=127.0.0.1
-        #|--port=4096
+        #|--port=0
         #|--log-level=debug
         #|
       ),


### PR DESCRIPTION
## PR概要
OpenCode SDKのデフォルトポートを固定値の4096から自動選択の0に変更し、mdtとSDKのバージョンを更新します。また、不要になったCodex設定の無効化指定を削除します。

## 処理フロー
```mermaid
flowchart TD
  A[ServerOptionsを生成] --> B{portを指定したか}
  B -->|Yes| C[指定されたポートを使用]
  B -->|No| D[port=0を設定]
  D --> E[OpenCodeが利用可能なポートを自動選択]
```

## Testing
Not run (not requested)