### PR TITLE
Enable MoonBit package publishing and update release versions

### DIFF
--- a/mbt/app/bw/moon.mod
+++ b/mbt/app/bw/moon.mod
@@ -1,14 +1,14 @@
 name = "totto2727/bw"
 
-version = "0.1.7"
+version = "0.2.0"
 
 preferred_target = "native"
 
 supported_targets = "native"
 
 import {
-  "totto2727/admiral@0.5.0",
-  "totto2727/lens@0.1.0",
+  "totto2727/admiral@0.6.0",
+  "totto2727/lens@0.2.0",
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.19.2",
   "gmlewis/base64@0.16.10",

--- a/mbt/app/bw/package.json
+++ b/mbt/app/bw/package.json
@@ -2,7 +2,7 @@
   "name": "@totto2727/bw",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   },
   "devDependencies": {
     "@totto2727/admiral": "workspace:*",

--- a/mbt/app/bw/package.json
+++ b/mbt/app/bw/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@totto2727/bw",
-  "private": true
+  "private": true,
+  "scripts": {
+    "publish": "moon publish"
+  }
 }

--- a/mbt/app/c-plugin/moon.mod
+++ b/mbt/app/c-plugin/moon.mod
@@ -1,15 +1,15 @@
 name = "totto2727/c-plugin"
 
-version = "0.1.0"
+version = "0.2.0"
 
 preferred_target = "native"
 
 supported_targets = "native"
 
 import {
-  "totto2727/admiral@0.5.0",
-  "totto2727/lens@0.1.0",
-  "totto2727/target-file-discovery@0.1.0",
+  "totto2727/admiral@0.6.0",
+  "totto2727/lens@0.2.0",
+  "totto2727/target-file-discovery@0.2.0",
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.19.2",
 }

--- a/mbt/app/c-plugin/package.json
+++ b/mbt/app/c-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "@totto2727/c-plugin",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   },
   "devDependencies": {
     "@totto2727/admiral": "workspace:*",

--- a/mbt/app/c-plugin/package.json
+++ b/mbt/app/c-plugin/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@totto2727/c-plugin",
-  "private": true
+  "private": true,
+  "scripts": {
+    "publish": "moon publish"
+  }
 }

--- a/mbt/app/mdt/moon.mod
+++ b/mbt/app/mdt/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/mdt"
 
-version = "0.1.3"
+version = "0.1.4"
 
 preferred_target = "native"
 
@@ -9,8 +9,8 @@ supported_targets = "native"
 import {
   "moonbitlang/async@0.20.1",
   "moonbitlang/x@0.4.38",
-  "totto2727/admiral@0.5.0",
-  "totto2727/opencode-sdk@0.1.1",
+  "totto2727/admiral@0.6.0",
+  "totto2727/opencode-sdk@0.2.0",
 }
 
 readme = "README.md"

--- a/mbt/app/mdt/package.json
+++ b/mbt/app/mdt/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@totto2727/mdt",
-  "private": true
+  "private": true,
+  "scripts": {
+    "publish": "moon publish"
+  }
 }

--- a/mbt/app/mdt/package.json
+++ b/mbt/app/mdt/package.json
@@ -2,7 +2,7 @@
   "name": "@totto2727/mdt",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   },
   "devDependencies": {
     "@totto2727/admiral": "workspace:*",

--- a/mbt/app/wt/moon.mod
+++ b/mbt/app/wt/moon.mod
@@ -1,14 +1,14 @@
 name = "totto2727/wt"
 
-version = "0.1.0"
+version = "0.1.1"
 
 preferred_target = "native"
 
 supported_targets = "native"
 
 import {
-  "totto2727/admiral@0.5.0",
-  "totto2727/lens@0.1.0",
+  "totto2727/admiral@0.6.0",
+  "totto2727/lens@0.2.0",
   "moonbitlang/async@0.19.2",
 }
 

--- a/mbt/app/wt/package.json
+++ b/mbt/app/wt/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@totto2727/wt",
-  "private": true
+  "private": true,
+  "scripts": {
+    "publish": "moon publish"
+  }
 }

--- a/mbt/app/wt/package.json
+++ b/mbt/app/wt/package.json
@@ -2,7 +2,7 @@
   "name": "@totto2727/wt",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   },
   "devDependencies": {
     "@totto2727/admiral": "workspace:*",

--- a/mbt/package/admiral/moon.mod
+++ b/mbt/package/admiral/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/admiral"
 
-version = "0.5.0"
+version = "0.6.0"
 
 readme = "README.md"
 

--- a/mbt/package/admiral/package.json
+++ b/mbt/package/admiral/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   }
 }

