### PR TITLE
Register MoonBit workspace packages and dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -233,15 +233,32 @@
     },
     "mbt/app/bw": {
       "name": "@totto2727/bw",
+      "devDependencies": {
+        "@totto2727/admiral": "workspace:*",
+        "@totto2727/lens": "workspace:*",
+      },
     },
     "mbt/app/c-plugin": {
       "name": "@totto2727/c-plugin",
+      "devDependencies": {
+        "@totto2727/admiral": "workspace:*",
+        "@totto2727/lens": "workspace:*",
+        "@totto2727/target-file-discovery": "workspace:*",
+      },
     },
     "mbt/app/mdt": {
       "name": "@totto2727/mdt",
+      "devDependencies": {
+        "@totto2727/admiral": "workspace:*",
+        "@totto2727/opencode-sdk": "workspace:*",
+      },
     },
     "mbt/app/wt": {
       "name": "@totto2727/wt",
+      "devDependencies": {
+        "@totto2727/admiral": "workspace:*",
+        "@totto2727/lens": "workspace:*",
+      },
     },
     "mbt/package/admiral": {
       "name": "@totto2727/admiral",
@@ -251,23 +268,52 @@
       "name": "@totto2727/agent-cli-sdk",
       "version": "0.0.0",
     },
+    "mbt/package/any-collection": {
+      "name": "@totto2727/any-collection",
+    },
     "mbt/package/codex-sdk": {
       "name": "@totto2727/codex-sdk",
+      "devDependencies": {
+        "@totto2727/agent-cli-sdk": "workspace:*",
+        "@totto2727/copy": "workspace:*",
+        "@totto2727/lens": "workspace:*",
+      },
+    },
+    "mbt/package/copy": {
+      "name": "@totto2727/copy",
     },
     "mbt/package/geo-mbt": {
       "name": "@totto2727/geo-mbt",
       "version": "0.0.0",
     },
+    "mbt/package/lens": {
+      "name": "@totto2727/lens",
+    },
+    "mbt/package/moon-agent-graph": {
+      "name": "@totto2727/moon-agent-graph",
+      "devDependencies": {
+        "@totto2727/codex-sdk": "workspace:*",
+        "@totto2727/opencode-sdk": "workspace:*",
+      },
+    },
     "mbt/package/opencode-sdk": {
       "name": "@totto2727/opencode-sdk",
       "version": "0.0.0",
+      "devDependencies": {
+        "@totto2727/agent-cli-sdk": "workspace:*",
+        "@totto2727/copy": "workspace:*",
+        "@totto2727/lens": "workspace:*",
+      },
     },
     "mbt/package/opencode-server-sdk": {
       "name": "@totto2727/opencode-server-sdk",
       "version": "0.0.0",
+      "devDependencies": {
+        "@totto2727/lens": "workspace:*",
+      },
     },
     "mbt/package/target-file-discovery": {
-      "name": "@package/target-file-discovery",
+      "name": "@totto2727/target-file-discovery",
     },
     "nix": {
       "name": "@app/nix",
@@ -936,8 +982,6 @@
 
     "@package/oxlint-plugin": ["@package/oxlint-plugin@workspace:js/package/oxlint-plugin"],
 
-    "@package/target-file-discovery": ["@package/target-file-discovery@workspace:mbt/package/target-file-discovery"],
-
     "@peculiar/asn1-android": ["@peculiar/asn1-android@2.8.0", "https://npm.flatt.tech/@peculiar/asn1-android/-/asn1-android-2.8.0.tgz", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-skLbS+IOGv1lUgDqtChr8xvtvEr3HMse/JGBaL2r1J1o/n7a8wqOrovMtlRq/UXLhxvmLaONP67hwtshgzwfzA=="],
 
     "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.8.0", "https://npm.flatt.tech/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA=="],
@@ -1118,21 +1162,31 @@
 
     "@totto2727/agent-cli-sdk": ["@totto2727/agent-cli-sdk@workspace:mbt/package/agent-cli-sdk"],
 
+    "@totto2727/any-collection": ["@totto2727/any-collection@workspace:mbt/package/any-collection"],
+
     "@totto2727/bw": ["@totto2727/bw@workspace:mbt/app/bw"],
 
     "@totto2727/c-plugin": ["@totto2727/c-plugin@workspace:mbt/app/c-plugin"],
 
     "@totto2727/codex-sdk": ["@totto2727/codex-sdk@workspace:mbt/package/codex-sdk"],
 
+    "@totto2727/copy": ["@totto2727/copy@workspace:mbt/package/copy"],
+
     "@totto2727/fp": ["@totto2727/fp@workspace:js/package/fp"],
 
     "@totto2727/geo-mbt": ["@totto2727/geo-mbt@workspace:mbt/package/geo-mbt"],
 
+    "@totto2727/lens": ["@totto2727/lens@workspace:mbt/package/lens"],
+
     "@totto2727/mdt": ["@totto2727/mdt@workspace:mbt/app/mdt"],
+
+    "@totto2727/moon-agent-graph": ["@totto2727/moon-agent-graph@workspace:mbt/package/moon-agent-graph"],
 
     "@totto2727/opencode-sdk": ["@totto2727/opencode-sdk@workspace:mbt/package/opencode-sdk"],
 
     "@totto2727/opencode-server-sdk": ["@totto2727/opencode-server-sdk@workspace:mbt/package/opencode-server-sdk"],
+
+    "@totto2727/target-file-discovery": ["@totto2727/target-file-discovery@workspace:mbt/package/target-file-discovery"],
 
     "@totto2727/wt": ["@totto2727/wt@workspace:mbt/app/wt"],
 

--- a/mbt/app/bw/package.json
+++ b/mbt/app/bw/package.json
@@ -1,4 +1,8 @@
 {
   "name": "@totto2727/bw",
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "@totto2727/admiral": "workspace:*",
+    "@totto2727/lens": "workspace:*"
+  }
 }

