### PR TITLE
Refactor MoonBit JSON parsing with Lens

### DIFF
--- a/mbt/app/bw/moon.mod
+++ b/mbt/app/bw/moon.mod
@@ -8,6 +8,7 @@ supported_targets = "native"
 
 import {
   "totto2727/admiral@0.5.0",
+  "totto2727/lens@0.1.0",
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.19.2",
   "gmlewis/base64@0.16.10",

--- a/mbt/app/bw/src/command_json.mbt
+++ b/mbt/app/bw/src/command_json.mbt
@@ -187,25 +187,28 @@ fn json_extract_result(raw : String) -> Json raise {
   let parsed = @json.parse(raw) catch {
     error => fail("Invalid json response JSON: \{error}")
   }
-  match parsed {
-    Object({ "success": True, "result": result, .. }) => result
+  let success = @lens.root().bool("success").get(parsed) catch { _ => false }
+  guard success else { fail("Invalid json response") }
+  @lens.root().json("result").get(parsed) catch {
     _ => fail("Invalid json response")
   }
 }
 
 ///|
 fn json_extract_result_text(raw : String) -> String raise {
-  match json_extract_result(raw) {
-    String(value) => value
-    result => result.stringify()
+  let result = json_extract_result(raw)
+  match result {
+    Json::String(value) => value
+    _ => result.stringify()
   }
 }
 
 ///|
 fn json_extract_result_markdown(raw : String) -> String raise {
-  match json_extract_result(raw) {
-    String(value) => value
-    result => "```json\n\{result.stringify()}\n```"
+  let result = json_extract_result(raw)
+  match result {
+    Json::String(value) => value
+    _ => "```json\n\{result.stringify()}\n```"
   }
 }
 

--- a/mbt/app/bw/src/command_snapshot.mbt
+++ b/mbt/app/bw/src/command_snapshot.mbt
@@ -179,19 +179,18 @@ fn snapshot_result(data : &@io.Data) -> (String, Bytes) raise {
   let parsed = @json.parse(data.text()) catch {
     error => fail("Invalid snapshot response JSON: \{error}")
   }
-  match parsed {
-    Object({ "success": True, "result": Object(result), .. }) =>
-      match (result.get("content"), result.get("screenshot")) {
-        (Some(String(content)), Some(String(screenshot))) => {
-          let screenshot_bytes = @base64.std_decode2bytes(screenshot) catch {
-            error => fail("Invalid snapshot screenshot data: \{error}")
-          }
-          (content, screenshot_bytes)
-        }
-        _ => fail("Invalid snapshot response: missing content or screenshot")
-      }
-    _ => fail("Invalid snapshot response")
+  let success = @lens.root().bool("success").get(parsed) catch { _ => false }
+  guard success else { fail("Invalid snapshot response") }
+  let content = @lens.object("result").string("content").get(parsed) catch {
+      _ => fail("Invalid snapshot response: missing content or screenshot")
+    }
+  let screenshot = @lens.object("result").string("screenshot").get(parsed) catch {
+      _ => fail("Invalid snapshot response: missing content or screenshot")
+    }
+  let screenshot_bytes = @base64.std_decode2bytes(screenshot) catch {
+    error => fail("Invalid snapshot screenshot data: \{error}")
   }
+  (content, screenshot_bytes)
 }
 
 ///|

--- a/mbt/app/bw/src/config.mbt
+++ b/mbt/app/bw/src/config.mbt
@@ -105,8 +105,7 @@ async fn load_config(
         "invalid config JSON in '\{config_path.val}': \{error}",
       )
   }
-  match parsed {
-    Object(object) => object
+  @lens.root().get(parsed) catch {
     _ =>
       raise @admiral.ConfigLoadFailure("config file must contain a JSON object")
   }

--- a/mbt/app/bw/src/moon.pkg
+++ b/mbt/app/bw/src/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "totto2727/admiral",
+  "totto2727/lens",
   "moonbitlang/core/env",
   "moonbitlang/core/json",
   "moonbitlang/core/string",

--- a/mbt/app/c-plugin/moon.mod
+++ b/mbt/app/c-plugin/moon.mod
@@ -8,6 +8,7 @@ supported_targets = "native"
 
 import {
   "totto2727/admiral@0.5.0",
+  "totto2727/lens@0.1.0",
   "totto2727/target-file-discovery@0.1.0",
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.19.2",

--- a/mbt/app/c-plugin/src/lock_file.mbt
+++ b/mbt/app/c-plugin/src/lock_file.mbt
@@ -91,31 +91,21 @@ fn empty_lock_file() -> LockFile {
 
 ///|
 fn lock_plugin_from_json(json : Json) -> LockPlugin? {
-  match json {
-    Json::Object(object) => {
-      let name = match object.get("name") {
-        Some(Json::String(value)) => value
-        _ => "plugin"
-      }
-      let path = match object.get("path") {
-        Some(Json::String(value)) => value
-        _ => name
-      }
-      let enabled_skills = match object.get("enabledSkills") {
-        Some(Json::Array(values)) => strings_from_json_array(values)
-        _ => []
-      }
-      Some({ name, path, enabled_skills })
+  let _ = @lens.root().get(json) catch { _ => return None }
+  let name = @lens.root().string("name").get(json) catch { _ => "plugin" }
+  let path = @lens.root().string("path").get(json) catch { _ => name }
+  let enabled_skills_json = @lens.root().json("enabledSkills").array().get(json) catch {
+      _ => []
     }
-    _ => None
-  }
+  let enabled_skills = strings_from_json_array(enabled_skills_json)
+  Some({ name, path, enabled_skills })
 }
 
 ///|
 fn strings_from_json_array(values : Array[Json]) -> Array[String] {
   values
   .iter()
-  .filter_map(fn(value) {
+  .filter_map(value => {
     match value {
       Json::String(text) => Some(text)
       _ => None
@@ -139,39 +129,29 @@ fn repositories_from_json_array(values : Array[Json]) -> Array[LockRepository] {
 
 ///|
 fn lock_repository_from_json(json : Json) -> LockRepository? raise {
-  match json {
-    Json::Object(object) => {
-      let source = match object.get("source") {
-        Some(Json::String(value)) => value
-        _ => ""
-      }
-      guard source != "" else { return None }
-      let source_type = match object.get("sourceType") {
-        Some(Json::String(value)) => value
-        _ => "local"
-      }
-      let marketplace_kind = match object.get("marketplaceKind") {
-        Some(Json::String(value)) => value
-        _ => "claude"
-      }
-      let commit_hash = match object.get("commitHash") {
-        Some(Json::String(value)) => Some(value)
-        _ => None
-      }
-      let plugins = match object.get("plugins") {
-        Some(Json::Array(values)) => lock_plugins_from_json(values)
-        _ => []
-      }
-      Some({
-        source_type: repository_source_type_from_string(source_type),
-        source,
-        marketplace_kind: marketplace_kind_from_string(marketplace_kind),
-        commit_hash,
-        plugins,
-      })
+  let _ = @lens.root().get(json) catch { _ => return None }
+  let source = @lens.root().string("source").get(json) catch { _ => "" }
+  guard source != "" else { return None }
+  let source_type = @lens.root().string("sourceType").get(json) catch {
+      _ => "local"
     }
-    _ => None
-  }
+  let marketplace_kind = @lens.root().string("marketplaceKind").get(json) catch {
+      _ => "claude"
+    }
+  let commit_hash = @lens.root().string("commitHash").optional().get(json) catch {
+      _ => None
+    }
+  let plugins_json = @lens.root().json("plugins").array().get(json) catch {
+      _ => []
+    }
+  let plugins = lock_plugins_from_json(plugins_json)
+  Some({
+    source_type: repository_source_type_from_string(source_type),
+    source,
+    marketplace_kind: marketplace_kind_from_string(marketplace_kind),
+    commit_hash,
+    plugins,
+  })
 }
 
 ///|
@@ -204,21 +184,20 @@ async fn read_lock(agents : String) -> LockFile {
   } else {
     empty_lock_text()
   }
-  let object = match (@json.parse(text) catch { _ => Json::null() }) {
-    Json::Object(object) => object
-    _ => return empty_lock_file()
-  }
-  guard object.get("version") == Some(Json::number(1.0, repr="1")) else {
-    return empty_lock_file()
-  }
-  let skill_dirs = match object.get("skillDirs") {
-    Some(Json::Array(values)) => strings_from_json_array(values)
-    _ => []
-  }
-  let repositories = match object.get("repositories") {
-    Some(Json::Array(values)) => repositories_from_json_array(values)
-    _ => []
-  }
+  let document = @json.parse(text) catch { _ => return empty_lock_file() }
+  let version = @lens.root().number("version").get(document) catch { _ => 0.0 }
+  guard version == 1.0 else { return empty_lock_file() }
+  let skill_dirs_json = @lens.root().json("skillDirs").array().get(document) catch {
+      _ => []
+    }
+  let repositories_json = @lens.root()
+    .json("repositories")
+    .array()
+    .get(document) catch {
+      _ => []
+    }
+  let skill_dirs = strings_from_json_array(skill_dirs_json)
+  let repositories = repositories_from_json_array(repositories_json)
   { skill_dirs, repositories }
 }
 

--- a/mbt/app/c-plugin/src/marketplace.mbt
+++ b/mbt/app/c-plugin/src/marketplace.mbt
@@ -191,27 +191,17 @@ fn normalize_plugin_source(value : String?) -> String? {
 }
 
 ///|
-fn plugin_source_from_json(
-  plugin : Map[String, Json],
-  kind : MarketplaceKind,
-) -> String? {
+fn plugin_source_from_json(plugin : Json, kind : MarketplaceKind) -> String? {
   match kind {
     Codex =>
-      match plugin.get("source") {
-        Some(Json::Object(source)) =>
-          normalize_plugin_source(
-            match source.get("path") {
-              Some(Json::String(value)) => Some(value)
-              _ => None
-            },
-          )
-        None => None
-        _ => None
-      }
+      normalize_plugin_source(
+        @lens.object("source").string("path").optional().get(plugin) catch {
+          _ => None
+        },
+      )
     _ =>
       normalize_plugin_source(
-        match plugin.get("source") {
-          Some(Json::String(value)) => Some(value)
+        @lens.root().string("source").optional().get(plugin) catch {
           _ => None
         },
       )
@@ -223,41 +213,29 @@ fn normalized_plugins_from_json(
   text : String,
   kind : MarketplaceKind,
 ) -> Array[NormalizedPlugin] {
-  let object = match (@json.parse(text) catch { _ => Json::null() }) {
-    Json::Object(object) => object
-    _ => Map([])
-  }
-  match object.get("plugins") {
-    Some(Json::Array(values)) =>
-      values
-      .iter()
-      .filter_map(fn(value) {
-        match value {
-          Json::Object(plugin) => normalized_plugin_from_json(plugin, kind)
-          _ => None
-        }
-      })
-      .collect()
-    _ => []
-  }
+  let document = @json.parse(text) catch { _ => return [] }
+  let plugins = @lens.root().json("plugins").array().get(document) catch {
+      _ => []
+    }
+  plugins
+  .iter()
+  .filter_map(plugin => normalized_plugin_from_json(plugin, kind))
+  .collect()
 }
 
 ///|
 fn normalized_plugin_from_json(
-  plugin : Map[String, Json],
+  plugin : Json,
   kind : MarketplaceKind,
 ) -> NormalizedPlugin? {
-  let name = match plugin.get("name") {
-    Some(Json::String(value)) => value
-    _ => "plugin"
-  }
+  let _ = @lens.root().get(plugin) catch { _ => return None }
+  let name = @lens.root().string("name").get(plugin) catch { _ => "plugin" }
   let source = plugin_source_from_json(plugin, kind).unwrap_or(name)
   if is_relative_plugin_path(source) {
     Some({
       name,
       source,
-      description: match plugin.get("description") {
-        Some(Json::String(value)) => Some(value)
+      description: @lens.root().string("description").optional().get(plugin) catch {
         _ => None
       },
     })
@@ -268,12 +246,8 @@ fn normalized_plugin_from_json(
 
 ///|
 fn marketplace_name_from_json(text : String) -> String {
-  match (@json.parse(text) catch { _ => Json::null() }) {
-    Json::Object(object) =>
-      match object.get("name") {
-        Some(Json::String(value)) => value
-        _ => "marketplace"
-      }
+  let document = @json.parse(text) catch { _ => return "marketplace" }
+  @lens.root().string("name").get(document) catch {
     _ => "marketplace"
   }
 }

--- a/mbt/app/c-plugin/src/moon.pkg
+++ b/mbt/app/c-plugin/src/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "totto2727/admiral",
+  "totto2727/lens",
   "totto2727/target-file-discovery" @target_file_discovery,
   "moonbitlang/core/env",
   "moonbitlang/core/json",

--- a/mbt/app/wt/moon.mod
+++ b/mbt/app/wt/moon.mod
@@ -8,6 +8,7 @@ supported_targets = "native"
 
 import {
   "totto2727/admiral@0.5.0",
+  "totto2727/lens@0.1.0",
   "moonbitlang/async@0.19.2",
 }
 

--- a/mbt/app/wt/src/moon.pkg
+++ b/mbt/app/wt/src/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "totto2727/admiral",
+  "totto2727/lens",
   "moonbitlang/core/env",
+  "moonbitlang/core/json",
   "moonbitlang/core/string",
   "moonbitlang/async",
   "moonbitlang/async/io",

--- a/mbt/app/wt/src/worktree.mbt
+++ b/mbt/app/wt/src/worktree.mbt
@@ -181,7 +181,13 @@ async fn pr_info(slug : String, branch : String, is_main : Bool) -> PrInfo {
     (open_task.wait(), all_task.wait())
   })
   if open_json != "" && open_json != "[]" {
-    return { state: "open", number: parse_pr_number(open_json) }
+    return {
+      state: "open",
+      number: match parse_pr_json(open_json) {
+        Some(pr) => pr.number
+        None => None
+      },
+    }
   }
   if json == "" {
     return { state: "unknown", number: None }
@@ -189,39 +195,37 @@ async fn pr_info(slug : String, branch : String, is_main : Bool) -> PrInfo {
   if json == "[]" {
     return { state: "none", number: None }
   }
-  let state = if json.contains("\"MERGED\"") {
-    "merged"
-  } else if json.contains("\"OPEN\"") {
-    "open"
-  } else if json.contains("\"CLOSED\"") {
-    "closed"
-  } else {
-    "none"
+  match parse_pr_json(json) {
+    Some(pr) => pr
+    None => { state: "none", number: None }
   }
-  { state, number: parse_pr_number(json) }
 }
 
 ///|
-fn parse_pr_number(json : String) -> String? {
-  let mut number : String? = None
-  match json.find("\"number\":") {
-    Some(start) => {
-      let tail = json[start + "\"number\":".length():]
-      let digits : Array[String] = []
-      for ch in tail.iter() {
-        if ch >= '0' && ch <= '9' {
-          digits.push(ch.to_string())
-        } else {
-          break
-        }
-      }
-      if digits.length() > 0 {
-        number = Some(digits.join(""))
-      }
-    }
-    None => ()
+fn parse_pr_json(source : String) -> PrInfo? {
+  let document = @json.parse(source) catch { _ => return None }
+  let entries = match document {
+    Json::Array(entries) => entries
+    _ => return None
   }
-  number
+  guard entries is [entry, ..] else { return None }
+  let number_value = @lens.root().int("number").optional().get(entry) catch {
+      _ => None
+    }
+  let number = match number_value {
+    Some(value) => Some(value.to_string())
+    None => None
+  }
+  let state_value = @lens.root().string("state").optional().get(entry) catch {
+      _ => None
+    }
+  let state = match state_value {
+    Some("MERGED") => "merged"
+    Some("OPEN") => "open"
+    Some("CLOSED") => "closed"
+    _ => "none"
+  }
+  Some({ state, number })
 }
 
 ///|

--- a/mbt/app/wt/src/worktree_wbtest.mbt
+++ b/mbt/app/wt/src/worktree_wbtest.mbt
@@ -42,6 +42,13 @@ test "parse_worktree_list ignores blocks without worktree line" {
 }
 
 ///|
+test "parse_pr_json - reads the first GitHub pull request" {
+  let pr = parse_pr_json("[{\"number\":42,\"state\":\"MERGED\"}]").unwrap()
+  inspect(pr.state, content="merged")
+  debug_inspect(pr.number, content="Some(\"42\")")
+}
+
+///|
 async test "fetch_repo_worktrees resolves a nested repository path" {
   let root = @fs.tmpdir(prefix="wt-fetch-repo-worktrees-")
   let nested = "\{root}/some/nested/directory"

--- a/mbt/package/codex-sdk/moon.mod
+++ b/mbt/package/codex-sdk/moon.mod
@@ -10,6 +10,7 @@ import {
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.19.2",
   "totto2727/agent-cli-sdk@0.1.0",
+  "totto2727/lens@0.1.0",
 }
 
 readme = "README.md"

--- a/mbt/package/codex-sdk/src/moon.pkg
+++ b/mbt/package/codex-sdk/src/moon.pkg
@@ -9,6 +9,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "totto2727/agent-cli-sdk" @agent_cli,
+  "totto2727/lens",
 }
 
 import {

--- a/mbt/package/codex-sdk/src/moonbit_internal_events_decode.mbt
+++ b/mbt/package/codex-sdk/src/moonbit_internal_events_decode.mbt
@@ -11,14 +11,9 @@ fn moonbit_internal_usage_from_json(json : Json) -> Usage raise CodexSdkError {
     cached_input_tokens: moonbit_internal_required_int(
       object, "cached_input_tokens", "usage",
     ),
-    cache_write_input_tokens: match object.get("cache_write_input_tokens") {
-      Some(Json::Number(value, ..)) => value.to_int()
-      None => 0
-      Some(_) =>
-        raise InvalidEvent(
-          message="usage.cache_write_input_tokens must be a number",
-        )
-    },
+    cache_write_input_tokens: moonbit_internal_int_or_missing_default(
+      object, "cache_write_input_tokens", "usage", 0,
+    ),
     output_tokens: moonbit_internal_required_int(
       object, "output_tokens", "usage",
     ),

--- a/mbt/package/codex-sdk/src/moonbit_internal_json_decode.mbt
+++ b/mbt/package/codex-sdk/src/moonbit_internal_json_decode.mbt
@@ -7,8 +7,7 @@ fn moonbit_internal_json_object(
   json : Json,
   context : String,
 ) -> Map[String, Json] raise CodexSdkError {
-  match json {
-    Json::Object(object) => object
+  @lens.root().get(json) catch {
     _ => raise InvalidEvent(message="\{context} must be an object")
   }
 }
@@ -19,9 +18,8 @@ fn moonbit_internal_required_json(
   key : String,
   context : String,
 ) -> Json raise CodexSdkError {
-  match object.get(key) {
-    Some(value) => value
-    None => raise InvalidEvent(message="\{context} is missing \{key}")
+  @lens.root().json(key).get(Json::object(object)) catch {
+    _ => raise InvalidEvent(message="\{context} is missing \{key}")
   }
 }
 
@@ -31,8 +29,10 @@ fn moonbit_internal_required_string(
   key : String,
   context : String,
 ) -> String raise CodexSdkError {
-  match moonbit_internal_required_json(object, key, context) {
-    Json::String(value) => value
+  @lens.root().string(key).get(Json::object(object)) catch {
+    @lens.LensError::LensError(issue) if issue.code ==
+      @lens.IssueCode::MissingProperty =>
+      raise InvalidEvent(message="\{context} is missing \{key}")
     _ => raise InvalidEvent(message="\{context}.\{key} must be a string")
   }
 }
@@ -43,8 +43,10 @@ fn moonbit_internal_required_int(
   key : String,
   context : String,
 ) -> Int raise CodexSdkError {
-  match moonbit_internal_required_json(object, key, context) {
-    Json::Number(value, ..) => value.to_int()
+  @lens.root().int(key).get(Json::object(object)) catch {
+    @lens.LensError::LensError(issue) if issue.code ==
+      @lens.IssueCode::MissingProperty =>
+      raise InvalidEvent(message="\{context} is missing \{key}")
     _ => raise InvalidEvent(message="\{context}.\{key} must be a number")
   }
 }
@@ -55,9 +57,10 @@ fn moonbit_internal_required_bool(
   key : String,
   context : String,
 ) -> Bool raise CodexSdkError {
-  match moonbit_internal_required_json(object, key, context) {
-    Json::True => true
-    Json::False => false
+  @lens.root().bool(key).get(Json::object(object)) catch {
+    @lens.LensError::LensError(issue) if issue.code ==
+      @lens.IssueCode::MissingProperty =>
+      raise InvalidEvent(message="\{context} is missing \{key}")
     _ => raise InvalidEvent(message="\{context}.\{key} must be a boolean")
   }
 }
@@ -68,8 +71,10 @@ fn moonbit_internal_required_array(
   key : String,
   context : String,
 ) -> Array[Json] raise CodexSdkError {
-  match moonbit_internal_required_json(object, key, context) {
-    Json::Array(value) => value
+  @lens.root().json(key).array().get(Json::object(object)) catch {
+    @lens.LensError::LensError(issue) if issue.code ==
+      @lens.IssueCode::MissingProperty =>
+      raise InvalidEvent(message="\{context} is missing \{key}")
     _ => raise InvalidEvent(message="\{context}.\{key} must be an array")
   }
 }
@@ -80,10 +85,8 @@ fn moonbit_internal_optional_int(
   key : String,
   context : String,
 ) -> Int? raise CodexSdkError {
-  match object.get(key) {
-    None | Some(Json::Null) => None
-    Some(Json::Number(value, ..)) => Some(value.to_int())
-    Some(_) => raise InvalidEvent(message="\{context}.\{key} must be a number")
+  @lens.root().int(key).nullish().get(Json::object(object)) catch {
+    _ => raise InvalidEvent(message="\{context}.\{key} must be a number")
   }
 }
 
@@ -92,8 +95,23 @@ fn moonbit_internal_optional_json(
   object : Map[String, Json],
   key : String,
 ) -> Json? {
-  match object.get(key) {
-    None | Some(Json::Null) => None
-    Some(value) => Some(value)
+  @lens.root().json(key).nullish().get(Json::object(object)) catch {
+    _ => None
+  }
+}
+
+///|
+fn moonbit_internal_int_or_missing_default(
+  object : Map[String, Json],
+  key : String,
+  context : String,
+  fallback : Int,
+) -> Int raise CodexSdkError {
+  let value = @lens.root().int(key).optional().get(Json::object(object)) catch {
+      _ => raise InvalidEvent(message="\{context}.\{key} must be a number")
+    }
+  match value {
+    Some(value) => value
+    None => fallback
   }
 }

--- a/mbt/package/codex-sdk/src/output_schema_file.mbt
+++ b/mbt/package/codex-sdk/src/output_schema_file.mbt
@@ -20,7 +20,13 @@ priv struct OutputSchemaFile {
 async fn create_output_schema_file(schema : Json?) -> OutputSchemaFile {
   match schema {
     None => { schema_path: None, schema_directory: None }
-    Some(Json::Object(_) as schema) => {
+    Some(schema) => {
+      let _ = @lens.root().get(schema) catch {
+        _ =>
+          raise InvalidOutputSchema(
+            message="output_schema must be a plain JSON object",
+          )
+      }
       let schema_directory = @fs.tmpdir(prefix="codex-output-schema-")
       let schema_path = @path.Path(schema_directory)
         |> @path.Path::join(@path.Path("schema.json"))
@@ -43,10 +49,6 @@ async fn create_output_schema_file(schema : Json?) -> OutputSchemaFile {
         }
       }
     }
-    Some(_) =>
-      raise InvalidOutputSchema(
-        message="output_schema must be a plain JSON object",
-      )
   }
 }
 

--- a/mbt/package/opencode-sdk/moon.mod
+++ b/mbt/package/opencode-sdk/moon.mod
@@ -10,6 +10,7 @@ import {
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.20.1",
   "totto2727/agent-cli-sdk@0.1.0",
+  "totto2727/lens@0.1.0",
 }
 
 readme = "README.md"

--- a/mbt/package/opencode-sdk/src/moon.pkg
+++ b/mbt/package/opencode-sdk/src/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/core/string",
   "moonbitlang/x/path",
   "totto2727/agent-cli-sdk" @agent_cli,
+  "totto2727/lens",
 }
 
 import {

--- a/mbt/package/opencode-sdk/src/moonbit_internal_events_decode.mbt
+++ b/mbt/package/opencode-sdk/src/moonbit_internal_events_decode.mbt
@@ -145,14 +145,11 @@ fn moonbit_internal_thread_event_from_json(
         "name",
         "\{event_type}.error",
       )
-      let message = match error.get("data") {
-        Some(Json::Object(data)) =>
-          match data.get("message") {
-            Some(Json::String(message)) => message
-            _ => name
-          }
-        _ => name
-      }
+      let message = @lens.object("data")
+        .string("message")
+        .get(Json::object(error)) catch {
+          _ => name
+        }
       StreamError({ session_id: Some(session_id), message })
     }
     _ =>

--- a/mbt/package/opencode-sdk/src/moonbit_internal_json_decode.mbt
+++ b/mbt/package/opencode-sdk/src/moonbit_internal_json_decode.mbt
@@ -3,8 +3,7 @@ fn moonbit_internal_json_object(
   json : Json,
   context : String,
 ) -> Map[String, Json] raise OpenCodeSdkError {
-  match json {
-    Json::Object(object) => object
+  @lens.root().get(json) catch {
     _ => raise InvalidEvent(message="\{context} must be an object")
   }
 }
@@ -15,9 +14,8 @@ fn moonbit_internal_required_json(
   key : String,
   context : String,
 ) -> Json raise OpenCodeSdkError {
-  match object.get(key) {
-    Some(value) => value
-    None => raise InvalidEvent(message="\{context}.\{key} is required")
+  @lens.root().json(key).get(Json::object(object)) catch {
+    _ => raise InvalidEvent(message="\{context}.\{key} is required")
   }
 }
 
@@ -27,10 +25,11 @@ fn moonbit_internal_required_string(
   key : String,
   context : String,
 ) -> String raise OpenCodeSdkError {
-  match object.get(key) {
-    Some(Json::String(value)) => value
-    Some(_) => raise InvalidEvent(message="\{context}.\{key} must be a string")
-    None => raise InvalidEvent(message="\{context}.\{key} is required")
+  @lens.root().string(key).get(Json::object(object)) catch {
+    @lens.LensError::LensError(issue) if issue.code ==
+      @lens.IssueCode::MissingProperty =>
+      raise InvalidEvent(message="\{context}.\{key} is required")
+    _ => raise InvalidEvent(message="\{context}.\{key} must be a string")
   }
 }
 
@@ -40,10 +39,11 @@ fn moonbit_internal_required_double(
   key : String,
   context : String,
 ) -> Double raise OpenCodeSdkError {
-  match object.get(key) {
-    Some(Json::Number(value, ..)) => value
-    Some(_) => raise InvalidEvent(message="\{context}.\{key} must be a number")
-    None => raise InvalidEvent(message="\{context}.\{key} is required")
+  @lens.root().number(key).get(Json::object(object)) catch {
+    @lens.LensError::LensError(issue) if issue.code ==
+      @lens.IssueCode::MissingProperty =>
+      raise InvalidEvent(message="\{context}.\{key} is required")
+    _ => raise InvalidEvent(message="\{context}.\{key} must be a number")
   }
 }
 
@@ -53,5 +53,10 @@ fn moonbit_internal_required_int(
   key : String,
   context : String,
 ) -> Int raise OpenCodeSdkError {
-  moonbit_internal_required_double(object, key, context).to_int()
+  @lens.root().int(key).get(Json::object(object)) catch {
+    @lens.LensError::LensError(issue) if issue.code ==
+      @lens.IssueCode::MissingProperty =>
+      raise InvalidEvent(message="\{context}.\{key} is required")
+    _ => raise InvalidEvent(message="\{context}.\{key} must be a number")
+  }
 }

--- a/mbt/package/opencode-server-sdk/moon.mod
+++ b/mbt/package/opencode-server-sdk/moon.mod
@@ -14,6 +14,7 @@ description = "Native MoonBit SDK for starting and managing an OpenCode server"
 
 import {
   "moonbitlang/async@0.20.1",
+  "totto2727/lens@0.1.0",
 }
 
 preferred_target = "native"

--- a/mbt/package/opencode-server-sdk/src/moon.pkg
+++ b/mbt/package/opencode-server-sdk/src/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/string",
+  "totto2727/lens",
 }
 
 import {

--- a/mbt/package/opencode-server-sdk/src/options.mbt
+++ b/mbt/package/opencode-server-sdk/src/options.mbt
@@ -2,12 +2,7 @@
 fn config_log_level(config : Json) -> String? {
   // Copied from the OpenCode TypeScript SDK log-level selection:
   // https://github.com/anomalyco/opencode/blob/66495a2a22cd0a57efcc4f721e65532f0987b4e8/packages/sdk/js/src/server.ts#L32-L33
-  match config {
-    Json::Object(object) =>
-      match object.get("logLevel") {
-        Some(Json::String(value)) => Some(value)
-        _ => None
-      }
+  @lens.root().string("logLevel").optional().get(config) catch {
     _ => None
   }
 }


### PR DESCRIPTION
## 概要

MoonBit applications and SDKs now use `totto2727/lens` for typed JSON traversal and validation instead of repetitive manual pattern matching. GitHub pull request parsing also now decodes structured JSON, while preserving existing defaults and error behavior.

```mermaid
flowchart TD
  A[Parse JSON] --> B{Valid JSON shape?}
  B -- No --> C[Return existing fallback or validation error]
  B -- Yes --> D[Read fields with Lens]
  D --> E{Field type and presence valid?}
  E -- No --> F[Apply existing default or report error]
  E -- Yes --> G[Build typed result]
```

## Testing

- Added a unit test covering pull request state and number parsing.
- Existing MoonBit test coverage should validate the refactored JSON decoding paths.