### PR TITLE
Add JSON path prefix helpers to lens errors

### DIFF
--- a/mbt/package/lens/src/lens.mbt
+++ b/mbt/package/lens/src/lens.mbt
@@ -160,6 +160,25 @@ pub fn[T] Lens::nullish(
 }
 
 ///|
+/// Appends this lens's pointer to an existing JSON path.
+pub fn[T] Lens::add_to_json_path(
+  self : Lens[T],
+  path : @json.JsonPath,
+) -> @json.JsonPath {
+  self.pointer.add_to_json_path(path)
+}
+
+///|
+/// Creates a standard JSON decode error at this lens's location under an existing path.
+pub fn[T] Lens::json_decode_error(
+  self : Lens[T],
+  path : @json.JsonPath,
+  message : String,
+) -> @json.JsonDecodeError {
+  self.pointer.json_decode_error(path, message)
+}
+
+///|
 /// Reads this object lens from a JSON document.
 pub fn ObjectLens::get(
   self : ObjectLens,
@@ -192,5 +211,18 @@ pub fn[T] Lens::get(self : Lens[T], document : Json) -> T raise LensError {
         code,
         message,
       })
+  }
+}
+
+///|
+/// Reads this lens and translates a lens failure into a standard JSON decode error.
+pub fn[T] Lens::get_or_json_decode_error(
+  self : Lens[T],
+  document : Json,
+  path : @json.JsonPath,
+) -> T raise @json.JsonDecodeError {
+  self.get(document) catch {
+    LensError(issue) =>
+      raise issue.pointer.json_decode_error(path, repr(LensError(issue)))
   }
 }

--- a/mbt/package/lens/src/lens_test.mbt
+++ b/mbt/package/lens/src/lens_test.mbt
@@ -42,6 +42,67 @@ fn assert_type_mismatch(
 }
 
 ///|
+fn root_json_path() -> @json.JsonPath raise {
+  try {
+    let _ : Bool = @json.from_json(Json::null())
+    fail("expected JsonDecodeError")
+  } catch {
+    @json.JsonDecodeError::JsonDecodeError((path, _)) => path
+    _ => fail("unexpected error")
+  }
+}
+
+///|
+test "Lens add_to_json_path - appends the lens pointer to the existing path" {
+  let path = root_json_path().add_key("request")
+  inspect(
+    @lens.object("user").string("name").add_to_json_path(path),
+    content="/request/user/name",
+  )
+}
+
+///|
+test "Lens json_decode_error - prefixes the path and preserves the message" {
+  let path = root_json_path().add_key("request")
+  let name_lens = @lens.object("user").string("name")
+  let @json.JsonDecodeError::JsonDecodeError((error_path, message)) = name_lens.json_decode_error(
+    path, "expected string",
+  )
+  inspect(error_path, content="/request/user/name")
+  inspect(message, content="expected string")
+}
+
+///|
+test "Lens get_or_json_decode_error - returns the decoded value" {
+  let document = @json.parse("{\"user\":{\"name\":\"Ada\"}}")
+  let path = root_json_path().add_key("request")
+  inspect(
+    @lens.object("user").string("name").get_or_json_decode_error(document, path),
+    content="Ada",
+  )
+}
+
+///|
+test "Lens get_or_json_decode_error - converts a lens failure" {
+  let document = @json.parse("{\"user\":{\"profile\":false}}")
+  let path = root_json_path().add_key("request")
+  try {
+    @lens.object("user")
+    .object("profile")
+    .string("name")
+    .get_or_json_decode_error(document, path)
+    |> ignore
+    fail("expected JsonDecodeError")
+  } catch {
+    @json.JsonDecodeError::JsonDecodeError((error_path, message)) => {
+      inspect(error_path, content="/request/user/profile")
+      assert_true(message.contains("TypeMismatch"))
+    }
+    _ => fail("unexpected error")
+  }
+}
+
+///|
 test "ObjectLens get - reads the selected object" {
   let document = @json.parse(
     "{\"user\":{\"name\":\"Ada\",\"metadata\":{\"role\":\"admin\"}}}",

--- a/mbt/package/lens/src/pointer.mbt
+++ b/mbt/package/lens/src/pointer.mbt
@@ -46,6 +46,30 @@ fn Pointer::prepend_index(self : Pointer, index : Int) -> Pointer {
 }
 
 ///|
+fn Pointer::add_to_json_path(
+  self : Pointer,
+  path : @json.JsonPath,
+) -> @json.JsonPath {
+  let mut result = path
+  for segment in self.segments {
+    result = match segment {
+      Key(key) => result.add_key(key)
+      Index(index) => result.add_index(index)
+    }
+  }
+  result
+}
+
+///|
+fn Pointer::json_decode_error(
+  self : Pointer,
+  path : @json.JsonPath,
+  message : String,
+) -> @json.JsonDecodeError {
+  @json.JsonDecodeError::JsonDecodeError((self.add_to_json_path(path), message))
+}
+
+///|
 fn escape_pointer_key(key : String) -> String {
   key.replace_all(old="~", new="~0").replace_all(old="/", new="~1")
 }


### PR DESCRIPTION
## 概要

既存の `JsonPath` にレンズのポインタを追加し、レンズの読み取り失敗を標準の `JsonDecodeError` に変換するヘルパーを追加します。

```mermaid
flowchart TD
  A[既存の JsonPath] --> B[レンズのポインタを追加]
  B --> C[値の読み取り]
  C -->|成功| D[デコード値を返す]
  C -->|LensError| E[JsonDecodeErrorへ変換]
  E --> F[合成されたパスとエラーメッセージを返す]
```

## テスト

以下のケースをユニットテストで確認します。

```mermaid
flowchart TD
  A[テスト開始] --> B{ケース}
  B -->|パス追加| C[/request/user/name を確認]
  B -->|エラー生成| D[/request/user/name とメッセージを確認]
  B -->|正常な読み取り| E[Ada を確認]
  B -->|読み取り失敗| F[/request/user/profile と TypeMismatch を確認]
```

- レンズポインタのパス追加
- `JsonDecodeError` のパスとメッセージ保持
- 正常な値の読み取り
- `LensError` から `JsonDecodeError` への変換