--- a/mbt/package/admiral/package.json
+++ b/mbt/package/admiral/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@totto2727/admiral",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "scripts": {
+    "publish": "moon publish"
+  }
 }

--- a/mbt/package/admiral/src/test/moon.pkg
+++ b/mbt/package/admiral/src/test/moon.pkg
@@ -2,5 +2,5 @@ supported_targets = "native"
 
 import {
   "moonbitlang/async",
-  "totto2727/admiral" @admiral,
+  "totto2727/admiral",
 } for "test"

--- a/mbt/package/agent-cli-sdk/moon.mod
+++ b/mbt/package/agent-cli-sdk/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/agent-cli-sdk"
 
-version = "0.1.0"
+version = "0.1.1"
 
 preferred_target = "native"
 

--- a/mbt/package/agent-cli-sdk/package.json
+++ b/mbt/package/agent-cli-sdk/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   }
 }

--- a/mbt/package/agent-cli-sdk/package.json
+++ b/mbt/package/agent-cli-sdk/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@totto2727/agent-cli-sdk",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "scripts": {
+    "publish": "moon publish"
+  }
 }

--- a/mbt/package/any-collection/moon.mod
+++ b/mbt/package/any-collection/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/any-collection"
 
-version = "0.1.0"
+version = "0.2.0"
 
 import {
   "Yoorkin/any@0.2.1",

--- a/mbt/package/any-collection/package.json
+++ b/mbt/package/any-collection/package.json
@@ -2,6 +2,6 @@
   "name": "@totto2727/any-collection",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   }
 }

--- a/mbt/package/codex-sdk/moon.mod
+++ b/mbt/package/codex-sdk/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/codex-sdk"
 
-version = "0.0.0"
+version = "0.1.0"
 
 preferred_target = "native"
 
@@ -9,9 +9,9 @@ supported_targets = "native"
 import {
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.20.1",
-  "totto2727/agent-cli-sdk@0.1.0",
-  "totto2727/copy@0.1.0",
-  "totto2727/lens@0.1.0",
+  "totto2727/agent-cli-sdk@0.1.1",
+  "totto2727/copy@0.2.0",
+  "totto2727/lens@0.2.0",
 }
 
 readme = "README.md"

--- a/mbt/package/codex-sdk/package.json
+++ b/mbt/package/codex-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@totto2727/codex-sdk",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   },
   "devDependencies": {
     "@totto2727/agent-cli-sdk": "workspace:*",

--- a/mbt/package/codex-sdk/package.json
+++ b/mbt/package/codex-sdk/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@totto2727/codex-sdk",
-  "private": true
+  "private": true,
+  "scripts": {
+    "publish": "moon publish"
+  }
 }

--- a/mbt/package/codex-sdk/src/test/exec_test.mbt
+++ b/mbt/package/codex-sdk/src/test/exec_test.mbt
@@ -116,7 +116,8 @@ async test "CodexExec env - preserves caller PATH entries without rewriting them
     ])
     let path = "/opt/codex/bin:/usr/bin:/opt/codex/bin"
     environment.set("PATH", path)
-    fixture.client(environment).start_thread().run(@codex.Prompt("Hello")) |> ignore
+    fixture.client(environment).start_thread().run(@codex.Prompt("Hello"))
+    |> ignore
     assert_true(fixture.recorded_lines("env", 1).contains("PATH=\{path}"))
   })
 }
@@ -134,7 +135,8 @@ async test "CodexExec env - preserves the Windows Path key" {
     ])
     environment.remove("PATH")
     environment.set("Path", "C:\\Windows\\System32")
-    fixture.client(environment).start_thread().run(@codex.Prompt("Hello")) |> ignore
+    fixture.client(environment).start_thread().run(@codex.Prompt("Hello"))
+    |> ignore
     let recorded_environment = fixture.recorded_lines("env", 1)
     assert_true(recorded_environment.contains("Path=C:\\Windows\\System32"))
     assert_true(

--- a/mbt/package/codex-sdk/src/test/thread_test.mbt
+++ b/mbt/package/codex-sdk/src/test/thread_test.mbt
@@ -213,7 +213,9 @@ async test "Codex run - passes webSearchMode to exec" {
       ]),
     )
     client
