### PR TITLE
Moon Agent Graphのフレームワーク比較HTMLを追加

### DIFF
--- a/mbt/package/moon-agent-graph/README.mbt.md
+++ b/mbt/package/moon-agent-graph/README.mbt.md
@@ -4,7 +4,7 @@ Native asynchronous graph execution for MoonBit with typed state patches, determ
 
 ## Status
 
-The sequential native runtime, MoonLLM boundary, common coding-agent node, Codex adapter, OpenCode adapter, deterministic test kit, and local E2E workflows are implemented. See the [architecture](docs/architecture.md), [core guide](docs/core-guide.md), [interfaces](docs/interfaces.md), and [test plan](docs/testing.md).
+The sequential native runtime, MoonLLM boundary, common coding-agent node, Codex adapter, OpenCode adapter, deterministic test kit, and local E2E workflows are implemented. See the [architecture](docs/architecture.md), [core guide](docs/core-guide.md), [interfaces](docs/interfaces.md), [test plan](docs/testing.md), and [Japanese framework comparison](docs/framework-comparison.ja.html).
 
 ## Packages
 

--- a/mbt/package/moon-agent-graph/docs/framework-comparison.ja.html
+++ b/mbt/package/moon-agent-graph/docs/framework-comparison.ja.html
@@ -1,0 +1,1096 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Moon Agent Graph、LangGraph、Google ADK 2.0の機能差を横幅制限なしで比較する技術資料"
+    />
+    <meta name="color-scheme" content="light" />
+    <title>Moon Agent Graph / LangGraph / Google ADK 2.0 機能比較</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --surface-canvas: #f4f2ed;
+        --surface-paper: #fffefa;
+        --surface-muted: #f7f5f0;
+        --text-primary: #24221f;
+        --text-secondary: #67625b;
+        --border-default: #d9d5cc;
+        --border-strong: #aaa49a;
+        --accent-moon: #6b4eff;
+        --accent-langgraph: #16745b;
+        --accent-adk: #1769aa;
+        --status-yes-bg: #e7f3eb;
+        --status-yes-text: #285c3d;
+        --status-partial-bg: #fbf0d2;
+        --status-partial-text: #765415;
+        --status-no-bg: #f7e6e4;
+        --status-no-text: #873d36;
+        --focus-ring: #1769aa;
+        --font-display: 3rem;
+        --font-h2: 1.75rem;
+        --font-h3: 1.25rem;
+        --font-body-lg: 1.125rem;
+        --font-body: 1rem;
+        --font-body-sm: 0.875rem;
+        --font-caption: 0.75rem;
+        --space-1: 0.25rem;
+        --space-2: 0.5rem;
+        --space-3: 0.75rem;
+        --space-4: 1rem;
+        --space-6: 1.5rem;
+        --space-8: 2rem;
+        --space-12: 3rem;
+        --space-16: 4rem;
+        --radius-sm: 0.25rem;
+        --radius-md: 0.5rem;
+        --matrix-axis: 17rem;
+        --matrix-column: 31rem;
+        --content-min: 117rem;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        min-inline-size: 100%;
+        background: var(--surface-canvas);
+      }
+
+      body {
+        margin: 0;
+        min-inline-size: 100%;
+        color: var(--text-primary);
+        background: var(--surface-canvas);
+        font-family: 'Avenir Next', 'Hiragino Sans', 'Yu Gothic UI', system-ui, sans-serif;
+        font-size: var(--font-body);
+        line-height: 1.65;
+        line-break: strict;
+        overflow-wrap: normal;
+      }
+
+      a {
+        color: inherit;
+        text-decoration-color: var(--border-strong);
+        text-underline-offset: var(--space-1);
+      }
+
+      a:hover {
+        text-decoration-color: currentcolor;
+      }
+
+      a:focus-visible {
+        outline: 0.125rem solid var(--focus-ring);
+        outline-offset: var(--space-1);
+        border-radius: var(--radius-sm);
+      }
+
+      .page {
+        min-inline-size: max(100%, var(--content-min));
+        background: var(--surface-paper);
+      }
+
+      .frame {
+        inline-size: 100%;
+        min-inline-size: 100%;
+        padding: var(--space-12) var(--space-12) var(--space-16);
+      }
+
+      header {
+        display: grid;
+        grid-template-columns: minmax(40rem, 1.35fr) repeat(3, minmax(24rem, 1fr));
+        gap: var(--space-6);
+        align-items: end;
+        padding-block-end: var(--space-12);
+        border-block-end: 0.0625rem solid var(--border-strong);
+      }
+
+      .intro {
+        padding-inline-end: var(--space-12);
+      }
+
+      .eyebrow,
+      .section-label,
+      .status,
+      .framework-key {
+        font-size: var(--font-caption);
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .eyebrow,
+      .section-label {
+        color: var(--text-secondary);
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin-block-start: 0;
+      }
+
+      h1 {
+        margin-block-end: var(--space-6);
+        font-family: 'Iowan Old Style', 'YuMincho', 'Hiragino Mincho ProN', serif;
+        font-size: var(--font-display);
+        line-height: 1.08;
+        letter-spacing: -0.025em;
+      }
+
+      .nowrap {
+        white-space: nowrap;
+      }
+
+      h2 {
+        margin-block-end: var(--space-6);
+        font-size: var(--font-h2);
+        line-height: 1.25;
+        letter-spacing: -0.015em;
+      }
+
+      h3 {
+        margin-block-end: var(--space-3);
+        font-size: var(--font-h3);
+        line-height: 1.35;
+      }
+
+      .lede {
+        margin-block-end: 0;
+        color: var(--text-secondary);
+        font-size: var(--font-body-lg);
+      }
+
+      .framework-card {
+        align-self: stretch;
+        padding: var(--space-6);
+        border: 0.0625rem solid var(--border-default);
+        border-block-start-width: 0.25rem;
+        border-radius: var(--radius-md);
+        background: var(--surface-paper);
+      }
+
+      .framework-card.moon {
+        border-block-start-color: var(--accent-moon);
+      }
+
+      .framework-card.langgraph {
+        border-block-start-color: var(--accent-langgraph);
+      }
+
+      .framework-card.adk {
+        border-block-start-color: var(--accent-adk);
+      }
+
+      .framework-card p:last-child {
+        margin-block-end: 0;
+        color: var(--text-secondary);
+      }
+
+      main section {
+        padding-block: var(--space-12);
+        border-block-end: 0.0625rem solid var(--border-default);
+      }
+
+      .section-heading {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-4);
+      }
+
+      .section-heading p {
+        margin-block-end: var(--space-6);
+        color: var(--text-secondary);
+      }
+
+      .matrix-wrap {
+        inline-size: 100%;
+        min-inline-size: 100%;
+      }
+
+      table {
+        inline-size: max-content;
+        min-inline-size: 100%;
+        border-collapse: separate;
+        border-spacing: 0;
+        table-layout: auto;
+        background: var(--surface-paper);
+      }
+
+      caption {
+        padding-block-end: var(--space-4);
+        color: var(--text-secondary);
+        font-size: var(--font-body-sm);
+        text-align: start;
+      }
+
+      col.axis {
+        inline-size: var(--matrix-axis);
+      }
+
+      col.framework {
+        inline-size: var(--matrix-column);
+      }
+
+      th,
+      td {
+        min-inline-size: var(--matrix-column);
+        padding: var(--space-4) var(--space-6);
+        border-inline-end: 0.0625rem solid var(--border-default);
+        border-block-end: 0.0625rem solid var(--border-default);
+        background: var(--surface-paper);
+        text-align: start;
+        vertical-align: top;
+      }
+
+      th:first-child,
+      td:first-child {
+        min-inline-size: var(--matrix-axis);
+        inline-size: var(--matrix-axis);
+        border-inline-start: 0.0625rem solid var(--border-default);
+      }
+
+      thead th {
+        position: sticky;
+        inset-block-start: 0;
+        z-index: 3;
+        border-block-start: 0.0625rem solid var(--border-strong);
+        border-block-end-color: var(--border-strong);
+        background: var(--surface-muted);
+        font-size: var(--font-h3);
+      }
+
+      thead th:first-child {
+        inset-inline-start: 0;
+        z-index: 5;
+      }
+
+      tbody th[scope='row'] {
+        position: sticky;
+        inset-inline-start: 0;
+        z-index: 2;
+        background: var(--surface-muted);
+        font-weight: 700;
+      }
+
+      .category-row th {
+        position: sticky;
+        inset-inline-start: 0;
+        z-index: 2;
+        padding-block: var(--space-3);
+        border-block-start: 0.0625rem solid var(--border-strong);
+        border-block-end-color: var(--border-strong);
+        background: var(--text-primary);
+        color: var(--surface-paper);
+        font-size: var(--font-caption);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      td p:last-child,
+      td ul:last-child {
+        margin-block-end: 0;
+      }
+
+      ul,
+      ol {
+        margin-block-start: var(--space-2);
+        padding-inline-start: var(--space-6);
+      }
+
+      li + li {
+        margin-block-start: var(--space-2);
+      }
+
+      code {
+        padding: var(--space-1) var(--space-2);
+        border: 0.0625rem solid var(--border-default);
+        border-radius: var(--radius-sm);
+        background: var(--surface-muted);
+        font-family: SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 0.9em;
+        white-space: nowrap;
+      }
+
+      .status {
+        display: inline-block;
+        margin-block-end: var(--space-2);
+        padding: var(--space-1) var(--space-2);
+        border-radius: 9999px;
+      }
+
+      .yes {
+        color: var(--status-yes-text);
+        background: var(--status-yes-bg);
+      }
+
+      .partial {
+        color: var(--status-partial-text);
+        background: var(--status-partial-bg);
+      }
+
+      .no {
+        color: var(--status-no-text);
+        background: var(--status-no-bg);
+      }
+
+      .moon-text {
+        color: var(--accent-moon);
+      }
+
+      .langgraph-text {
+        color: var(--accent-langgraph);
+      }
+
+      .adk-text {
+        color: var(--accent-adk);
+      }
+
+      .decision-grid,
+      .source-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(31rem, 1fr));
+        gap: var(--space-6);
+        inline-size: 100%;
+        min-inline-size: 100%;
+      }
+
+      .decision-card,
+      .source-card,
+      .roadmap-step {
+        padding: var(--space-6);
+        border: 0.0625rem solid var(--border-default);
+        border-radius: var(--radius-md);
+        background: var(--surface-paper);
+      }
+
+      .decision-card p:last-child,
+      .source-card ul:last-child,
+      .roadmap-step p:last-child {
+        margin-block-end: 0;
+      }
+
+      .roadmap {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(24rem, 1fr));
+        gap: var(--space-4);
+        inline-size: 100%;
+        min-inline-size: 100%;
+        list-style: none;
+        padding: 0;
+      }
+
+      .roadmap-step strong {
+        display: block;
+        margin-block-end: var(--space-2);
+      }
+
+      footer {
+        display: flex;
+        justify-content: space-between;
+        gap: var(--space-12);
+        padding-block-start: var(--space-12);
+        color: var(--text-secondary);
+        font-size: var(--font-body-sm);
+      }
+
+      footer p {
+        margin-block-end: 0;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          scroll-behavior: auto !important;
+        }
+      }
+
+      @media print {
+        @page {
+          size: A3 landscape;
+          margin: var(--space-3);
+        }
+
+        thead th,
+        tbody th[scope='row'],
+        .category-row th {
+          position: static;
+        }
+
+        a {
+          text-decoration: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="frame">
+        <header>
+          <div class="intro">
+            <p class="eyebrow">Agent orchestration field guide / 2026-07-31</p>
+            <h1>Moon Agent Graph、LangGraph、<span class="nowrap">Google ADK 2.0</span> 機能比較</h1>
+            <p class="lede">
+              三者は同じ「エージェントフレームワーク」に見えますが、担当範囲が異なります。この資料では、MoonBit
+              nativeの実行契約、耐久性の高いグラフ実行、総合的なエージェント開発基盤という違いを、列幅を圧縮せず横並びで比較します。
+            </p>
+          </div>
+          <article class="framework-card moon">
+            <p class="framework-key moon-text">Moon Agent Graph</p>
+            <h2>MoonBit向けの型付き実行核</h2>
+            <p>
+              型付きPatch、静的な遷移検証、構造化並行性、Codex/OpenCodeプロセスの安全な所有に集中したnative-only MVP。
+            </p>
+          </article>
+          <article class="framework-card langgraph">
+            <p class="framework-key langgraph-text">LangGraph</p>
+            <h2>耐久性の高いグラフランタイム</h2>
+            <p>
+              checkpoint、再開、HITL、time
+              travel、並列super-stepを中核に据えた、長時間・ステートフル処理の低レベル基盤。
+            </p>
+          </article>
+          <article class="framework-card adk">
+            <p class="framework-key adk-text">Google ADK 2.0</p>
+            <h2>エージェント開発の総合SDK</h2>
+            <p>Graph Workflow、Agent、Tool、MCP、A2A、評価、UI、Cloud運用までを一つの体系で扱う広範な開発基盤。</p>
+          </article>
+        </header>
+
+        <main>
+          <section aria-labelledby="matrix-title">
+            <div class="section-heading">
+              <div>
+                <p class="section-label">Capability matrix</p>
+                <h2 id="matrix-title">機能マトリクス</h2>
+              </div>
+              <p>横方向にスクロールしても、項目名と列見出しは固定されます。</p>
+            </div>
+            <div class="matrix-wrap">
+              <table>
+                <caption>
+                  「外部」は別製品・別サービスとの組み合わせ、「部分」はSDKや実行方式により対応範囲が異なることを示します。
+                </caption>
+                <colgroup>
+                  <col class="axis" />
+                  <col class="framework" />
+                  <col class="framework" />
+                  <col class="framework" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th scope="col">比較項目</th>
+                    <th scope="col" class="moon-text">Moon Agent Graph</th>
+                    <th scope="col" class="langgraph-text">LangGraph</th>
+                    <th scope="col" class="adk-text">Google ADK 2.0</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="category-row">
+                    <th colspan="4" scope="rowgroup">位置付けと実行モデル</th>
+                  </tr>
+                  <tr>
+                    <th scope="row">主目的</th>
+                    <td>
+                      <span class="status yes">特化</span>
+                      <p>
+                        MoonBit native上で決定的なグラフを実行し、LLMやCoding Agentの処理を型付き状態遷移へ統合する。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">低レベル基盤</span>
+                      <p>
+                        長時間・ステートフルなエージェントやワークフローを、障害から再開可能なグラフとして実行する。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">総合SDK</span>
+                      <p>
+                        エージェントの構築、ツール連携、協調、評価、可観測性、デプロイまでを一つの開発体系で提供する。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">対応ランタイム・言語</th>
+                    <td>
+                      <span class="status partial">MoonBit / native-only</span>
+                      <p>
+                        <code>preferred_target = "native"</code> と
+                        <code>supported_targets = "native"</code>。ブラウザやWASM向けランタイムは対象外。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">Python / JavaScript</span>
+                      <p>LangGraph SDKとして提供。モデルやTool実装はLangChainまたは独自コードと組み合わせる。</p>
+                    </td>
+                    <td>
+                      <span class="status partial">GraphはPython / Go 2.0</span>
+                      <p>
+                        ADK全体はPython、TypeScript、Go、Java、Kotlin。新しいGraph Workflow APIは現時点でPythonとGo
+                        2.0が中心。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">グラフ定義</th>
+                    <td>
+                      <span class="status yes">型付き</span>
+                      <p>
+                        <code>GraphDefinition[S, P]</code>、<code>Node[S, P]</code>、<code>Reducer[S, P]</code
+                        >、<code>Router[S]</code>。状態とPatchを別の型として扱う。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">StateGraph</span>
+                      <p>State schema、Reducer、通常Edge、条件付きEdge、<code>Command</code>、Functional APIを提供。</p>
+                    </td>
+                    <td>
+                      <span class="status yes">複数方式</span>
+                      <p>
+                        静的な<code>Workflow</code> graph、Dynamic Workflow、Sequential / Parallel / Loop
+                        Agentを用途に応じて選択。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">構造検証</th>
+                    <td>
+                      <span class="status yes">厳格</span>
+                      <p>
+                        entry、全NodeのRouter、未知の遷移先、到達不能Nodeをcompile時に検出。Routerは取り得る遷移先を事前宣言する。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">compileあり</span>
+                      <p>
+                        Graphをcompileして実行可能形式にする。条件遷移や<code>Command</code>により、実行時の柔軟性を広く確保する。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">明示Edge</span>
+                      <p>
+                        NodeとEdge、route key、fan-out/fan-inを明示する。複雑な反復や再帰はDynamic Workflowへ移せる。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">実行スケジューリング</th>
+                    <td>
+                      <span class="status no">逐次のみ</span>
+                      <p>
+                        1回のiterationで1 Nodeを実行。Cycleは許可され、<code>max_steps</code>で無限ループを防止する。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">並列super-step</span>
+                      <p>複数の遷移先を同じsuper-stepで並列実行。<code>max_concurrency</code>で並行数を制御できる。</p>
+                    </td>
+                    <td>
+                      <span class="status yes">fan-out / join</span>
+                      <p>Graphのfan-out/join、<code>ParallelAgent</code>、Dynamic Workflowの並列ルートを提供する。</p>
+                    </td>
+                  </tr>
+
+                  <tr class="category-row">
+                    <th colspan="4" scope="rowgroup">状態、耐久性、Human-in-the-loop</th>
+                  </tr>
+                  <tr>
+                    <th scope="row">状態モデル</th>
+                    <td>
+                      <span class="status yes">呼び出し内</span>
+                      <p>
+                        Nodeが現在状態<code>S</code>を読み、Patch
+                        <code>P</code>を返す。Reducerだけが状態を更新する。状態はinvoke内のメモリに保持。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">Thread / Checkpoint</span>
+                      <p>
+                        Graph stateをsuper-stepごとのcheckpointとしてThreadに保存。短期状態と長期Storeを分離できる。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">Session / State / Event</span>
+                      <p>
+                        Sessionが会話ThreadとEvent履歴を持ち、Stateを保持。Memory
+                        ServiceはSessionをまたぐ検索可能な知識を扱う。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">永続checkpoint</th>
+                    <td>
+                      <span class="status no">未実装</span>
+                      <p>pluggable state store、checkpoint serializer、永続run stateはMVP外。</p>
+                    </td>
+                    <td>
+                      <span class="status yes">中核機能</span>
+                      <p>
+                        各super-stepのstate snapshotとnode単位のpending
+                        writeを保存。Postgres、MongoDB、RedisなどのStore実装を選択可能。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status partial">方式依存</span>
+                      <p>
+                        Session ServiceとResume機能を提供。Dynamic
+                        Workflowは成功済みsub-nodeを記録し、再開時に自動skipする。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">障害復旧・再開</th>
+                    <td>
+                      <span class="status no">run再開なし</span>
+                      <p>
+                        Node内のCoding Agent session continuationは扱うが、Graph
+                        runそのものを途中checkpointから再開する機能はない。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">durable execution</span>
+                      <p>障害後に直前のcheckpointから再開し、同じsuper-stepで成功済みのNodeを再実行せず復旧できる。</p>
+                    </td>
+                    <td>
+                      <span class="status partial">Resume対応</span>
+                      <p>
+                        Invocation IDとEvent履歴を使って停止したworkflowを再開。SDK、Agent種別、custom
+                        agent実装により対応条件が異なる。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Time travel / Fork</th>
+                    <td>
+                      <span class="status no">未実装</span>
+                      <p>過去のstate snapshot、replay、別trajectoryへのforkはない。</p>
+                    </td>
+                    <td>
+                      <span class="status yes">標準対応</span>
+                      <p>過去checkpointからのreplayと、状態を編集した分岐runを実行できる。</p>
+                    </td>
+                    <td>
+                      <span class="status partial">Session rewind</span>
+                      <p>
+                        Session履歴とResume関連機能はあるが、LangGraphのcheckpoint forkを中心としたtime
+                        travelとは設計の焦点が異なる。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Human-in-the-loop</th>
+                    <td>
+                      <span class="status no">未実装</span>
+                      <p>人間の承認待ちとしてGraph runをsuspendし、後から再開するruntime contractはない。</p>
+                    </td>
+                    <td>
+                      <span class="status yes">interrupt</span>
+                      <p>
+                        <code>interrupt()</code
+                        >で無期限停止し、stateを確認・変更して<code>Command(resume=...)</code>で続行できる。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">HITL Node</span>
+                      <p>
+                        <code>RequestInput</code>やTool
+                        confirmationをGraphに組み込み、入力や承認が届くまでworkflowを停止できる。
+                      </p>
+                    </td>
+                  </tr>
+
+                  <tr class="category-row">
+                    <th colspan="4" scope="rowgroup">構成、Agent、Tool連携</th>
+                  </tr>
+                  <tr>
+                    <th scope="row">Subgraph / Nested workflow</th>
+                    <td>
+                      <span class="status no">未実装</span>
+                      <p>CompiledGraphを別GraphのNodeとして埋め込む階層化や、親子stateの受け渡し機構はない。</p>
+                    </td>
+                    <td>
+                      <span class="status yes">Subgraph</span>
+                      <p>per-invocation、per-thread、statelessの永続化モードを選択でき、親Graphへの遷移も可能。</p>
+                    </td>
+                    <td>
+                      <span class="status yes">Nested workflow</span>
+                      <p>追加のWorkflow AgentをNodeとして入れ子にし、outputやrouteを外側へ渡せる。</p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Multi-agent</th>
+                    <td>
+                      <span class="status partial">Nodeとして可能</span>
+                      <p>
+                        複数のCoding Agent NodeをGraphに置けるが、Supervisor、Team、handoff、subagent固有のruntime
+                        abstractionはない。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status partial">構築可能</span>
+                      <p>
+                        Subgraph、handoff、agent-as-toolを組み合わせる。事前構築済みパターンはLangChainやDeep
+                        Agents側が担当。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">第一級機能</span>
+                      <p>
+                        Coordinatorとsubagent、Chat / Task / Single-turn
+                        mode、並列subagent、親Agentへの自動returnを提供。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Remote Agent連携</th>
+                    <td>
+                      <span class="status no">専用protocolなし</span>
+                      <p>
+                        Codex/OpenCode CLI sessionはローカルadapterとして扱う。A2AのAgent Cardやremote discoveryはない。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status partial">周辺基盤</span>
+                      <p>
+                        LangSmith DeploymentやRemoteGraphではMCP/A2Aを使ったAgent compositionが可能。OSS
+                        core単体とは別レイヤー。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">A2A</span>
+                      <p>
+                        AgentをA2A serverとして公開し、別プロセス・別frameworkのremote
+                        agentを利用できる。現状は実験的対応を含む。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">LLM・Coding Agent</th>
+                    <td>
+                      <span class="status yes">専用adapter</span>
+                      <p>
+                        MoonLLM callback Node、共通Coding Agent Node、Codex SDK adapter、OpenCode CLI SDK
+                        adapterを実装済み。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status partial">モデル非依存</span>
+                      <p>
+                        LangGraph coreはpromptやmodel
+                        architectureを抽象化しない。LangChainまたは独自NodeでLLM/Agentを接続する。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">Agent標準搭載</span>
+                      <p>
+                        LLM Agent、Managed Agent、Workflow Agent、model routing、複数model providerをSDK体系内で扱う。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Tool・Integration</th>
+                    <td>
+                      <span class="status partial">Function境界</span>
+                      <p>
+                        任意のasync Function Nodeは実装できるが、Tool
+                        registry、schema生成、MCP、OpenAPI、認証統合はない。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status partial">周辺ecosystem</span>
+                      <p>任意のPython/JavaScript関数をNodeにできる。豊富なTool統合は主にLangChain側。</p>
+                    </td>
+                    <td>
+                      <span class="status yes">豊富</span>
+                      <p>
+                        Function Tool、MCP、OpenAPI、認証、long-running tool、action confirmation、Google Search
+                        Groundingなどを提供。
+                      </p>
+                    </td>
+                  </tr>
+
+                  <tr class="category-row">
+                    <th colspan="4" scope="rowgroup">運用、安全性、開発支援</th>
+                  </tr>
+                  <tr>
+                    <th scope="row">Cancellation・Resource所有</th>
+                    <td>
+                      <span class="status yes">主要な強み</span>
+                      <p>
+                        invokeごとの<code>TaskGroup</code>、Node/Run scope session、Node
+                        timeout、逆順close、close-once、cancellation-protected cleanupをruntime contractとして持つ。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status partial">Node実装依存</span>
+                      <p>
+                        Graph
+                        runやtaskのcancelは扱えるが、任意のsubprocessや外部resourceの所有・cleanup契約はアプリケーションNode側で設計する。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">Run cancellation</span>
+                      <p>
+                        RunnerからAgent、Toolへcancelを伝播。ToolはAbortSignal等を使って外部処理の中断を実装できる。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Retry・Cache</th>
+                    <td>
+                      <span class="status partial">Agent open retry</span>
+                      <p>
+                        Coding Agent session open失敗後の再取得など限定的な回復契約はあるが、汎用Node retry/cache
+                        policyはない。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">Node policy</span>
+                      <p>NodeごとのRetryPolicyとCachePolicyを指定でき、並列branchの失敗部分だけを再実行できる。</p>
+                    </td>
+                    <td>
+                      <span class="status yes">RetryConfig / Plugin</span>
+                      <p>Node retryのほか、Reflect and Retry Toolsやresponse cacheなどのPluginを利用できる。</p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Event・Streaming</th>
+                    <td>
+                      <span class="status partial">同期EventSink</span>
+                      <p>
+                        Run/Node/Route/Resource lifecycleを同期的・best-effortで通知する。tokenやstate
+                        updateを利用者へ流すstream APIはない。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">複数stream mode</span>
+                      <p>
+                        values、updates、messages、custom、subgraph等をstreamでき、Agent
+                        Serverでもリアルタイム配信可能。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status partial">Graph制限あり</span>
+                      <p>
+                        ADK全体はEventとstreamingを持つが、ADK 2.0のgraph-based workflowは現在live streaming非対応。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Artifact</th>
+                    <td>
+                      <span class="status partial">記述子のみ</span>
+                      <p>
+                        <code>Artifact</code
+                        >はFile、Directory、Text、JSON、CommandLog等のkind、name、URI、metadataを持つが、保存・versioning
+                        serviceはない。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status partial">アプリ側設計</span>
+                      <p>
+                        state、Store、外部object storageを組み合わせる。ADKのような専用Artifact
+                        Serviceはcoreの中心機能ではない。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">Artifact Service</span>
+                      <p>session/user scopeのnamed binary data、versioning、InMemory/GCS backendを提供する。</p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Observability・評価</th>
+                    <td>
+                      <span class="status partial">テスト中心</span>
+                      <p>
+                        決定的fake、event recorder、102 MoonBit test blocks、ローカルprocess E2Eを持つ。trace UIやagent
+                        evaluation frameworkはない。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status partial">LangSmithと連携</span>
+                      <p>
+                        OSS
+                        coreはstream/eventを提供し、trace、Studio、dataset評価、trajectory評価はLangSmithという別製品が担当。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">SDK体系内</span>
+                      <p>
+                        trajectory/tool-use評価、test/evalset、custom metrics、Trace View、logging、metrics、Plugin
+                        callbackを提供。
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Deployment</th>
+                    <td>
+                      <span class="status no">ライブラリのみ</span>
+                      <p>API server、worker、control plane、managed deploymentは提供しない。</p>
+                    </td>
+                    <td>
+                      <span class="status partial">LangSmith Deployment</span>
+                      <p>
+                        Agent ServerをCloud、Standalone、Self-hostedで運用できる。OSS libraryとmanaged
+                        platformは分離されている。
+                      </p>
+                    </td>
+                    <td>
+                      <span class="status yes">複数経路</span>
+                      <p>ADK API Server、Cloud Run、GKE、Google Cloud Agent Runtime、Agents CLI deploymentを提供。</p>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section aria-labelledby="decision-title">
+            <p class="section-label">Decision guide</p>
+            <h2 id="decision-title">用途から選ぶ</h2>
+            <div class="decision-grid">
+              <article class="decision-card">
+                <p class="framework-key moon-text">Choose Moon Agent Graph</p>
+                <h3>MoonBitでCoding Agentを安全に動かす</h3>
+                <p>
+                  Codex/OpenCodeをNodeとして扱い、subprocessの終了、cancellation、session
+                  scope、型付きPatchまで一つのnative runtime契約に収めたい場合。
+                </p>
+              </article>
+              <article class="decision-card">
+                <p class="framework-key langgraph-text">Choose LangGraph</p>
+                <h3>長時間runを停止・再開・分岐する</h3>
+                <p>
+                  障害復旧、checkpoint、HITL、time
+                  travel、並列branchが主要要件で、LLMやToolの構成はアプリケーション側で選びたい場合。
+                </p>
+              </article>
+              <article class="decision-card">
+                <p class="framework-key adk-text">Choose Google ADK</p>
+                <h3>Agent製品を一通り構築・運用する</h3>
+                <p>
+                  Agent、Tool、MCP、A2A、Memory、Artifact、評価、Web UI、Google Cloud
+                  deploymentまで共通SDKの流儀で揃えたい場合。
+                </p>
+              </article>
+            </div>
+          </section>
+
+          <section aria-labelledby="roadmap-title">
+            <p class="section-label">Moon Agent Graph roadmap</p>
+            <h2 id="roadmap-title">他フレームワークへ近づける場合の優先差分</h2>
+            <ol class="roadmap">
+              <li class="roadmap-step">
+                <strong>1. Checkpoint / Resume / HITL</strong>
+                <p>
+                  状態serialization、run ID、checkpoint
+                  store、suspend/resume契約を同時に設計する。最も大きい実用上の差。
+                </p>
+              </li>
+              <li class="roadmap-step">
+                <strong>2. Fan-out / Join / Subgraph</strong>
+                <p>bounded parallelism、複数Patchのmerge規則、親子Graphのstate境界を追加する。</p>
+              </li>
+              <li class="roadmap-step">
+                <strong>3. Stream / Memory / Artifact Store</strong>
+                <p>同期EventSinkとは別に利用者向けstream、永続Memory、versioned Artifact backendを定義する。</p>
+              </li>
+              <li class="roadmap-step">
+                <strong>4. MCP / A2A / Eval / Deploy</strong>
+                <p>ここから先はランタイムではなくplatform領域。必要性を確認して個別packageへ分離する。</p>
+              </li>
+            </ol>
+          </section>
+
+          <section aria-labelledby="sources-title">
+            <p class="section-label">Evidence</p>
+            <h2 id="sources-title">参照資料</h2>
+            <div class="source-grid">
+              <article class="source-card">
+                <h3 class="moon-text">Moon Agent Graph</h3>
+                <ul>
+                  <li><a href="../README.mbt.md">READMEと現行制約</a></li>
+                  <li><a href="architecture.md">ArchitectureとMVP scope</a></li>
+                  <li><a href="../src/core/runtime.mbt">Sequential runtime実装</a></li>
+                  <li><a href="../src/core/graph.mbt">Graph compileとvalidation実装</a></li>
+                </ul>
+              </article>
+              <article class="source-card">
+                <h3 class="langgraph-text">LangGraph公式</h3>
+                <ul>
+                  <li>
+                    <a href="https://docs.langchain.com/oss/python/langgraph/overview" target="_blank" rel="noreferrer"
+                      >Overview</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      href="https://docs.langchain.com/oss/python/langgraph/persistence"
+                      target="_blank"
+                      rel="noreferrer"
+                      >Persistence</a
+                    >
+                  </li>
+                  <li>
+                    <a href="https://docs.langchain.com/oss/python/langgraph/graph-api" target="_blank" rel="noreferrer"
+                      >Graph API</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      href="https://docs.langchain.com/oss/python/langgraph/use-subgraphs"
+                      target="_blank"
+                      rel="noreferrer"
+                      >Subgraphs</a
+                    >
+                  </li>
+                  <li>
+                    <a href="https://docs.langchain.com/oss/python/langgraph/streaming" target="_blank" rel="noreferrer"
+                      >Streaming</a
+                    >
+                  </li>
+                  <li>
+                    <a href="https://docs.langchain.com/langsmith/deployment" target="_blank" rel="noreferrer"
+                      >LangSmith Deployment</a
+                    >
+                  </li>
+                </ul>
+              </article>
+              <article class="source-card">
+                <h3 class="adk-text">Google ADK公式</h3>
+                <ul>
+                  <li><a href="https://adk.dev/graphs/" target="_blank" rel="noreferrer">Graph-based workflows</a></li>
+                  <li><a href="https://adk.dev/graphs/routes/" target="_blank" rel="noreferrer">Graph routes</a></li>
+                  <li>
+                    <a href="https://adk.dev/graphs/dynamic/" target="_blank" rel="noreferrer">Dynamic workflows</a>
+                  </li>
+                  <li>
+                    <a href="https://adk.dev/graphs/human-input/" target="_blank" rel="noreferrer">Human input</a>
+                  </li>
+                  <li>
+                    <a href="https://adk.dev/sessions/" target="_blank" rel="noreferrer">Sessions, State and Memory</a>
+                  </li>
+                  <li><a href="https://adk.dev/evaluate/" target="_blank" rel="noreferrer">Evaluation</a></li>
+                  <li><a href="https://adk.dev/a2a/" target="_blank" rel="noreferrer">A2A</a></li>
+                </ul>
+              </article>
+            </div>
+          </section>
+        </main>
+
+        <footer>
+          <p>
+            調査基準日: 2026-07-31。Moon Agent Graphはこのworktreeの実装、LangGraphとGoogle
+            ADKは各公式資料を基準にしています。
+          </p>
+          <p>横幅制限なし / 静的HTML / JavaScript・外部font・画像なし</p>
+        </footer>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## 概要

- Moon Agent Graph、LangGraph、Google ADK 2.0の機能差を横並びで確認できる日本語HTML資料を追加
- 比較表、用途別の選択ガイド、Moon Agent Graphの優先ロードマップ、一次資料リンクを収録
- 横幅上限を設けず、各フレームワークの列幅を維持したまま横スクロールできる構成
- Moon Agent GraphのREADMEから比較資料へ移動できるリンクを追加

## 処理フロー

```mermaid
flowchart LR
  README["Moon Agent Graph README"] --> HTML["framework-comparison.ja.html"]
  HTML --> Matrix["機能マトリクス"]
  HTML --> Guide["用途別ガイド"]
  HTML --> Roadmap["優先ロードマップ"]
  HTML --> Sources["一次資料リンク"]
```

## 確認内容

- `vp fmt mbt/package/moon-agent-graph/README.mbt.md mbt/package/moon-agent-graph/docs/framework-comparison.ja.html --check`
- `git diff --check HEAD^ HEAD`
- HTML内のローカル相対リンク先が存在することを確認
- `max-width` / `max-inline-size`による横幅上限がないことを確認

## 補足

- HTMLはJavaScript、外部フォント、画像を使用しない自己完結型です。
- ブラウザでの追加再検証は、ユーザー指示により省略しています。