--- a/mbt/app/c-plugin/package.json
+++ b/mbt/app/c-plugin/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@totto2727/c-plugin",
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "@totto2727/admiral": "workspace:*",
+    "@totto2727/lens": "workspace:*",
+    "@totto2727/target-file-discovery": "workspace:*"
+  }
 }

--- a/mbt/app/wt/package.json
+++ b/mbt/app/wt/package.json
@@ -1,4 +1,8 @@
 {
   "name": "@totto2727/wt",
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "@totto2727/admiral": "workspace:*",
+    "@totto2727/lens": "workspace:*"
+  }
 }

--- a/mbt/package/any-collection/package.json
+++ b/mbt/package/any-collection/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@totto2727/any-collection",
+  "private": true
+}

--- a/mbt/package/codex-sdk/package.json
+++ b/mbt/package/codex-sdk/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@totto2727/codex-sdk",
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "@totto2727/agent-cli-sdk": "workspace:*",
+    "@totto2727/copy": "workspace:*",
+    "@totto2727/lens": "workspace:*"
+  }
 }

--- a/mbt/package/copy/package.json
+++ b/mbt/package/copy/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@totto2727/copy",
+  "private": true
+}

--- a/mbt/package/lens/package.json
+++ b/mbt/package/lens/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@totto2727/lens",
+  "private": true
+}

--- a/mbt/package/moon-agent-graph/package.json
+++ b/mbt/package/moon-agent-graph/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@totto2727/mdt",
+  "name": "@totto2727/moon-agent-graph",
   "private": true,
   "devDependencies": {
-    "@totto2727/admiral": "workspace:*",
+    "@totto2727/codex-sdk": "workspace:*",
     "@totto2727/opencode-sdk": "workspace:*"
   }
 }

--- a/mbt/package/opencode-sdk/package.json
+++ b/mbt/package/opencode-sdk/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@totto2727/opencode-sdk",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "@totto2727/agent-cli-sdk": "workspace:*",
+    "@totto2727/copy": "workspace:*",
+    "@totto2727/lens": "workspace:*"
+  }
 }

--- a/mbt/package/opencode-server-sdk/package.json
+++ b/mbt/package/opencode-server-sdk/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@totto2727/opencode-server-sdk",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "@totto2727/lens": "workspace:*"
+  }
 }

--- a/mbt/package/target-file-discovery/package.json
+++ b/mbt/package/target-file-discovery/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "@package/target-file-discovery",
+  "name": "@totto2727/target-file-discovery",
   "private": true
 }


### PR DESCRIPTION
## 概要

- MoonBitパッケージをworkspaceとして登録
- 各アプリケーションおよびSDKのworkspace依存関係を追加
- `target-file-discovery`のパッケージ名を`@totto2727/target-file-discovery`へ修正
- Codexの不要なエージェント設定を削除

```mermaid
flowchart TD
  Apps[MoonBit applications] --> Admiral[admiral]
  Apps --> Lens[lens]
  Apps --> Target[target-file-discovery]
  SDKs[MoonBit SDKs] --> Agent[agent-cli-sdk]
  SDKs --> Copy[copy]
  SDKs --> Lens
  Graph[moon-agent-graph] --> Codex[codex-sdk]
  Graph --> OpenCode[opencode-sdk]
  Workspace[Workspace lockfile] --> Apps
  Workspace --> SDKs
  Workspace --> Graph
```

## Testing

Not run (not requested).