-    .start_thread(options=ThreadOptions::ThreadOptions(web_search_mode=@codex.Cached))
+    .start_thread(
+      options=ThreadOptions::ThreadOptions(web_search_mode=@codex.Cached),
+    )
     .run(@codex.Prompt("apply web search mode"))
     |> ignore
     assert_true(
@@ -771,8 +773,12 @@ async test "Codex runStreamed - sends previous items when called twice" {
       ]),
     )
     let thread = client.start_thread()
-    thread.run_streamed(@codex.Prompt("first input"), async fn(_) { @async.pause() })
-    thread.run_streamed(@codex.Prompt("second input"), async fn(_) { @async.pause() })
+    thread.run_streamed(@codex.Prompt("first input"), async fn(_) {
+      @async.pause()
+    })
+    thread.run_streamed(@codex.Prompt("second input"), async fn(_) {
+      @async.pause()
+    })
     let second_args = fixture.recorded_lines("args", 2)
     assert_true(contains_pair(second_args, "resume", "thread-1"))
     inspect(fixture.recorded_text("input", 2), content="second input")
@@ -790,9 +796,13 @@ async test "Codex runStreamed - resumes thread by ID" {
       ]),
     )
     let original = client.start_thread()
-    original.run_streamed(@codex.Prompt("first input"), async fn(_) { @async.pause() })
+    original.run_streamed(@codex.Prompt("first input"), async fn(_) {
+      @async.pause()
+    })
     let resumed = client.resume_thread(original.id().unwrap_or(""))
-    resumed.run_streamed(@codex.Prompt("second input"), async fn(_) { @async.pause() })
+    resumed.run_streamed(@codex.Prompt("second input"), async fn(_) {
+      @async.pause()
+    })
     assert_true(
       contains_pair(fixture.recorded_lines("args", 2), "resume", "thread-1"),
     )

--- a/mbt/package/copy/moon.mod
+++ b/mbt/package/copy/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/copy"
 
-version = "0.1.0"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 

--- a/mbt/package/copy/package.json
+++ b/mbt/package/copy/package.json
@@ -2,6 +2,6 @@
   "name": "@totto2727/copy",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   }
 }

--- a/mbt/package/geo-mbt/moon.mod
+++ b/mbt/package/geo-mbt/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/geo-mbt"
 
-version = "0.1.0"
+version = "0.1.1"
 
 import {
   "moonbitlang/x@0.4.38",

--- a/mbt/package/geo-mbt/package.json
+++ b/mbt/package/geo-mbt/package.json
@@ -2,6 +2,6 @@
   "name": "@totto2727/geo-mbt",
   "version": "0.0.0",
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   }
 }

--- a/mbt/package/geo-mbt/package.json
+++ b/mbt/package/geo-mbt/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@totto2727/geo-mbt",
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "scripts": {
+    "publish": "moon publish"
+  }
 }

--- a/mbt/package/lens/moon.mod
+++ b/mbt/package/lens/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/lens"
 
-version = "0.1.0"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 

--- a/mbt/package/lens/package.json
+++ b/mbt/package/lens/package.json
@@ -2,6 +2,6 @@
   "name": "@totto2727/lens",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   }
 }

--- a/mbt/package/moon-agent-graph/moon.mod
+++ b/mbt/package/moon-agent-graph/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/moon-agent-graph"
 
-version = "0.0.0"
+version = "0.1.0"
 
 readme = "README.md"
 
@@ -23,8 +23,8 @@ import {
   "DC-Z-lab/moonllm@0.1.0",
   "moonbitlang/async@0.20.1",
   "moonbitlang/x@0.4.38",
-  "totto2727/codex-sdk@0.0.0",
-  "totto2727/opencode-sdk@0.1.1",
+  "totto2727/codex-sdk@0.1.0",
+  "totto2727/opencode-sdk@0.2.0",
 }
 
 preferred_target = "native"

--- a/mbt/package/moon-agent-graph/package.json
+++ b/mbt/package/moon-agent-graph/package.json
@@ -2,7 +2,7 @@
   "name": "@totto2727/moon-agent-graph",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   },
   "devDependencies": {
     "@totto2727/codex-sdk": "workspace:*",

--- a/mbt/package/opencode-sdk/moon.mod
+++ b/mbt/package/opencode-sdk/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/opencode-sdk"
 
-version = "0.1.1"
+version = "0.2.0"
 
 preferred_target = "native"
 
@@ -9,9 +9,9 @@ supported_targets = "native"
 import {
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.20.1",
-  "totto2727/agent-cli-sdk@0.1.0",
-  "totto2727/copy@0.1.0",
-  "totto2727/lens@0.1.0",
+  "totto2727/agent-cli-sdk@0.1.1",
+  "totto2727/copy@0.2.0",
+  "totto2727/lens@0.2.0",
 }
 
 readme = "README.md"

--- a/mbt/package/opencode-sdk/package.json
+++ b/mbt/package/opencode-sdk/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@totto2727/opencode-sdk",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "scripts": {
+    "publish": "moon publish"
+  }
 }

