### PR TITLE
treefmtによるファイル単位フォーマットとGit hooksの統合

### DIFF
--- a/.vite-hooks/pre-push
+++ b/.vite-hooks/pre-push
@@ -1,0 +1,1 @@
+vp run ci

--- a/flake.nix
+++ b/flake.nix
@@ -41,9 +41,9 @@
         {
           default = pkgs.mkShell {
             env = pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-                MOONBIT_OPENSSL_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
-                MOONBIT_NEW_NATIVE = "1";
-              };
+              MOONBIT_OPENSSL_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
+              MOONBIT_NEW_NATIVE = "1";
+            };
 
             packages = [
               # JS
@@ -65,6 +65,7 @@
               pkgs.beam29Packages.erlang
               # Util
               pkgs.just
+              pkgs.treefmt
             ];
 
             shellHook = ''

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,24 @@
+[formatter.elixir]
+command = "mix"
+options = ["format"]
+includes = ["*.ex", "*.exs"]
+
+[formatter.go]
+command = "gofmt"
+options = ["-w"]
+includes = ["*.go"]
+
+[formatter.moonbit]
+command = "moon"
+options = ["fmt"]
+includes = ["*.mbt", "*.mbt.md", "*.mbti", "*.mbtx", "*/moon.mod", "*/moon.pkg", "moon.mod", "moon.pkg", "moon.work"]
+
+[formatter.nix]
+command = "nixfmt"
+includes = ["*.nix"]
+
+[formatter.vite-plus]
+command = "vp"
+options = ["check", "--no-error-on-unmatched-pattern", "--fix"]
+includes = ["*"]
+excludes = ["*.mbt.md"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -171,7 +171,7 @@ export default defineConfig({
     },
   },
   staged: {
-    '*': "sh -c 'vp run w:fix'",
+    '*': 'treefmt',
   },
   test: {
     dir: 'js/',


### PR DESCRIPTION
## 概要

git hookおよびAI向けhookからファイル単位でフォーマッターを統合利用できるよう、Nix開発環境へtreefmtを追加し、リポジトリルートに設定を追加します。既存の`js:fix`、`mbt:fix`、各サブコマンドは変更していません。

## 変更内容

- `flake.nix`の開発shellへ`pkgs.treefmt`を追加
- Elixir、Go、MoonBit、Nix、Vite+を`treefmt.toml`へ登録
- MoonBit対象へ`*.mbt`、`*.mbt.md`、`*.mbti`、`*.mbtx`、`moon.work`、`moon.mod`、`moon.pkg`を追加
- `*.mbt.md`をVite+から除外し、`moon fmt`だけで処理
- Vite+を`vp check --no-error-on-unmatched-pattern --fix`で実行
- staged処理を`treefmt`へ切り替え、Vite+から渡されたファイル単位で実行
- `.vite-hooks/pre-push`を追加し、`vp run ci`を実行

## 処理フロー

```mermaid
flowchart TD
  A["pre-commit: vp staged"] --> B["Vite+がstagedファイルをtreefmtへ渡す"]
  B --> C["treefmtがファイル種別ごとに振り分ける"]
  C --> D["Vite+: vp check --no-error-on-unmatched-pattern --fix"]
  C --> E["MoonBit: moon fmt"]
  C --> F["Elixir / Go / Nix formatter"]
  G["pre-push"] --> H["vp run ci"]
  H --> I["workspace check / test / build"]
```

## 検証

- `nix flake check --no-build`
- `nix develop . -c treefmt --no-cache --fail-on-change ...`で代表9ファイルを実行し、9ファイル処理・変更0件
- `vp staged`でstagedファイルが`treefmt`へ渡されることを確認
- `moon fmt --check`で361タスク成功
- `vp check --no-error-on-unmatched-pattern vite.config.ts`
- `./.vite-hooks/pre-push`を直接実行し、`vp run ci`が46/46タスク成功
- 要件、手動QA、コード品質、セキュリティ、リポジトリ規約の5レビューが同一コミットSHAでPASS

## 補足

- trackedな`*.mbti`は現時点で存在しないため、設定上のdispatchを確認しています。
- 現在の一部ローカルcheckoutには旧`core.hooksPath`設定が残っています。通常のhook導入経路は[Vite+ Commit Hooks](https://viteplus.dev/guide/commit-hooks)に従う`vp config`です。
- treefmt設定は[treefmt configuration](https://treefmt.com/treefmt-configuration/)および[formatter specification](https://treefmt.com/formatters-spec/)に準拠しています。
