### PR TITLE
Extend Copy support across SDKs and agent graph

### DIFF
--- a/mbt/package/codex-sdk/moon.mod
+++ b/mbt/package/codex-sdk/moon.mod
@@ -10,6 +10,7 @@ import {
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.20.1",
   "totto2727/agent-cli-sdk@0.1.0",
+  "totto2727/copy@0.1.0",
   "totto2727/lens@0.1.0",
 }
 

--- a/mbt/package/codex-sdk/src/exec.mbt
+++ b/mbt/package/codex-sdk/src/exec.mbt
@@ -160,7 +160,7 @@ async fn CodexExec::run(
   }
 
   let environment = match self.env_override {
-    Some(environment_override) => environment_override.copy()
+    Some(environment_override) => @copy.Copy::copy(environment_override)
     None => Map([])
   }
   let inherited_originator = if self.env_override is None {

--- a/mbt/package/codex-sdk/src/moon.pkg
+++ b/mbt/package/codex-sdk/src/moon.pkg
@@ -9,6 +9,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "totto2727/agent-cli-sdk" @agent_cli,
+  "totto2727/copy",
   "totto2727/lens",
 }
 

--- a/mbt/package/copy/README.mbt.md
+++ b/mbt/package/copy/README.mbt.md
@@ -18,7 +18,7 @@ test {
 }
 ```
 
-The package implements `Copy` for primitive and immutable scalar values, `Option`, `Result`, `Array`, `FixedArray`, and two- and three-element tuples. Composite implementations require their contained values to implement `Copy`.
+The package implements `Copy` for primitive and immutable scalar values, `Option`, `Result`, `Array`, `FixedArray`, `ReadOnlyArray`, `Map`, and two- and three-element tuples. Composite implementations require their contained values to implement `Copy`; map keys must also implement `Hash` and `Eq`.
 
 ## Custom mutable values
 

--- a/mbt/package/copy/src/copy.mbt
+++ b/mbt/package/copy/src/copy.mbt
@@ -67,10 +67,9 @@ pub impl[T : Copy] Copy for T? with fn copy(self) {
 }
 
 ///|
-pub impl[Value : Copy, CopyError : Copy] Copy for Result[
-  Value,
-  CopyError,
-] with fn copy(self) {
+pub impl[Value : Copy, CopyError : Copy] Copy for Result[Value, CopyError] with fn copy(
+  self,
+) {
   match self {
     Ok(value) => Ok(Copy::copy(value))
     Err(error) => Err(Copy::copy(error))
@@ -85,6 +84,25 @@ pub impl[T : Copy] Copy for Array[T] with fn copy(self) {
 ///|
 pub impl[T : Copy] Copy for FixedArray[T] with fn copy(self) {
   self.map(value => Copy::copy(value))
+}
+
+///|
+pub impl[T : Copy] Copy for ReadOnlyArray[T] with fn copy(self) {
+  ReadOnlyArray::from_iter(self.iter().map(value => Copy::copy(value)))
+}
+
+///|
+pub impl[Key : Hash + Eq + Copy, Value : Copy] Copy for Map[Key, Value] with fn copy(
+  self,
+) {
+  Map::from_iter(
+    self
+    .iter()
+    .map(entry => {
+      let (key, value) = entry
+      (Copy::copy(key), Copy::copy(value))
+    }),
+  )
 }
 
 ///|

--- a/mbt/package/moon-agent-graph/docs/core-guide.ja.md
+++ b/mbt/package/moon-agent-graph/docs/core-guide.ja.md
@@ -198,8 +198,8 @@ pub fn[S, P] GraphDefinition::compile(
 ) -> CompiledGraph[S, P] raise GraphValidationError {
   let entry = self.entry.unwrap_or_error(MissingEntry)
   validate_graph(self.nodes, self.routers, entry)
-  let nodes = self.nodes.map((_id, value) => copy_node(value))
-  let routers = self.routers.map((_source, value) => copy_router(value))
+  let nodes = self.nodes.map((_id, value) => @copy.Copy::copy(value))
+  let routers = self.routers.map((_source, value) => @copy.Copy::copy(value))
   CompiledGraph::{ reducer: self.reducer, nodes, routers, entry }
 }
 ```