--- a/mbt/package/opencode-sdk/package.json
+++ b/mbt/package/opencode-sdk/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   },
   "devDependencies": {
     "@totto2727/agent-cli-sdk": "workspace:*",

--- a/mbt/package/opencode-sdk/src/test/exec_test.mbt
+++ b/mbt/package/opencode-sdk/src/test/exec_test.mbt
@@ -20,10 +20,12 @@ async test "OpenCodeExec run 1 - reports nonzero exits" {
     environment["FAKE_OPENCODE_STDERR"] = "cli failed"
     environment["FAKE_OPENCODE_EXIT_CODE"] = "17"
     let message = try {
-      fixture.client(environment).start_thread().run(@opencode.Prompt("fail")) |> ignore
+      fixture.client(environment).start_thread().run(@opencode.Prompt("fail"))
+      |> ignore
       "no error"
     } catch {
-      @opencode.OpenCodeSdkError::ExecFailed(code~, stderr~) => "\{code}:\{stderr}"
+      @opencode.OpenCodeSdkError::ExecFailed(code~, stderr~) =>
+        "\{code}:\{stderr}"
       error => "unexpected: \{error}"
     }
     inspect(message, content="17:cli failed")

--- a/mbt/package/opencode-server-sdk/moon.mod
+++ b/mbt/package/opencode-server-sdk/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/opencode-server-sdk"
 
-version = "0.1.0"
+version = "0.2.0"
 
 readme = "README.md"
 
@@ -14,7 +14,7 @@ description = "Native MoonBit SDK for starting and managing an OpenCode server"
 
 import {
   "moonbitlang/async@0.20.1",
-  "totto2727/lens@0.1.0",
+  "totto2727/lens@0.2.0",
 }
 
 preferred_target = "native"

--- a/mbt/package/opencode-server-sdk/package.json
+++ b/mbt/package/opencode-server-sdk/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@totto2727/opencode-server-sdk",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "scripts": {
+    "publish": "moon publish"
+  }
 }

--- a/mbt/package/opencode-server-sdk/package.json
+++ b/mbt/package/opencode-server-sdk/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   },
   "devDependencies": {
     "@totto2727/lens": "workspace:*"

--- a/mbt/package/target-file-discovery/moon.mod
+++ b/mbt/package/target-file-discovery/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/target-file-discovery"
 
-version = "0.1.0"
+version = "0.2.0"
 
 preferred_target = "native"
 

--- a/mbt/package/target-file-discovery/package.json
+++ b/mbt/package/target-file-discovery/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@package/target-file-discovery",
-  "private": true
+  "private": true,
+  "scripts": {
+    "publish": "moon publish"
+  }
 }

--- a/mbt/package/target-file-discovery/package.json
+++ b/mbt/package/target-file-discovery/package.json
@@ -2,6 +2,6 @@
   "name": "@totto2727/target-file-discovery",
   "private": true,
   "scripts": {
-    "publish": "moon publish"
+    "publish": "bash ../../scripts/moon-publish.sh"
   }
 }

--- a/mbt/scripts/moon-publish.sh
+++ b/mbt/scripts/moon-publish.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+moon update
+
 publish_log="$(mktemp)"
 trap 'rm -f "$publish_log"' EXIT
 

--- a/mbt/scripts/moon-publish.sh
+++ b/mbt/scripts/moon-publish.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+publish_log="$(mktemp)"
+trap 'rm -f "$publish_log"' EXIT
+
+set +e
+moon publish "$@" 2>&1 | tee "$publish_log"
+pipeline_status=("${PIPESTATUS[@]}")
+set -e
+
+moon_status="${pipeline_status[0]}"
+tee_status="${pipeline_status[1]}"
+
+if [[ "$tee_status" -ne 0 ]]; then
+  exit "$tee_status"
+fi
+
+if [[ "$moon_status" -eq 0 ]]; then
+  exit 0
+fi
+
+if grep -Fq "409 Conflict" "$publish_log" &&
+  grep -Fq "Version Error:" "$publish_log" &&
+  grep -Fq "is duplicated with an existing version" "$publish_log"; then
+  echo "MoonBit module version is already published; continuing."
+  exit 0
+fi
+
+exit "$moon_status"

