### PR TITLE
Require explicit deep-copy implementations for custom types

### DIFF
--- a/mbt/package/copy/README.mbt.md
+++ b/mbt/package/copy/README.mbt.md
@@ -4,6 +4,8 @@ An explicit copy trait for MoonBit values.
 
 MoonBit does not move values when they are passed to a function, so this package is not a marker for Rust-style move semantics. `Copy::copy` instead creates an independent logical copy. Composite implementations recursively copy their contents, while immutable storage may be shared when it cannot expose mutation.
 
+`Copy` has no blanket or default implementation. Every custom type must explicitly define how its independent logical copy is constructed so mutable fields and collections cannot be shared accidentally.
+
 ## Generic copying
 
 Use a `Copy` bound when an operation must produce a logically independent value:

--- a/mbt/package/copy/src/copy.mbt
+++ b/mbt/package/copy/src/copy.mbt
@@ -5,58 +5,83 @@
 /// implementation may share immutable internal storage when doing so cannot
 /// expose mutation through the returned value.
 pub(open) trait Copy {
-  fn copy(Self) -> Self = _
+  fn copy(Self) -> Self
 }
 
 ///|
-impl Copy with fn copy(self) {
+pub impl Copy for Unit with fn copy(self) {
   self
 }
 
 ///|
-pub impl Copy for Unit
+pub impl Copy for Bool with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for Bool
+pub impl Copy for Byte with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for Byte
+pub impl Copy for Char with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for Char
+pub impl Copy for Int16 with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for Int16
+pub impl Copy for Int with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for Int
+pub impl Copy for Int64 with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for Int64
+pub impl Copy for UInt16 with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for UInt16
+pub impl Copy for UInt with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for UInt
+pub impl Copy for UInt64 with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for UInt64
+pub impl Copy for Float with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for Float
+pub impl Copy for Double with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for Double
+pub impl Copy for BigInt with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for BigInt
+pub impl Copy for String with fn copy(self) {
+  self
+}
 
 ///|
-pub impl Copy for String
-
-///|
-pub impl Copy for Bytes
+pub impl Copy for Bytes with fn copy(self) {
+  self
+}
 
 ///|
 pub impl[T : Copy] Copy for T? with fn copy(self) {

--- a/mbt/package/copy/src/copy_test.mbt
+++ b/mbt/package/copy/src/copy_test.mbt
@@ -1,11 +1,12 @@
 ///|
 priv struct MutableBox {
   mut value : Int
+  values : Array[Int]
 }
 
 ///|
 impl @copy.Copy for MutableBox with fn copy(self) {
-  MutableBox::{ value: self.value }
+  MutableBox::{ value: self.value, values: @copy.Copy::copy(self.values) }
 }
 
 ///|
@@ -31,8 +32,12 @@ test "Copy::copy - recursively copies composite values" {
 
 ///|
 test "MutableBox Copy::copy - uses the type-defined copy policy" {
-  let source = MutableBox::{ value: 1 }
+  let source = MutableBox::{ value: 1, values: [1] }
   let copied = @copy.Copy::copy(source)
   copied.value = 2
-  debug_inspect((source.value, copied.value), content="(1, 2)")
+  copied.values[0] = 2
+  debug_inspect(
+    (source.value, source.values[0], copied.value, copied.values[0]),
+    content="(1, 1, 2, 2)",
+  )
 }

--- a/mbt/package/moon-agent-graph/src/core/identifiers.mbt
+++ b/mbt/package/moon-agent-graph/src/core/identifiers.mbt
@@ -2,7 +2,10 @@
 pub struct NodeId(String) derive(Eq, Hash, Debug)
 
 ///|
-pub impl @copy.Copy for NodeId
+pub impl @copy.Copy for NodeId with fn copy(self) {
+  let NodeId(value) = self
+  NodeId(@copy.Copy::copy(value))
+}
 
 ///|
 pub struct RunId(String) derive(Eq, Hash, Debug)


### PR DESCRIPTION
## 概要

`Copy` から暗黙のデフォルト実装を削除し、カスタム型が独立したコピー方法を明示的に定義するようにします。可変コレクションの共有を防ぎ、`NodeId` と組み込み型の実装を明示化します。

```mermaid
flowchart TD
  A[Copy trait] --> B{明示的な実装があるか}
  B -->|Yes| C[定義されたコピー方針を適用]
  B -->|No| D[コンパイル時に実装不足として検出]
  C --> E[可変フィールドを独立コピー]
```

## Testing

- MutableBox のスカラー値と配列をコピーし、コピー側の変更が元値に影響しないことを検証しました。

```mermaid
flowchart TD
  A[MutableBoxを作成] --> B[Copy::copyを実行]
  B --> C[コピー側のIntを変更]
  C --> D[コピー側のArray要素を変更]
  D --> E{元値が保持されるか}
  E -->|Yes| F[テスト成功]
  E -->|No| G[テスト失敗]
```

- Unit、Bool、数値型、String、Bytes などの組み込み型の明示的なコピー実装を追加しました。
- テストは未実行です。