### PR TITLE
Add GitHub CLI extensions to Nix environments

### DIFF
--- a/nix/macos-work/flake.nix
+++ b/nix/macos-work/flake.nix
@@ -106,7 +106,7 @@
                     ]);
 
                   programs =
-                    (import ../share/programs.nix)
+                    (import ../share/programs.nix { inherit pkgs; })
                     // (import ../share/programs-macos.nix { inherit pkgs; }).programs
                     // {
                       zsh = (import ../share/zsh.nix { inherit pkgs; }) // {

--- a/nix/macos/flake.nix
+++ b/nix/macos/flake.nix
@@ -132,7 +132,7 @@
                     ]);
 
                   programs =
-                    (import ../share/programs.nix)
+                    (import ../share/programs.nix { inherit pkgs; })
                     // (import ../share/programs-macos.nix { inherit pkgs; }).programs
                     // {
                       zsh = (import ../share/zsh.nix { inherit pkgs; }) // {

--- a/nix/nixos-server/flake.nix
+++ b/nix/nixos-server/flake.nix
@@ -139,7 +139,7 @@
                     docker
                   ]);
 
-                programs = (import ../share/programs.nix) // {
+                programs = (import ../share/programs.nix { inherit pkgs; }) // {
                   home-manager.enable = true;
                   zsh = (import ../share/zsh.nix { inherit pkgs; }) // {
                     initContent = ''

--- a/nix/nixos/flake.nix
+++ b/nix/nixos/flake.nix
@@ -53,7 +53,7 @@
                     starship.enable = true;
                     zoxide.enable = true;
                     git = import ../share/git.nix;
-                    gh = import ../share/gh.nix;
+                    gh = import ../share/gh.nix { inherit pkgs; };
                     zsh = {
                       enable = true;
                       enableCompletion = true;

--- a/nix/sandbox/flake.nix
+++ b/nix/sandbox/flake.nix
@@ -67,7 +67,7 @@
                 })
                 ++ (import ../share/packages-scripts.nix { inherit pkgs npm; }).sandbox;
 
-              programs = (import ../share/programs.nix) // {
+              programs = (import ../share/programs.nix { inherit pkgs; }) // {
                 home-manager.enable = true;
                 zsh = (import ../share/zsh.nix { inherit pkgs; }) // {
                   shellAliases = (import ../share/shell-aliases.nix) // {

--- a/nix/share/gh.nix
+++ b/nix/share/gh.nix
@@ -1,4 +1,9 @@
+{ pkgs }:
 {
   enable = true;
+  extensions = [
+    pkgs.gh-poi
+    pkgs.gh-stack
+  ];
   gitCredentialHelper.enable = true;
 }

--- a/nix/share/programs.nix
+++ b/nix/share/programs.nix
@@ -1,9 +1,10 @@
+{ pkgs }:
 {
   direnv = import ./direnv.nix;
   zoxide = import ./zoxide.nix;
   starship = import ./starship.nix;
   git = import ./git.nix;
-  gh = import ./gh.nix;
+  gh = import ./gh.nix { inherit pkgs; };
   delta = import ./delta.nix;
   lazygit = import ./lazygit.nix;
 }


### PR DESCRIPTION
## 概要

Nix環境のGitHub CLI設定に`gh-poi`と`gh-stack`を追加し、各flakeから`pkgs`を渡すように更新します。また、不要になったCodex設定の無効化・エージェント上限設定を削除します。

## 処理フロー

```mermaid
flowchart TD
  A[各Nix flake] --> B[pkgsを共有programs設定へ渡す]
  B --> C[共有gh設定を評価]
  C --> D[gh-poiをGitHub CLI拡張として有効化]
  C --> E[gh-stackをGitHub CLI拡張として有効化]
  D --> F[GitHub CLI環境]
  E --> F
```

## Testing

Not run (not requested)