--- a/mbt/scripts/moon-publish_test.sh
+++ b/mbt/scripts/moon-publish_test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+moon() {
+  if [[ "${1:-}" != "publish" || "${2:-}" != "--frozen" ]]; then
+    echo "unexpected moon arguments: $*" >&2
+    return 64
+  fi
+
+  case "${MOON_PUBLISH_TEST_SCENARIO:-}" in
+    success)
+      echo "Server status: 200 OK"
+      return 0
+      ;;
+    duplicate)
+      printf 'Server status: \033[1;31m409 Conflict\033[0m, detail: Version Error: The version you are attempting to upload (0.1.1) is duplicated with an existing version (0.1.1). Please select a different version to publish.\n'
+      echo 'Error: `moon publish` failed'
+      return 1
+      ;;
+    unauthorized)
+      echo "Server status: 401 Unauthorized, detail: invalid credentials"
+      return 1
+      ;;
+    other-conflict)
+      echo "Server status: 409 Conflict, detail: Module ownership mismatch"
+      return 1
+      ;;
+    *)
+      echo "unknown test scenario" >&2
+      return 64
+      ;;
+  esac
+}
+
+export -f moon
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+wrapper="$repo_root/mbt/scripts/moon-publish.sh"
+
+run_case() {
+  local scenario="$1"
+  local expected_status="$2"
+  local expected_output="$3"
+  local output
+  local status
+
+  set +e
+  output="$(MOON_PUBLISH_TEST_SCENARIO="$scenario" bash "$wrapper" --frozen 2>&1)"
+  status=$?
+  set -e
+
+  if [[ "$status" -ne "$expected_status" ]]; then
+    printf 'scenario %s: expected status %s, got %s\n%s\n' "$scenario" "$expected_status" "$status" "$output" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq "$expected_output" <<<"$output"; then
+    printf 'scenario %s: missing output %s\n%s\n' "$scenario" "$expected_output" "$output" >&2
+    exit 1
+  fi
+}
+
+run_case success 0 "Server status: 200 OK"
+run_case duplicate 0 "MoonBit module version is already published; continuing."
+run_case unauthorized 1 "401 Unauthorized"
+run_case other-conflict 1 "Module ownership mismatch"
+
+echo "moon publish wrapper tests passed"

--- a/mbt/scripts/moon-publish_test.sh
+++ b/mbt/scripts/moon-publish_test.sh
@@ -3,6 +3,16 @@
 set -euo pipefail
 
 moon() {
+  if [[ "${1:-}" == "update" ]]; then
+    if [[ "${MOON_PUBLISH_TEST_SCENARIO:-}" == "update-failure" ]]; then
+      echo "Registry index update failed"
+      return 2
+    fi
+
+    echo "Registry index updated successfully"
+    return 0
+  fi
+
   if [[ "${1:-}" != "publish" || "${2:-}" != "--frozen" ]]; then
     echo "unexpected moon arguments: $*" >&2
     return 64
@@ -59,11 +69,22 @@ run_case() {
     printf 'scenario %s: missing output %s\n%s\n' "$scenario" "$expected_output" "$output" >&2
     exit 1
   fi
+
+  if [[ "$scenario" == "update-failure" ]]; then
+    if grep -Fq "Server status:" <<<"$output"; then
+      printf 'scenario %s: publish ran after update failed\n%s\n' "$scenario" "$output" >&2
+      exit 1
+    fi
+  elif [[ "$output" != *"Registry index updated successfully"*"$expected_output"* ]]; then
+    printf 'scenario %s: moon update did not run before publish\n%s\n' "$scenario" "$output" >&2
+    exit 1
+  fi
 }
 
 run_case success 0 "Server status: 200 OK"
 run_case duplicate 0 "MoonBit module version is already published; continuing."
 run_case unauthorized 1 "401 Unauthorized"
 run_case other-conflict 1 "Module ownership mismatch"
+run_case update-failure 2 "Registry index update failed"
 
 echo "moon publish wrapper tests passed"


### PR DESCRIPTION
## 概要

- 各MoonBitパッケージに `moon publish` 用の `publish` スクリプトを追加
- パッケージのバージョンと依存関係を次のリリース系列へ更新
- 不要になったCodex設定の自動無効化およびエージェント設定を削除

```mermaid
flowchart TD
    A[Package metadata] --> B[Add publish script]
    A --> C[Update package version]
    C --> D[Update dependent package versions]
    B --> E[Run moon publish]
    D --> E
    E --> F[Publishable MoonBit packages]
```

## Testing

- Not run (not requested)