--- a/mbt/package/moon-agent-graph/docs/core-guide.md
+++ b/mbt/package/moon-agent-graph/docs/core-guide.md
@@ -198,8 +198,8 @@ pub fn[S, P] GraphDefinition::compile(
 ) -> CompiledGraph[S, P] raise GraphValidationError {
   let entry = self.entry.unwrap_or_error(MissingEntry)
   validate_graph(self.nodes, self.routers, entry)
-  let nodes = self.nodes.map((_id, value) => copy_node(value))
-  let routers = self.routers.map((_source, value) => copy_router(value))
+  let nodes = self.nodes.map((_id, value) => @copy.Copy::copy(value))
+  let routers = self.routers.map((_source, value) => @copy.Copy::copy(value))
   CompiledGraph::{ reducer: self.reducer, nodes, routers, entry }
 }
 ```

--- a/mbt/package/moon-agent-graph/moon.mod
+++ b/mbt/package/moon-agent-graph/moon.mod
@@ -17,6 +17,7 @@ import {
   "moonbitlang/async@0.20.1",
   "moonbitlang/x@0.4.38",
   "totto2727/codex-sdk@0.0.0",
+  "totto2727/copy@0.1.0",
   "totto2727/opencode-sdk@0.1.1",
 }
 

--- a/mbt/package/moon-agent-graph/src/core/graph.mbt
+++ b/mbt/package/moon-agent-graph/src/core/graph.mbt
@@ -66,7 +66,7 @@ pub fn[S, P] GraphDefinition::set_router(
   value : Router[S],
 ) -> Unit raise GraphBuildError {
   guard !self.routers.contains(from) else { raise DuplicateRouter(from) }
-  self.routers[from] = router(value.declared_targets, value.evaluate)
+  self.routers[from] = @copy.Copy::copy(value)
 }
 
 ///|
@@ -76,20 +76,6 @@ pub fn[S, P] GraphDefinition::set_entry(
 ) -> Unit raise GraphBuildError {
   guard !entry.to_string().is_empty() else { raise InvalidId("NodeId") }
   self.entry = Some(entry)
-}
-
-///|
-fn[S] copy_router(value : Router[S]) -> Router[S] {
-  router(value.declared_targets, value.evaluate)
-}
-
-///|
-fn[S, P] copy_node(value : Node[S, P]) -> Node[S, P] {
-  Node::{
-    id: value.id,
-    metadata: @copy.Copy::copy(value.metadata),
-    execute: value.execute,
-  }
 }
 
 ///|
@@ -135,8 +121,8 @@ pub fn[S, P] GraphDefinition::compile(
 ) -> CompiledGraph[S, P] raise GraphValidationError {
   let entry = self.entry.unwrap_or_error(MissingEntry)
   validate_graph(self.nodes, self.routers, entry)
-  let nodes = self.nodes.map((_id, value) => copy_node(value))
-  let routers = self.routers.map((_source, value) => copy_router(value))
+  let nodes = self.nodes.map((_id, value) => @copy.Copy::copy(value))
+  let routers = self.routers.map((_source, value) => @copy.Copy::copy(value))
   CompiledGraph::{ reducer: self.reducer, nodes, routers, entry }
 }
 
@@ -166,5 +152,5 @@ pub fn[S, P] CompiledGraph::get_router(
   self : CompiledGraph[S, P],
   id : NodeId,
 ) -> Router[S] raise GraphRuntimeError {
-  copy_router(self.routers.get(id).unwrap_or_error(RouterNotFound(id)))
+  @copy.Copy::copy(self.routers.get(id).unwrap_or_error(RouterNotFound(id)))
 }

--- a/mbt/package/moon-agent-graph/src/core/graph.mbt
+++ b/mbt/package/moon-agent-graph/src/core/graph.mbt
@@ -87,12 +87,7 @@ fn[S] copy_router(value : Router[S]) -> Router[S] {
 fn[S, P] copy_node(value : Node[S, P]) -> Node[S, P] {
   Node::{
     id: value.id,
-    metadata: NodeMetadata::{
-      name: value.metadata.name,
-      description: value.metadata.description,
-      kind: value.metadata.kind,
-      tags: ReadOnlyArray::from_array([..value.metadata.tags]),
-    },
+    metadata: @copy.Copy::copy(value.metadata),
     execute: value.execute,
   }
 }

--- a/mbt/package/moon-agent-graph/src/core/identifiers.mbt
+++ b/mbt/package/moon-agent-graph/src/core/identifiers.mbt
@@ -2,6 +2,9 @@
 pub struct NodeId(String) derive(Eq, Hash, Debug)
 
 ///|
+pub impl @copy.Copy for NodeId
+
+///|
 pub struct RunId(String) derive(Eq, Hash, Debug)
 
 ///|

--- a/mbt/package/moon-agent-graph/src/core/model.mbt
+++ b/mbt/package/moon-agent-graph/src/core/model.mbt
@@ -146,6 +146,16 @@ pub(all) struct Node[S, P] {
 }
 
 ///|
+/// Copies node-owned data while retaining the callback that defines its behavior.
+pub impl[S, P] @copy.Copy for Node[S, P] with fn copy(self) {
+  Node::{
+    id: self.id,
+    metadata: @copy.Copy::copy(self.metadata),
+    execute: self.execute,
+  }
+}
+
+///|
 pub fn[S, P] function_node(
   id : NodeId,
   metadata : NodeMetadata,
@@ -158,6 +168,15 @@ pub fn[S, P] function_node(
 pub(all) struct Router[S] {
   declared_targets : ReadOnlyArray[NodeId]
   evaluate : (S, NodeCompletion) -> Route raise
+}
+
+///|
+/// Copies router-owned data while retaining the callback that defines its behavior.
+pub impl[S] @copy.Copy for Router[S] with fn copy(self) {
+  Router::{
+    declared_targets: @copy.Copy::copy(self.declared_targets),
+    evaluate: self.evaluate,
+  }
 }
 
 ///|

--- a/mbt/package/moon-agent-graph/src/core/model.mbt
+++ b/mbt/package/moon-agent-graph/src/core/model.mbt
@@ -22,6 +22,16 @@ pub(all) struct NodeMetadata {
 } derive(Debug)
 
 ///|
+pub impl @copy.Copy for NodeMetadata with fn copy(self) {
+  NodeMetadata::{
+    name: self.name,
+    description: self.description,
+    kind: self.kind,
+    tags: @copy.Copy::copy(self.tags),
+  }
+}
+
+///|
 pub(all) enum ArtifactKind {
   File
   Directory
@@ -155,10 +165,7 @@ pub fn[S] router(
   declared_targets : ReadOnlyArray[NodeId],
   evaluate : (S, NodeCompletion) -> Route raise,
 ) -> Router[S] {
-  Router::{
-    declared_targets: ReadOnlyArray::from_array([..declared_targets]),
-    evaluate,
-  }
+  Router::{ declared_targets: @copy.Copy::copy(declared_targets), evaluate }
 }
 
 ///|

--- a/mbt/package/moon-agent-graph/src/core/moon.pkg
+++ b/mbt/package/moon-agent-graph/src/core/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbitlang/core/random",
   "moonbitlang/async",
   "moonbitlang/x/path",
+  "totto2727/copy",
 }
 
 supported_targets = "native"

--- a/mbt/package/opencode-sdk/moon.mod
+++ b/mbt/package/opencode-sdk/moon.mod
@@ -10,6 +10,7 @@ import {
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.20.1",
   "totto2727/agent-cli-sdk@0.1.0",
+  "totto2727/copy@0.1.0",
   "totto2727/lens@0.1.0",
 }
 

--- a/mbt/package/opencode-sdk/src/exec.mbt
+++ b/mbt/package/opencode-sdk/src/exec.mbt
@@ -78,7 +78,7 @@ async fn OpenCodeExec::run(
   }
 
   let environment = match self.env_override {
-    Some(environment_override) => environment_override.copy()
+    Some(environment_override) => @copy.Copy::copy(environment_override)
     None => Map([])
   }
   if self.config is Some(config) {

--- a/mbt/package/opencode-sdk/src/moon.pkg
+++ b/mbt/package/opencode-sdk/src/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/core/string",
   "moonbitlang/x/path",
   "totto2727/agent-cli-sdk" @agent_cli,
+  "totto2727/copy",
   "totto2727/lens",
 }
 


### PR DESCRIPTION
## 概要

`Copy` trait に `ReadOnlyArray` と `Map` の実装を追加し、Codex SDK・OpenCode SDK・agent graph のコピー処理を共通実装へ移行します。agent graph のメタデータとルーティング対象を安全に複製できるようにし、関連する依存関係と設定も更新します。

```mermaid
flowchart TD
  A[Copy trait] --> B[ReadOnlyArray の複製]
  A --> C[Map の複製]
  B --> D[NodeMetadata の複製]
  C --> E[環境変数の複製]
  D --> F[agent graph の node/router]
  E --> G[Codex SDK]
  E --> H[OpenCode SDK]
```

## Testing

Not run (not requested)