### PR TITLE
Add typed Any collection maps for MoonBit

### DIFF
--- a/mbt/package/any-collection/README.mbt.md
+++ b/mbt/package/any-collection/README.mbt.md
@@ -17,6 +17,10 @@ test {
   mutable.set(retry_count, 2)
   debug_inspect(mutable.get(request_id), content="Some(\"request-1\")")
   debug_inspect(mutable.get(retry_count), content="Some(2)")
+  let retry_text : @any_collection.AnyRef[String, String] =
+    @any_collection.AnyRef::AnyRef("retry_count")
+  inspect(mutable.get_or(retry_text, "fallback"), content="fallback")
+  debug_inspect(mutable.get_or_none(retry_text), content="None")
   inspect(mutable.map.length(), content="2")
 
   let immutable =
@@ -31,6 +35,8 @@ test {
 
 The wrappers only provide the operations that require a typed reference and value conversion. Use the public `map` field directly for operations such as `contains`, `remove`, `length`, `is_empty`, iteration, and merging. Direct insertion of `Any` values is allowed.
 
-`get` returns `None` when a key is absent or when the stored runtime type does not match the reference's type. Define one shared `AnyRef[K, T]` for each key and value type so mismatched references cannot be introduced accidentally.
+`get` returns `None` when a key is absent and raises the original `Yoorkin/any` conversion error when the stored runtime type does not match the reference's type. `get_or` replaces both absence and conversion errors with its default value. `get_or_none` preserves successful and missing results while replacing conversion errors with `None`.
+
+Define one shared `AnyRef[K, T]` for each key and value type so mismatched references cannot be introduced accidentally.
 
 Value types must implement `Yoorkin/any.Anyable`. The dependency provides implementations for MoonBit core types. Custom types must extend `Yoorkin/any.Payload` and implement `Anyable`; see `src/examples/basic/main.mbt` for a complete example.

--- a/mbt/package/any-collection/README.mbt.md
+++ b/mbt/package/any-collection/README.mbt.md
@@ -12,9 +12,10 @@ test {
   let retry_count : @any_collection.AnyRef[String, Int] =
     @any_collection.AnyRef::AnyRef("retry_count")
 
-  let mutable = @any_collection.AnyMutableMap::AnyMutableMap()
-  mutable.set(request_id, "request-1")
-  mutable.set(retry_count, 2)
+  let mutable = @any_collection.AnyMutableMap::AnyMutableMap([
+    request_id.entry("request-1"),
+    retry_count.entry(2),
+  ])
   debug_inspect(mutable.get(request_id), content="Some(\"request-1\")")
   debug_inspect(mutable.get(retry_count), content="Some(2)")
   let retry_text : @any_collection.AnyRef[String, String] =
@@ -23,13 +24,15 @@ test {
   debug_inspect(mutable.get_or_none(retry_text), content="None")
   inspect(mutable.map.length(), content="2")
 
-  let immutable =
-    @any_collection.AnyImmutableHashMap::AnyImmutableHashMap()
-    .added(request_id, "request-2")
+  let immutable = @any_collection.AnyImmutableHashMap::AnyImmutableHashMap([
+    request_id.entry("request-2"),
+  ])
   debug_inspect(immutable.get(request_id), content="Some(\"request-2\")")
   inspect(immutable.map.contains(request_id.key), content="true")
 }
 ```
+
+The constructors mirror the underlying collection interfaces: `AnyMutableMap(entries, capacity?)` delegates to `Map(entries, capacity?)`, while `AnyImmutableHashMap(entries)` delegates to `@immut.HashMap(entries)`. Pass `[]` to create an empty collection. Use `AnyRef::entry` to create a `(K, Yoorkin/any.Any)` constructor entry without handling `Any` directly. Raw `Any` entries remain accepted.
 
 `AnyMutableMap::set` mutates its map. `AnyImmutableHashMap::added` returns a new map and preserves its source map. Both map types accept the same `AnyRef[K, T]` instance.
 

--- a/mbt/package/any-collection/README.mbt.md
+++ b/mbt/package/any-collection/README.mbt.md
@@ -1,15 +1,15 @@
 # any-collection
 
-`totto2727/any-collection` provides mutable and immutable maps whose values are stored as `tonyfettes/any.Any` and retrieved through reusable typed references. Names are supplied only when references are defined; collection operations do not accept raw string names.
+`totto2727/any-collection` provides mutable and immutable maps whose values are stored as `Yoorkin/any.Any` and retrieved through reusable typed references. Keys are supplied when references are defined and may use any type supported by the underlying map.
 
 ## Usage
 
 ```mbt check
 ///|
 test {
-  let request_id : @any_collection.AnyRef[String] =
+  let request_id : @any_collection.AnyRef[String, String] =
     @any_collection.AnyRef::AnyRef("request_id")
-  let retry_count : @any_collection.AnyRef[Int] =
+  let retry_count : @any_collection.AnyRef[String, Int] =
     @any_collection.AnyRef::AnyRef("retry_count")
 
   let mutable = @any_collection.AnyMutableMap::AnyMutableMap()
@@ -17,14 +17,20 @@ test {
   mutable.set(retry_count, 2)
   debug_inspect(mutable.get(request_id), content="Some(\"request-1\")")
   debug_inspect(mutable.get(retry_count), content="Some(2)")
+  inspect(mutable.map.length(), content="2")
 
   let immutable =
     @any_collection.AnyImmutableHashMap::AnyImmutableHashMap()
     .added(request_id, "request-2")
   debug_inspect(immutable.get(request_id), content="Some(\"request-2\")")
+  inspect(immutable.map.contains(request_id.key), content="true")
 }
 ```
 
-`AnyMutableMap::set` mutates its map. `AnyImmutableHashMap::added` and `AnyImmutableHashMap::removed` return new maps and preserve their source maps. Both map types accept the same `AnyRef[T]` instance.
+`AnyMutableMap::set` mutates its map. `AnyImmutableHashMap::added` returns a new map and preserves its source map. Both map types accept the same `AnyRef[K, T]` instance.
 
-`get` returns `None` when a name is absent or when the stored runtime type does not match the reference's type. Define one shared `AnyRef[T]` for each name and value type so mismatched references cannot be introduced accidentally.
+The wrappers only provide the operations that require a typed reference and value conversion. Use the public `map` field directly for operations such as `contains`, `remove`, `length`, `is_empty`, iteration, and merging. Direct insertion of `Any` values is allowed.
+
+`get` returns `None` when a key is absent or when the stored runtime type does not match the reference's type. Define one shared `AnyRef[K, T]` for each key and value type so mismatched references cannot be introduced accidentally.
+
+Value types must implement `Yoorkin/any.Anyable`. The dependency provides implementations for MoonBit core types. Custom types must extend `Yoorkin/any.Payload` and implement `Anyable`; see `src/examples/basic/main.mbt` for a complete example.

--- a/mbt/package/any-collection/README.mbt.md
+++ b/mbt/package/any-collection/README.mbt.md
@@ -1,0 +1,30 @@
+# any-collection
+
+`totto2727/any-collection` provides mutable and immutable maps whose values are stored as `tonyfettes/any.Any` and retrieved through reusable typed references. Names are supplied only when references are defined; collection operations do not accept raw string names.
+
+## Usage
+
+```mbt check
+///|
+test {
+  let request_id : @any_collection.AnyRef[String] =
+    @any_collection.AnyRef::AnyRef("request_id")
+  let retry_count : @any_collection.AnyRef[Int] =
+    @any_collection.AnyRef::AnyRef("retry_count")
+
+  let mutable = @any_collection.AnyMutableMap::AnyMutableMap()
+  mutable.set(request_id, "request-1")
+  mutable.set(retry_count, 2)
+  debug_inspect(mutable.get(request_id), content="Some(\"request-1\")")
+  debug_inspect(mutable.get(retry_count), content="Some(2)")
+
+  let immutable =
+    @any_collection.AnyImmutableHashMap::AnyImmutableHashMap()
+    .added(request_id, "request-2")
+  debug_inspect(immutable.get(request_id), content="Some(\"request-2\")")
+}
+```
+
+`AnyMutableMap::set` mutates its map. `AnyImmutableHashMap::added` and `AnyImmutableHashMap::removed` return new maps and preserve their source maps. Both map types accept the same `AnyRef[T]` instance.
+
+`get` returns `None` when a name is absent or when the stored runtime type does not match the reference's type. Define one shared `AnyRef[T]` for each name and value type so mismatched references cannot be introduced accidentally.

--- a/mbt/package/any-collection/README.md
+++ b/mbt/package/any-collection/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/mbt/package/any-collection/moon.mod
+++ b/mbt/package/any-collection/moon.mod
@@ -3,7 +3,7 @@ name = "totto2727/any-collection"
 version = "0.1.0"
 
 import {
-  "tonyfettes/any@0.1.5",
+  "Yoorkin/any@0.2.1",
 }
 
 readme = "README.mbt.md"

--- a/mbt/package/any-collection/moon.mod
+++ b/mbt/package/any-collection/moon.mod
@@ -1,0 +1,19 @@
+name = "totto2727/any-collection"
+
+version = "0.1.0"
+
+import {
+  "tonyfettes/any@0.1.5",
+}
+
+readme = "README.mbt.md"
+
+repository = "https://github.com/totto2727-org/monorepo"
+
+license = "MIT"
+
+keywords = [ "any", "collection", "context", "map", "moonbit" ]
+
+description = "Typed references over mutable and immutable maps of dynamically typed values"
+
+source = "./src"

--- a/mbt/package/any-collection/src/examples/basic/main.mbt
+++ b/mbt/package/any-collection/src/examples/basic/main.mbt
@@ -55,19 +55,17 @@ fn main {
   guard immutable.map.contains(request_id.key) else {
     abort("missing immutable request ID key")
   }
-  guard mutable.get(request_id) is Some(mutable_request_id) else {
+  guard mutable.get_or_none(request_id) is Some(mutable_request_id) else {
     abort("missing mutable request ID")
   }
-  guard mutable.get(retry_count) is Some(retries) else {
-    abort("missing retry count")
-  }
-  guard immutable.get(request_id) is Some(immutable_request_id) else {
+  let retries = mutable.get_or(retry_count, 0)
+  guard immutable.get_or_none(request_id) is Some(immutable_request_id) else {
     abort("missing immutable request ID")
   }
-  guard mutable.get(request_context) is Some(mutable_context) else {
+  guard mutable.get_or_none(request_context) is Some(mutable_context) else {
     abort("missing mutable custom context")
   }
-  guard immutable.get(request_context) is Some(immutable_context) else {
+  guard immutable.get_or_none(request_context) is Some(immutable_context) else {
     abort("missing immutable custom context")
   }
   println(

--- a/mbt/package/any-collection/src/examples/basic/main.mbt
+++ b/mbt/package/any-collection/src/examples/basic/main.mbt
@@ -5,14 +5,35 @@ struct RequestContext {
 } derive(Debug, Eq)
 
 ///|
+extenum @any.Payload += {
+  RequestContext(RequestContext)
+}
+
+///|
+impl @any.Anyable for RequestContext with fn iso() {
+  {
+    id: @any.TypeId::TypeId(
+      "totto2727/any-collection/examples/basic",
+      "RequestContext",
+      [],
+    ),
+    box: context => RequestContext(context),
+    unbox: payload => {
+      guard payload is RequestContext(context)
+      context
+    },
+  }
+}
+
+///|
 fn main {
-  let request_id : @any_collection.AnyRef[String] = @any_collection.AnyRef::AnyRef(
+  let request_id : @any_collection.AnyRef[String, String] = @any_collection.AnyRef::AnyRef(
     "request_id",
   )
-  let retry_count : @any_collection.AnyRef[Int] = @any_collection.AnyRef::AnyRef(
+  let retry_count : @any_collection.AnyRef[String, Int] = @any_collection.AnyRef::AnyRef(
     "retry_count",
   )
-  let request_context : @any_collection.AnyRef[RequestContext] = @any_collection.AnyRef::AnyRef(
+  let request_context : @any_collection.AnyRef[String, RequestContext] = @any_collection.AnyRef::AnyRef(
     "request_context",
   )
   let mutable = @any_collection.AnyMutableMap::AnyMutableMap()
@@ -28,6 +49,12 @@ fn main {
       request_id: "immutable-custom",
       retry_count: 4,
     })
+  guard mutable.map.contains(request_id.key) else {
+    abort("missing mutable request ID key")
+  }
+  guard immutable.map.contains(request_id.key) else {
+    abort("missing immutable request ID key")
+  }
   guard mutable.get(request_id) is Some(mutable_request_id) else {
     abort("missing mutable request ID")
   }

--- a/mbt/package/any-collection/src/examples/basic/main.mbt
+++ b/mbt/package/any-collection/src/examples/basic/main.mbt
@@ -36,19 +36,21 @@ fn main {
   let request_context : @any_collection.AnyRef[String, RequestContext] = @any_collection.AnyRef::AnyRef(
     "request_context",
   )
-  let mutable = @any_collection.AnyMutableMap::AnyMutableMap()
-  mutable.set(request_id, "mutable-request")
-  mutable.set(retry_count, 2)
-  mutable.set(request_context, RequestContext::{
-    request_id: "mutable-custom",
-    retry_count: 3,
-  })
-  let immutable = @any_collection.AnyImmutableHashMap::AnyImmutableHashMap()
-    .added(request_id, "immutable-request")
-    .added(request_context, RequestContext::{
+  let mutable = @any_collection.AnyMutableMap::AnyMutableMap([
+    request_id.entry("mutable-request"),
+    retry_count.entry(2),
+    request_context.entry(RequestContext::{
+      request_id: "mutable-custom",
+      retry_count: 3,
+    }),
+  ])
+  let immutable = @any_collection.AnyImmutableHashMap::AnyImmutableHashMap([
+    request_id.entry("immutable-request"),
+    request_context.entry(RequestContext::{
       request_id: "immutable-custom",
       retry_count: 4,
-    })
+    }),
+  ])
   guard mutable.map.contains(request_id.key) else {
     abort("missing mutable request ID key")
   }

--- a/mbt/package/any-collection/src/examples/basic/main.mbt
+++ b/mbt/package/any-collection/src/examples/basic/main.mbt
@@ -1,0 +1,61 @@
+///|
+struct RequestContext {
+  request_id : String
+  retry_count : Int
+} derive(Debug, Eq)
+
+///|
+fn main {
+  let request_id : @any_collection.AnyRef[String] = @any_collection.AnyRef::AnyRef(
+    "request_id",
+  )
+  let retry_count : @any_collection.AnyRef[Int] = @any_collection.AnyRef::AnyRef(
+    "retry_count",
+  )
+  let request_context : @any_collection.AnyRef[RequestContext] = @any_collection.AnyRef::AnyRef(
+    "request_context",
+  )
+  let mutable = @any_collection.AnyMutableMap::AnyMutableMap()
+  mutable.set(request_id, "mutable-request")
+  mutable.set(retry_count, 2)
+  mutable.set(request_context, RequestContext::{
+    request_id: "mutable-custom",
+    retry_count: 3,
+  })
+  let immutable = @any_collection.AnyImmutableHashMap::AnyImmutableHashMap()
+    .added(request_id, "immutable-request")
+    .added(request_context, RequestContext::{
+      request_id: "immutable-custom",
+      retry_count: 4,
+    })
+  guard mutable.get(request_id) is Some(mutable_request_id) else {
+    abort("missing mutable request ID")
+  }
+  guard mutable.get(retry_count) is Some(retries) else {
+    abort("missing retry count")
+  }
+  guard immutable.get(request_id) is Some(immutable_request_id) else {
+    abort("missing immutable request ID")
+  }
+  guard mutable.get(request_context) is Some(mutable_context) else {
+    abort("missing mutable custom context")
+  }
+  guard immutable.get(request_context) is Some(immutable_context) else {
+    abort("missing immutable custom context")
+  }
+  println(
+    mutable_request_id +
+    "," +
+    retries.to_string() +
+    "," +
+    immutable_request_id +
+    "," +
+    mutable_context.request_id +
+    ":" +
+    mutable_context.retry_count.to_string() +
+    "," +
+    immutable_context.request_id +
+    ":" +
+    immutable_context.retry_count.to_string(),
+  )
+}

--- a/mbt/package/any-collection/src/examples/basic/moon.pkg
+++ b/mbt/package/any-collection/src/examples/basic/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "Yoorkin/any",
   "totto2727/any-collection" @any_collection,
 }
 

--- a/mbt/package/any-collection/src/examples/basic/moon.pkg
+++ b/mbt/package/any-collection/src/examples/basic/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "totto2727/any-collection" @any_collection,
+}
+
+pkgtype(kind: "executable")

--- a/mbt/package/any-collection/src/immutable_hash_map.mbt
+++ b/mbt/package/any-collection/src/immutable_hash_map.mbt
@@ -1,0 +1,63 @@
+///|
+/// An immutable hash map of named dynamically typed values accessed through
+/// `AnyRef`.
+pub struct AnyImmutableHashMap {
+  priv values : @immut.HashMap[String, @any.Any]
+}
+
+///|
+/// Creates an empty immutable any hash map.
+pub fn AnyImmutableHashMap::AnyImmutableHashMap() -> AnyImmutableHashMap {
+  { values: @immut.new() }
+}
+
+///|
+/// Returns a map associating `value` with `reference` without changing this map.
+pub fn[T] AnyImmutableHashMap::added(
+  self : AnyImmutableHashMap,
+  reference : AnyRef[T],
+  value : T,
+) -> AnyImmutableHashMap {
+  { values: self.values.add(reference.name, (reference.encode)(value)) }
+}
+
+///|
+/// Returns the value selected by `reference` when it exists with type `T`.
+///
+/// A missing name or a value stored through a differently typed reference
+/// returns `None`.
+pub fn[T] AnyImmutableHashMap::get(
+  self : AnyImmutableHashMap,
+  reference : AnyRef[T],
+) -> T? {
+  match self.values.get(reference.name) {
+    Some(value) => (reference.decode)(value)
+    None => None
+  }
+}
+
+///|
+/// Returns whether a value is associated with `reference`'s name.
+pub fn[T] AnyImmutableHashMap::contains(
+  self : AnyImmutableHashMap,
+  reference : AnyRef[T],
+) -> Bool {
+  self.values.contains(reference.name)
+}
+
+///|
+/// Returns a map without the value associated with `reference`'s name.
+pub fn[T] AnyImmutableHashMap::removed(
+  self : AnyImmutableHashMap,
+  reference : AnyRef[T],
+) -> AnyImmutableHashMap {
+  { values: self.values.remove(reference.name) }
+}
+
+///|
+/// Returns the number of stored values.
+///
+/// This operation has the same `O(N)` cost as `@immut.HashMap::length`.
+pub fn AnyImmutableHashMap::length(self : AnyImmutableHashMap) -> Int {
+  self.values.length()
+}

--- a/mbt/package/any-collection/src/immutable_hash_map.mbt
+++ b/mbt/package/any-collection/src/immutable_hash_map.mbt
@@ -6,9 +6,11 @@ pub(all) struct AnyImmutableHashMap[K] {
 }
 
 ///|
-/// Creates an empty immutable any hash map.
-pub fn[K] AnyImmutableHashMap::AnyImmutableHashMap() -> AnyImmutableHashMap[K] {
-  { map: @immut.new() }
+/// Creates an immutable any hash map from key-value pairs.
+pub fn[K : Hash + Eq] AnyImmutableHashMap::AnyImmutableHashMap(
+  entries : ArrayView[(K, @any.Any)],
+) -> AnyImmutableHashMap[K] {
+  { map: @immut.HashMap::HashMap(entries) }
 }
 
 ///|

--- a/mbt/package/any-collection/src/immutable_hash_map.mbt
+++ b/mbt/package/any-collection/src/immutable_hash_map.mbt
@@ -25,13 +25,37 @@ pub fn[K : Hash + Eq, T] AnyImmutableHashMap::added(
 /// Returns the value selected by `reference` when it exists with type `T`.
 ///
 /// A missing key or a value stored through a differently typed reference
-/// returns `None`.
+/// returns `None` or raises the conversion error, respectively.
 pub fn[K : Hash + Eq, T] AnyImmutableHashMap::get(
   self : AnyImmutableHashMap[K],
   reference : AnyRef[K, T],
-) -> T? {
+) -> T? raise {
   match self.map.get(reference.key) {
-    Some(value) => (reference.decode)(value)
+    Some(value) => Some((reference.decode)(value))
     None => None
+  }
+}
+
+///|
+/// Returns the selected value, replacing a missing key or conversion error with
+/// `default`.
+pub fn[K : Hash + Eq, T] AnyImmutableHashMap::get_or(
+  self : AnyImmutableHashMap[K],
+  reference : AnyRef[K, T],
+  default : T,
+) -> T {
+  try self.get(reference).unwrap_or(default) catch {
+    _ => default
+  }
+}
+
+///|
+/// Returns the selected value, replacing a conversion error with `None`.
+pub fn[K : Hash + Eq, T] AnyImmutableHashMap::get_or_none(
+  self : AnyImmutableHashMap[K],
+  reference : AnyRef[K, T],
+) -> T? {
+  try self.get(reference) catch {
+    _ => None
   }
 }

--- a/mbt/package/any-collection/src/immutable_hash_map.mbt
+++ b/mbt/package/any-collection/src/immutable_hash_map.mbt
@@ -1,63 +1,37 @@
 ///|
-/// An immutable hash map of named dynamically typed values accessed through
+/// An immutable hash map of dynamically typed values accessed through
 /// `AnyRef`.
-pub struct AnyImmutableHashMap {
-  priv values : @immut.HashMap[String, @any.Any]
+pub(all) struct AnyImmutableHashMap[K] {
+  map : @immut.HashMap[K, @any.Any]
 }
 
 ///|
 /// Creates an empty immutable any hash map.
-pub fn AnyImmutableHashMap::AnyImmutableHashMap() -> AnyImmutableHashMap {
-  { values: @immut.new() }
+pub fn[K] AnyImmutableHashMap::AnyImmutableHashMap() -> AnyImmutableHashMap[K] {
+  { map: @immut.new() }
 }
 
 ///|
 /// Returns a map associating `value` with `reference` without changing this map.
-pub fn[T] AnyImmutableHashMap::added(
-  self : AnyImmutableHashMap,
-  reference : AnyRef[T],
+pub fn[K : Hash + Eq, T] AnyImmutableHashMap::added(
+  self : AnyImmutableHashMap[K],
+  reference : AnyRef[K, T],
   value : T,
-) -> AnyImmutableHashMap {
-  { values: self.values.add(reference.name, (reference.encode)(value)) }
+) -> AnyImmutableHashMap[K] {
+  { map: self.map.add(reference.key, (reference.encode)(value)) }
 }
 
 ///|
 /// Returns the value selected by `reference` when it exists with type `T`.
 ///
-/// A missing name or a value stored through a differently typed reference
+/// A missing key or a value stored through a differently typed reference
 /// returns `None`.
-pub fn[T] AnyImmutableHashMap::get(
-  self : AnyImmutableHashMap,
-  reference : AnyRef[T],
+pub fn[K : Hash + Eq, T] AnyImmutableHashMap::get(
+  self : AnyImmutableHashMap[K],
+  reference : AnyRef[K, T],
 ) -> T? {
-  match self.values.get(reference.name) {
+  match self.map.get(reference.key) {
     Some(value) => (reference.decode)(value)
     None => None
   }
-}
-
-///|
-/// Returns whether a value is associated with `reference`'s name.
-pub fn[T] AnyImmutableHashMap::contains(
-  self : AnyImmutableHashMap,
-  reference : AnyRef[T],
-) -> Bool {
-  self.values.contains(reference.name)
-}
-
-///|
-/// Returns a map without the value associated with `reference`'s name.
-pub fn[T] AnyImmutableHashMap::removed(
-  self : AnyImmutableHashMap,
-  reference : AnyRef[T],
-) -> AnyImmutableHashMap {
-  { values: self.values.remove(reference.name) }
-}
-
-///|
-/// Returns the number of stored values.
-///
-/// This operation has the same `O(N)` cost as `@immut.HashMap::length`.
-pub fn AnyImmutableHashMap::length(self : AnyImmutableHashMap) -> Int {
-  self.values.length()
 }

--- a/mbt/package/any-collection/src/immutable_hash_map_test.mbt
+++ b/mbt/package/any-collection/src/immutable_hash_map_test.mbt
@@ -1,0 +1,22 @@
+///|
+test "AnyImmutableHashMap added - preserves the original map" {
+  let request_id : AnyRef[String] = AnyRef::AnyRef("request_id")
+  let original = AnyImmutableHashMap::AnyImmutableHashMap()
+  let updated = original.added(request_id, "request-1")
+  debug_inspect(original.get(request_id), content="None")
+  debug_inspect(updated.get(request_id), content="Some(\"request-1\")")
+  inspect(updated.contains(request_id), content="true")
+  inspect(updated.length(), content="1")
+}
+
+///|
+test "AnyImmutableHashMap removed - preserves the source map" {
+  let request_id : AnyRef[String] = AnyRef::AnyRef("request_id")
+  let populated = AnyImmutableHashMap::AnyImmutableHashMap().added(
+    request_id, "request-1",
+  )
+  let removed = populated.removed(request_id)
+  debug_inspect(populated.get(request_id), content="Some(\"request-1\")")
+  debug_inspect(removed.get(request_id), content="None")
+  inspect(removed.length(), content="0")
+}

--- a/mbt/package/any-collection/src/immutable_hash_map_test.mbt
+++ b/mbt/package/any-collection/src/immutable_hash_map_test.mbt
@@ -22,3 +22,23 @@ test "AnyImmutableHashMap map - exposes persistent operations" {
   debug_inspect(removed.get(request_id), content="None")
   inspect(removed.map.length(), content="0")
 }
+
+///|
+test "AnyImmutableHashMap get variants - handle conversion errors explicitly" {
+  let count : AnyRef[Int, Int] = AnyRef::AnyRef(1)
+  let text : AnyRef[Int, String] = AnyRef::AnyRef(1)
+  let missing : AnyRef[Int, String] = AnyRef::AnyRef(2)
+  let context = AnyImmutableHashMap::AnyImmutableHashMap().added(count, 2)
+  let mismatch_raised = try {
+    context.get(text) |> ignore
+    false
+  } catch {
+    Failure::Failure(_) => true
+    _ => false
+  }
+  inspect(mismatch_raised, content="true")
+  inspect(context.get_or(text, "fallback"), content="fallback")
+  inspect(context.get_or(missing, "fallback"), content="fallback")
+  debug_inspect(context.get_or_none(text), content="None")
+  debug_inspect(context.get_or_none(missing), content="None")
+}

--- a/mbt/package/any-collection/src/immutable_hash_map_test.mbt
+++ b/mbt/package/any-collection/src/immutable_hash_map_test.mbt
@@ -1,22 +1,24 @@
 ///|
 test "AnyImmutableHashMap added - preserves the original map" {
-  let request_id : AnyRef[String] = AnyRef::AnyRef("request_id")
+  let request_id : AnyRef[String, String] = AnyRef::AnyRef("request_id")
   let original = AnyImmutableHashMap::AnyImmutableHashMap()
   let updated = original.added(request_id, "request-1")
   debug_inspect(original.get(request_id), content="None")
   debug_inspect(updated.get(request_id), content="Some(\"request-1\")")
-  inspect(updated.contains(request_id), content="true")
-  inspect(updated.length(), content="1")
+  inspect(updated.map.contains(request_id.key), content="true")
+  inspect(updated.map.length(), content="1")
 }
 
 ///|
-test "AnyImmutableHashMap removed - preserves the source map" {
-  let request_id : AnyRef[String] = AnyRef::AnyRef("request_id")
+test "AnyImmutableHashMap map - exposes persistent operations" {
+  let request_id : AnyRef[String, String] = AnyRef::AnyRef("request_id")
   let populated = AnyImmutableHashMap::AnyImmutableHashMap().added(
     request_id, "request-1",
   )
-  let removed = populated.removed(request_id)
+  let removed : AnyImmutableHashMap[String] = {
+    map: populated.map.remove(request_id.key),
+  }
   debug_inspect(populated.get(request_id), content="Some(\"request-1\")")
   debug_inspect(removed.get(request_id), content="None")
-  inspect(removed.length(), content="0")
+  inspect(removed.map.length(), content="0")
 }

--- a/mbt/package/any-collection/src/immutable_hash_map_test.mbt
+++ b/mbt/package/any-collection/src/immutable_hash_map_test.mbt
@@ -1,10 +1,12 @@
 ///|
 test "AnyImmutableHashMap added - preserves the original map" {
   let request_id : AnyRef[String, String] = AnyRef::AnyRef("request_id")
-  let original = AnyImmutableHashMap::AnyImmutableHashMap()
-  let updated = original.added(request_id, "request-1")
-  debug_inspect(original.get(request_id), content="None")
-  debug_inspect(updated.get(request_id), content="Some(\"request-1\")")
+  let original = AnyImmutableHashMap::AnyImmutableHashMap([
+    request_id.entry("request-1"),
+  ])
+  let updated = original.added(request_id, "request-2")
+  debug_inspect(original.get(request_id), content="Some(\"request-1\")")
+  debug_inspect(updated.get(request_id), content="Some(\"request-2\")")
   inspect(updated.map.contains(request_id.key), content="true")
   inspect(updated.map.length(), content="1")
 }
@@ -12,9 +14,9 @@ test "AnyImmutableHashMap added - preserves the original map" {
 ///|
 test "AnyImmutableHashMap map - exposes persistent operations" {
   let request_id : AnyRef[String, String] = AnyRef::AnyRef("request_id")
-  let populated = AnyImmutableHashMap::AnyImmutableHashMap().added(
-    request_id, "request-1",
-  )
+  let populated = AnyImmutableHashMap::AnyImmutableHashMap([
+    request_id.entry("request-1"),
+  ])
   let removed : AnyImmutableHashMap[String] = {
     map: populated.map.remove(request_id.key),
   }
@@ -28,7 +30,7 @@ test "AnyImmutableHashMap get variants - handle conversion errors explicitly" {
   let count : AnyRef[Int, Int] = AnyRef::AnyRef(1)
   let text : AnyRef[Int, String] = AnyRef::AnyRef(1)
   let missing : AnyRef[Int, String] = AnyRef::AnyRef(2)
-  let context = AnyImmutableHashMap::AnyImmutableHashMap().added(count, 2)
+  let context = AnyImmutableHashMap::AnyImmutableHashMap([count.entry(2)])
   let mismatch_raised = try {
     context.get(text) |> ignore
     false

--- a/mbt/package/any-collection/src/moon.pkg
+++ b/mbt/package/any-collection/src/moon.pkg
@@ -1,0 +1,4 @@
+import {
+  "moonbitlang/core/immut/hashmap" @immut,
+  "tonyfettes/any",
+}

--- a/mbt/package/any-collection/src/moon.pkg
+++ b/mbt/package/any-collection/src/moon.pkg
@@ -1,4 +1,4 @@
 import {
+  "Yoorkin/any",
   "moonbitlang/core/immut/hashmap" @immut,
-  "tonyfettes/any",
 }

--- a/mbt/package/any-collection/src/mutable_map.mbt
+++ b/mbt/package/any-collection/src/mutable_map.mbt
@@ -1,0 +1,66 @@
+///|
+/// A mutable map of named dynamically typed values accessed through `AnyRef`.
+pub struct AnyMutableMap {
+  priv values : Map[String, @any.Any]
+}
+
+///|
+/// Creates an empty mutable any map.
+pub fn AnyMutableMap::AnyMutableMap() -> AnyMutableMap {
+  { values: Map([]) }
+}
+
+///|
+/// Associates `value` with `reference`, replacing an existing value.
+pub fn[T] AnyMutableMap::set(
+  self : AnyMutableMap,
+  reference : AnyRef[T],
+  value : T,
+) -> Unit {
+  self.values[reference.name] = (reference.encode)(value)
+}
+
+///|
+/// Returns the value selected by `reference` when it exists with type `T`.
+///
+/// A missing name or a value stored through a differently typed reference
+/// returns `None`.
+pub fn[T] AnyMutableMap::get(
+  self : AnyMutableMap,
+  reference : AnyRef[T],
+) -> T? {
+  match self.values.get(reference.name) {
+    Some(value) => (reference.decode)(value)
+    None => None
+  }
+}
+
+///|
+/// Returns whether a value is associated with `reference`'s name.
+pub fn[T] AnyMutableMap::contains(
+  self : AnyMutableMap,
+  reference : AnyRef[T],
+) -> Bool {
+  self.values.contains(reference.name)
+}
+
+///|
+/// Removes the value associated with `reference`'s name when present.
+pub fn[T] AnyMutableMap::remove(
+  self : AnyMutableMap,
+  reference : AnyRef[T],
+) -> Unit {
+  self.values.remove(reference.name)
+}
+
+///|
+/// Returns the number of stored values.
+pub fn AnyMutableMap::length(self : AnyMutableMap) -> Int {
+  self.values.length()
+}
+
+///|
+/// Returns whether this map contains no values.
+pub fn AnyMutableMap::is_empty(self : AnyMutableMap) -> Bool {
+  self.values.is_empty()
+}

--- a/mbt/package/any-collection/src/mutable_map.mbt
+++ b/mbt/package/any-collection/src/mutable_map.mbt
@@ -24,13 +24,37 @@ pub fn[K : Hash + Eq, T] AnyMutableMap::set(
 /// Returns the value selected by `reference` when it exists with type `T`.
 ///
 /// A missing key or a value stored through a differently typed reference
-/// returns `None`.
+/// returns `None` or raises the conversion error, respectively.
 pub fn[K : Hash + Eq, T] AnyMutableMap::get(
   self : AnyMutableMap[K],
   reference : AnyRef[K, T],
-) -> T? {
+) -> T? raise {
   match self.map.get(reference.key) {
-    Some(value) => (reference.decode)(value)
+    Some(value) => Some((reference.decode)(value))
     None => None
+  }
+}
+
+///|
+/// Returns the selected value, replacing a missing key or conversion error with
+/// `default`.
+pub fn[K : Hash + Eq, T] AnyMutableMap::get_or(
+  self : AnyMutableMap[K],
+  reference : AnyRef[K, T],
+  default : T,
+) -> T {
+  try self.get(reference).unwrap_or(default) catch {
+    _ => default
+  }
+}
+
+///|
+/// Returns the selected value, replacing a conversion error with `None`.
+pub fn[K : Hash + Eq, T] AnyMutableMap::get_or_none(
+  self : AnyMutableMap[K],
+  reference : AnyRef[K, T],
+) -> T? {
+  try self.get(reference) catch {
+    _ => None
   }
 }

--- a/mbt/package/any-collection/src/mutable_map.mbt
+++ b/mbt/package/any-collection/src/mutable_map.mbt
@@ -1,66 +1,36 @@
 ///|
-/// A mutable map of named dynamically typed values accessed through `AnyRef`.
-pub struct AnyMutableMap {
-  priv values : Map[String, @any.Any]
+/// A mutable map of dynamically typed values accessed through `AnyRef`.
+pub(all) struct AnyMutableMap[K] {
+  map : Map[K, @any.Any]
 }
 
 ///|
 /// Creates an empty mutable any map.
-pub fn AnyMutableMap::AnyMutableMap() -> AnyMutableMap {
-  { values: Map([]) }
+pub fn[K : Hash + Eq] AnyMutableMap::AnyMutableMap() -> AnyMutableMap[K] {
+  { map: Map([]) }
 }
 
 ///|
 /// Associates `value` with `reference`, replacing an existing value.
-pub fn[T] AnyMutableMap::set(
-  self : AnyMutableMap,
-  reference : AnyRef[T],
+pub fn[K : Hash + Eq, T] AnyMutableMap::set(
+  self : AnyMutableMap[K],
+  reference : AnyRef[K, T],
   value : T,
 ) -> Unit {
-  self.values[reference.name] = (reference.encode)(value)
+  self.map[reference.key] = (reference.encode)(value)
 }
 
 ///|
 /// Returns the value selected by `reference` when it exists with type `T`.
 ///
-/// A missing name or a value stored through a differently typed reference
+/// A missing key or a value stored through a differently typed reference
 /// returns `None`.
-pub fn[T] AnyMutableMap::get(
-  self : AnyMutableMap,
-  reference : AnyRef[T],
+pub fn[K : Hash + Eq, T] AnyMutableMap::get(
+  self : AnyMutableMap[K],
+  reference : AnyRef[K, T],
 ) -> T? {
-  match self.values.get(reference.name) {
+  match self.map.get(reference.key) {
     Some(value) => (reference.decode)(value)
     None => None
   }
-}
-
-///|
-/// Returns whether a value is associated with `reference`'s name.
-pub fn[T] AnyMutableMap::contains(
-  self : AnyMutableMap,
-  reference : AnyRef[T],
-) -> Bool {
-  self.values.contains(reference.name)
-}
-
-///|
-/// Removes the value associated with `reference`'s name when present.
-pub fn[T] AnyMutableMap::remove(
-  self : AnyMutableMap,
-  reference : AnyRef[T],
-) -> Unit {
-  self.values.remove(reference.name)
-}
-
-///|
-/// Returns the number of stored values.
-pub fn AnyMutableMap::length(self : AnyMutableMap) -> Int {
-  self.values.length()
-}
-
-///|
-/// Returns whether this map contains no values.
-pub fn AnyMutableMap::is_empty(self : AnyMutableMap) -> Bool {
-  self.values.is_empty()
 }

--- a/mbt/package/any-collection/src/mutable_map.mbt
+++ b/mbt/package/any-collection/src/mutable_map.mbt
@@ -5,9 +5,12 @@ pub(all) struct AnyMutableMap[K] {
 }
 
 ///|
-/// Creates an empty mutable any map.
-pub fn[K : Hash + Eq] AnyMutableMap::AnyMutableMap() -> AnyMutableMap[K] {
-  { map: Map([]) }
+/// Creates a mutable any map from key-value pairs.
+pub fn[K : Hash + Eq] AnyMutableMap::AnyMutableMap(
+  entries : ArrayView[(K, @any.Any)],
+  capacity? : Int,
+) -> AnyMutableMap[K] {
+  { map: Map(entries, capacity?) }
 }
 
 ///|

--- a/mbt/package/any-collection/src/mutable_map_test.mbt
+++ b/mbt/package/any-collection/src/mutable_map_test.mbt
@@ -2,9 +2,10 @@
 test "AnyMutableMap get - returns values through typed references" {
   let request_id : AnyRef[String, String] = AnyRef::AnyRef("request_id")
   let retry_count : AnyRef[String, Int] = AnyRef::AnyRef("retry_count")
-  let context = AnyMutableMap::AnyMutableMap()
-  context.set(request_id, "request-1")
-  context.set(retry_count, 2)
+  let context = AnyMutableMap::AnyMutableMap(
+    [request_id.entry("request-1"), retry_count.entry(2)],
+    capacity=8,
+  )
   debug_inspect(context.get(request_id), content="Some(\"request-1\")")
   debug_inspect(context.get(retry_count), content="Some(2)")
 }
@@ -14,8 +15,7 @@ test "AnyMutableMap get variants - handle conversion errors explicitly" {
   let count : AnyRef[Int, Int] = AnyRef::AnyRef(1)
   let text : AnyRef[Int, String] = AnyRef::AnyRef(1)
   let missing : AnyRef[Int, String] = AnyRef::AnyRef(2)
-  let context = AnyMutableMap::AnyMutableMap()
-  context.set(count, 2)
+  let context = AnyMutableMap::AnyMutableMap([count.entry(2)])
   let mismatch_raised = try {
     context.get(text) |> ignore
     false
@@ -33,7 +33,7 @@ test "AnyMutableMap get variants - handle conversion errors explicitly" {
 ///|
 test "AnyMutableMap map - exposes operations without typed conversion" {
   let request_id : AnyRef[String, String] = AnyRef::AnyRef("request_id")
-  let context = AnyMutableMap::AnyMutableMap()
+  let context = AnyMutableMap::AnyMutableMap([])
   context.set(request_id, "request-1")
   context.map.remove(request_id.key)
   debug_inspect(context.get(request_id), content="None")

--- a/mbt/package/any-collection/src/mutable_map_test.mbt
+++ b/mbt/package/any-collection/src/mutable_map_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "AnyMutableMap get - returns values through typed references" {
-  let request_id : AnyRef[String] = AnyRef::AnyRef("request_id")
-  let retry_count : AnyRef[Int] = AnyRef::AnyRef("retry_count")
+  let request_id : AnyRef[String, String] = AnyRef::AnyRef("request_id")
+  let retry_count : AnyRef[String, Int] = AnyRef::AnyRef("retry_count")
   let context = AnyMutableMap::AnyMutableMap()
   context.set(request_id, "request-1")
   context.set(retry_count, 2)
@@ -11,21 +11,21 @@ test "AnyMutableMap get - returns values through typed references" {
 
 ///|
 test "AnyMutableMap get - rejects a mismatched reference type" {
-  let count : AnyRef[Int] = AnyRef::AnyRef("value")
-  let text : AnyRef[String] = AnyRef::AnyRef("value")
+  let count : AnyRef[Int, Int] = AnyRef::AnyRef(1)
+  let text : AnyRef[Int, String] = AnyRef::AnyRef(1)
   let context = AnyMutableMap::AnyMutableMap()
   context.set(count, 2)
   debug_inspect(context.get(text), content="None")
 }
 
 ///|
-test "AnyMutableMap remove - removes the referenced value" {
-  let request_id : AnyRef[String] = AnyRef::AnyRef("request_id")
+test "AnyMutableMap map - exposes operations without typed conversion" {
+  let request_id : AnyRef[String, String] = AnyRef::AnyRef("request_id")
   let context = AnyMutableMap::AnyMutableMap()
   context.set(request_id, "request-1")
-  context.remove(request_id)
+  context.map.remove(request_id.key)
   debug_inspect(context.get(request_id), content="None")
-  inspect(context.contains(request_id), content="false")
-  inspect(context.length(), content="0")
-  inspect(context.is_empty(), content="true")
+  inspect(context.map.contains(request_id.key), content="false")
+  inspect(context.map.length(), content="0")
+  inspect(context.map.is_empty(), content="true")
 }

--- a/mbt/package/any-collection/src/mutable_map_test.mbt
+++ b/mbt/package/any-collection/src/mutable_map_test.mbt
@@ -1,0 +1,31 @@
+///|
+test "AnyMutableMap get - returns values through typed references" {
+  let request_id : AnyRef[String] = AnyRef::AnyRef("request_id")
+  let retry_count : AnyRef[Int] = AnyRef::AnyRef("retry_count")
+  let context = AnyMutableMap::AnyMutableMap()
+  context.set(request_id, "request-1")
+  context.set(retry_count, 2)
+  debug_inspect(context.get(request_id), content="Some(\"request-1\")")
+  debug_inspect(context.get(retry_count), content="Some(2)")
+}
+
+///|
+test "AnyMutableMap get - rejects a mismatched reference type" {
+  let count : AnyRef[Int] = AnyRef::AnyRef("value")
+  let text : AnyRef[String] = AnyRef::AnyRef("value")
+  let context = AnyMutableMap::AnyMutableMap()
+  context.set(count, 2)
+  debug_inspect(context.get(text), content="None")
+}
+
+///|
+test "AnyMutableMap remove - removes the referenced value" {
+  let request_id : AnyRef[String] = AnyRef::AnyRef("request_id")
+  let context = AnyMutableMap::AnyMutableMap()
+  context.set(request_id, "request-1")
+  context.remove(request_id)
+  debug_inspect(context.get(request_id), content="None")
+  inspect(context.contains(request_id), content="false")
+  inspect(context.length(), content="0")
+  inspect(context.is_empty(), content="true")
+}

--- a/mbt/package/any-collection/src/mutable_map_test.mbt
+++ b/mbt/package/any-collection/src/mutable_map_test.mbt
@@ -10,12 +10,24 @@ test "AnyMutableMap get - returns values through typed references" {
 }
 
 ///|
-test "AnyMutableMap get - rejects a mismatched reference type" {
+test "AnyMutableMap get variants - handle conversion errors explicitly" {
   let count : AnyRef[Int, Int] = AnyRef::AnyRef(1)
   let text : AnyRef[Int, String] = AnyRef::AnyRef(1)
+  let missing : AnyRef[Int, String] = AnyRef::AnyRef(2)
   let context = AnyMutableMap::AnyMutableMap()
   context.set(count, 2)
-  debug_inspect(context.get(text), content="None")
+  let mismatch_raised = try {
+    context.get(text) |> ignore
+    false
+  } catch {
+    Failure::Failure(_) => true
+    _ => false
+  }
+  inspect(mismatch_raised, content="true")
+  inspect(context.get_or(text, "fallback"), content="fallback")
+  inspect(context.get_or(missing, "fallback"), content="fallback")
+  debug_inspect(context.get_or_none(text), content="None")
+  debug_inspect(context.get_or_none(missing), content="None")
 }
 
 ///|

--- a/mbt/package/any-collection/src/reference.mbt
+++ b/mbt/package/any-collection/src/reference.mbt
@@ -6,7 +6,7 @@
 pub struct AnyRef[K, T] {
   key : K
   priv encode : (T) -> @any.Any
-  priv decode : (@any.Any) -> T?
+  priv decode : (@any.Any) -> T raise
 }
 
 ///|
@@ -14,16 +14,11 @@ pub struct AnyRef[K, T] {
 ///
 /// Callers should define one shared reference per key and value type. Creating
 /// references with the same key but different value types makes mismatched
-/// reads return `None`.
+/// reads raise the conversion error unless a fallback getter is used.
 pub fn[K, T : @any.Anyable] AnyRef::AnyRef(key : K) -> AnyRef[K, T] {
   {
     key,
     encode: value => @any.Any::Any(value),
-    decode: value =>
-      try {
-        Some((value.dyn_cast() : T))
-      } catch {
-        _ => None
-      },
+    decode: value => (value.dyn_cast() : T),
   }
 }

--- a/mbt/package/any-collection/src/reference.mbt
+++ b/mbt/package/any-collection/src/reference.mbt
@@ -1,24 +1,29 @@
 ///|
-/// A reusable typed reference to one named value in an any collection.
+/// A reusable typed reference to one keyed value in an any collection.
 ///
 /// The same reference can be used with both `AnyMutableMap` and
 /// `AnyImmutableHashMap`.
-pub struct AnyRef[T] {
-  priv name : String
+pub struct AnyRef[K, T] {
+  key : K
   priv encode : (T) -> @any.Any
   priv decode : (@any.Any) -> T?
 }
 
 ///|
-/// Creates a typed reference for `name`.
+/// Creates a typed reference for `key`.
 ///
-/// Callers should define one shared reference per name and value type. Creating
-/// references with the same name but different value types makes mismatched
+/// Callers should define one shared reference per key and value type. Creating
+/// references with the same key but different value types makes mismatched
 /// reads return `None`.
-pub fn[T] AnyRef::AnyRef(name : String) -> AnyRef[T] {
+pub fn[K, T : @any.Anyable] AnyRef::AnyRef(key : K) -> AnyRef[K, T] {
   {
-    name,
-    encode: value => @any.of(value),
-    decode: value => value.try_to(),
+    key,
+    encode: value => @any.Any::Any(value),
+    decode: value =>
+      try {
+        Some((value.dyn_cast() : T))
+      } catch {
+        _ => None
+      },
   }
 }

--- a/mbt/package/any-collection/src/reference.mbt
+++ b/mbt/package/any-collection/src/reference.mbt
@@ -1,0 +1,24 @@
+///|
+/// A reusable typed reference to one named value in an any collection.
+///
+/// The same reference can be used with both `AnyMutableMap` and
+/// `AnyImmutableHashMap`.
+pub struct AnyRef[T] {
+  priv name : String
+  priv encode : (T) -> @any.Any
+  priv decode : (@any.Any) -> T?
+}
+
+///|
+/// Creates a typed reference for `name`.
+///
+/// Callers should define one shared reference per name and value type. Creating
+/// references with the same name but different value types makes mismatched
+/// reads return `None`.
+pub fn[T] AnyRef::AnyRef(name : String) -> AnyRef[T] {
+  {
+    name,
+    encode: value => @any.of(value),
+    decode: value => value.try_to(),
+  }
+}

--- a/mbt/package/any-collection/src/reference.mbt
+++ b/mbt/package/any-collection/src/reference.mbt
@@ -22,3 +22,12 @@ pub fn[K, T : @any.Anyable] AnyRef::AnyRef(key : K) -> AnyRef[K, T] {
     decode: value => (value.dyn_cast() : T),
   }
 }
+
+///|
+/// Creates a key-value entry for collection initialization.
+pub fn[K, T] AnyRef::entry(
+  self : AnyRef[K, T],
+  value : T,
+) -> (K, @any.Any) {
+  (self.key, (self.encode)(value))
+}

--- a/mbt/package/any-collection/src/reference_test.mbt
+++ b/mbt/package/any-collection/src/reference_test.mbt
@@ -1,6 +1,6 @@
 ///|
 test "AnyRef - is shared by mutable and immutable maps" {
-  let request_id : AnyRef[String] = AnyRef::AnyRef("request_id")
+  let request_id : AnyRef[String, String] = AnyRef::AnyRef("request_id")
   let mutable = AnyMutableMap::AnyMutableMap()
   let immutable = AnyImmutableHashMap::AnyImmutableHashMap().added(
     request_id, "immutable-request",

--- a/mbt/package/any-collection/src/reference_test.mbt
+++ b/mbt/package/any-collection/src/reference_test.mbt
@@ -1,0 +1,14 @@
+///|
+test "AnyRef - is shared by mutable and immutable maps" {
+  let request_id : AnyRef[String] = AnyRef::AnyRef("request_id")
+  let mutable = AnyMutableMap::AnyMutableMap()
+  let immutable = AnyImmutableHashMap::AnyImmutableHashMap().added(
+    request_id, "immutable-request",
+  )
+  mutable.set(request_id, "mutable-request")
+  debug_inspect(mutable.get(request_id), content="Some(\"mutable-request\")")
+  debug_inspect(
+    immutable.get(request_id),
+    content="Some(\"immutable-request\")",
+  )
+}

--- a/mbt/package/any-collection/src/reference_test.mbt
+++ b/mbt/package/any-collection/src/reference_test.mbt
@@ -1,8 +1,8 @@
 ///|
 test "AnyRef - is shared by mutable and immutable maps" {
   let request_id : AnyRef[String, String] = AnyRef::AnyRef("request_id")
-  let mutable = AnyMutableMap::AnyMutableMap()
-  let immutable = AnyImmutableHashMap::AnyImmutableHashMap().added(
+  let mutable = AnyMutableMap::AnyMutableMap([])
+  let immutable = AnyImmutableHashMap::AnyImmutableHashMap([]).added(
     request_id, "immutable-request",
   )
   mutable.set(request_id, "mutable-request")
@@ -11,4 +11,12 @@ test "AnyRef - is shared by mutable and immutable maps" {
     immutable.get(request_id),
     content="Some(\"immutable-request\")",
   )
+}
+
+///|
+test "AnyRef entry - creates a typed constructor entry" {
+  let request_id : AnyRef[String, String] = AnyRef::AnyRef("request_id")
+  let (key, value) = request_id.entry("request-1")
+  inspect(key, content="request_id")
+  inspect((value.dyn_cast() : String), content="request-1")
 }

--- a/mbt/package/codex-sdk/moon.mod
+++ b/mbt/package/codex-sdk/moon.mod
@@ -18,7 +18,7 @@ readme = "README.md"
 
 repository = "https://github.com/totto2727-org/monorepo"
 
-license = "Apache-2.0"
+license = "MIT"
 
 keywords = [ "openai", "codex", "sdk", "moonbit" ]
 

--- a/mbt/package/copy/moon.mod
+++ b/mbt/package/copy/moon.mod
@@ -6,7 +6,7 @@ readme = "README.mbt.md"
 
 repository = "https://github.com/totto2727-org/monorepo"
 
-license = "Apache-2.0"
+license = "MIT"
 
 keywords = [ "copy", "trait", "moonbit" ]
 

--- a/mbt/package/geo-mbt/moon.mod
+++ b/mbt/package/geo-mbt/moon.mod
@@ -10,7 +10,7 @@ readme = "README.mbt.md"
 
 repository = ""
 
-license = "Apache-2.0"
+license = "MIT"
 
 keywords = [ "gis", "geo", "geography", "geospatial" ]
 

--- a/mbt/package/lens/moon.mod
+++ b/mbt/package/lens/moon.mod
@@ -6,7 +6,7 @@ readme = "README.mbt.md"
 
 repository = "https://github.com/totto2727-org/monorepo"
 
-license = "Apache-2.0"
+license = "MIT"
 
 keywords = [ "json", "lens", "validation", "moonbit" ]
 

--- a/moon.work
+++ b/moon.work
@@ -1,6 +1,7 @@
 members = [
   "./mbt/package/admiral",
   "./mbt/package/agent-cli-sdk",
+  "./mbt/package/any-collection",
   "./mbt/package/codex-sdk",
   "./mbt/package/copy",
   "./mbt/package/opencode-server-sdk",


### PR DESCRIPTION
## 概要

- `Yoorkin/any.Any` を格納する型付き参照ベースの mutable map / immutable hash map を追加
- `AnyRef` による型付き取得、挿入、変換エラー時のフォールバック API を提供
- 使用例とテストを追加し、`moon.work` にパッケージを登録
- 既存 MoonBit パッケージのライセンス表記を MIT に統一

```mermaid
flowchart TD
  A[AnyRef K T を定義] --> B[Any 値を encode]
  B --> C[Map または HashMap に格納]
  C --> D{キーが存在するか}
  D -->|なし| E[None または default]
  D -->|あり| F{型変換に成功するか}
  F -->|成功| G[型付きの値を返す]
  F -->|失敗| H[get は変換エラー]
  H --> I[get_or / get_or_none はフォールバック]
```

## Testing

- mutable map / immutable hash map の型付き取得、更新、永続性、削除をテスト
- キー欠落および型不一致時の `get`、`get_or`、`get_or_none` をテスト
- `AnyRef` の共有利用とエントリ生成をテスト
- 実行結果: 未実行（依頼文に実行指定なし）