### PR TITLE
レンズからJSON Schemaを生成・統合する

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -6,5 +6,12 @@ plan_mode_reasoning_effort = "xhigh"
 command = "linear-mcp"
 args = []
 
+# Managed by LazyCodex: multi_agent_v2 is re-disabled on every Codex session start
+# because enabling it fails every turn with HTTP 400 (openai/codex#26753).
+# Opt out: LAZYCODEX_CONFIG_MIGRATION_DISABLED=1 (or OMO_CODEX_CONFIG_MIGRATION_DISABLED=1).
 [features.multi_agent_v2]
+enabled = false
 max_concurrent_threads_per_session = 16
+
+[agents]
+max_threads = 1000

--- a/mbt/package/lens/README.mbt.md
+++ b/mbt/package/lens/README.mbt.md
@@ -92,7 +92,7 @@ Here, missing means that the selected leaf property is absent. A missing interme
 
 ## Validation
 
-`LensTrait` exposes only the type-erased `check` operation required by aggregate validation. `Lens[T]` and `ObjectLens` implement it, so heterogeneous lenses can be passed directly to `validate`. Every check runs, and failures are returned in input order.
+`LensTrait` exposes the type-erased operations required by aggregate validation and JSON Schema generation. `Lens[T]` and `ObjectLens` implement it, so heterogeneous lenses can be passed directly to `validate` and `json_schema`. Every validation check runs, and failures are returned in input order.
 
 ```mbt check
 test {
@@ -116,12 +116,31 @@ test {
 
 `Validation::Valid` carries no decoded value. `Validation::Invalid` carries only `Array[Issue]`.
 
+## JSON Schema
+
+Every `Lens[T]` and `ObjectLens` implements `LensTrait::to_json_schema`. The result is a Draft 2020-12 schema fragment that includes the lens's complete path. Pass the same heterogeneous lens array accepted by `validate` to `json_schema` to produce a complete schema. Aggregate checks are emitted as `allOf` entries because validation requires every lens to succeed.
+
+```mbt check
+test {
+  let user = object("user")
+  let schema = json_schema([
+    user.string("name"),
+    user.int("age"),
+    user.string("tags").array().optional(),
+  ])
+
+  inspect(schema is Json::Object(_), content="true")
+}
+```
+
+The generated schema includes only the constraints represented by the current lens API: object paths, primitive JSON kinds, array items, missing-property requirements, and nullable values. A raw `json` lens contributes an unconstrained `{}` value schema. An `int` lens contributes `{ "type": "number" }` because the current decoder accepts every JSON number and applies `Double::to_int`; emitting `integer` would be stricter than runtime validation. Unknown object properties remain allowed.
+
 ## Numeric behavior
 
 `number` returns the existing `Double` stored in `Json::Number` without further validation, including non-finite values. `int` delegates directly to MoonBit's standard `Double::to_int` conversion without package-level validation, inheriting its truncation, saturation, and special-value behavior. The package never reparses the retained JSON number text.
 
 ## Current scope
 
-The API supports object-property traversal and builder construction; `String`, `Bool`, `Double`, standard-converted `Int`, and raw `Json` values; typed arrays; and nullable, optional, and nullish values. `Lens::set` writes to `JsonBuilder`; it does not mutate or copy an existing JSON document. Refinements, alternatives, and source-document mutation remain outside the current scope.
+The API supports object-property traversal and builder construction; `String`, `Bool`, `Double`, standard-converted `Int`, and raw `Json` values; typed arrays; nullable, optional, and nullish values; aggregate validation; and minimal JSON Schema generation. `Lens::set` writes to `JsonBuilder`; it does not mutate or copy an existing JSON document. Refinements, alternatives, descriptions, and source-document mutation remain outside the current scope.
 
 See [the design document](docs/design.md) for the detailed contract and roadmap. A Japanese translation is available at [docs/design.ja.md](docs/design.ja.md).

--- a/mbt/package/lens/README.mbt.md
+++ b/mbt/package/lens/README.mbt.md
@@ -118,7 +118,7 @@ test {
 
 ## JSON Schema
 
-Every `Lens[T]` and `ObjectLens` implements `LensTrait::to_json_schema`. The result is a Draft 2020-12 schema fragment that includes the lens's complete path. Pass the same heterogeneous lens array accepted by `validate` to `json_schema` to produce a complete schema. Aggregate checks are emitted as `allOf` entries because validation requires every lens to succeed.
+Every `Lens[T]` and `ObjectLens` implements `LensTrait::to_json_schema`. The result is a Draft 2020-12 schema fragment that includes the lens's complete path. Pass the same heterogeneous lens array accepted by `validate` to `json_schema` to produce one object schema. Compatible paths are merged recursively, required names retain their first-seen order, and incompatible declarations at the same path produce a `false` property schema.
 
 ```mbt check
 test {

--- a/mbt/package/lens/docs/design.ja.md
+++ b/mbt/package/lens/docs/design.ja.md
@@ -11,13 +11,13 @@
 ## 決定事項の概要
 
 - 型付きJSONアクセス、builderによる構築、集約検証を提供する。
-- lensを、パッケージが所有するJSON Pointerと値デコーダーおよびエンコーダーとしてモデル化する。
+- lensを、パッケージが所有するJSON Pointerと値デコーダー、エンコーダー、最小限のJSON Schema shapeとしてモデル化する。
 - `Lens[T]`を型付き値に、`ObjectLens`を型付きオブジェクト値および子プロパティlensを作成できるパスに使用する。
 - パッケージ独自のpointer表現を`@json.JsonPath`から独立させる。
 - 1つのlensからは`LensError`を発生させ、集約チェックからは非ジェネリックな`Validation`を返す。
 - 欠落プロパティと明示的なJSON`null`を異なる状態として保持する。
 - `Lens[T]`と`ObjectLens`に静的な結果型を保持し、検証は成功または蓄積された問題のみを報告する。
-- 具体的なlens型を集約検証の境界で消去するため、チェック専用の`LensTrait`トレイトオブジェクトを使用する。
+- 集約検証とJSON Schemaの境界で具体的なlens型を消去するため、`LensTrait`トレイトオブジェクトを使用する。
 - まずオブジェクトプロパティとプリミティブデコーダーから開始する。
 - 数値の解析と変換はMoonBit core APIに委譲し、パッケージ独自の数値パーサーは持たない。
 - 可変な`JsonBuilder`を通じて送信用オブジェクトを構築し、`ToJson`を実装する。
@@ -89,7 +89,7 @@ lookupでは、要求されたpointerと、正常にトラバーサルできたp
 
 MoonBitは、TypeScriptライブラリがZodスキーマ式から型を推論するように、実行時コレクションに含まれる検証定義からコンパイル時の結果型を導出できません。検証APIは、`Schema[T]`、固定個数builder、値を生成する検証結果によってそのモデルを模倣すべきではありません。
 
-`Lens[T]`はプリミティブ値とraw JSON値の静的型情報の源です。`ObjectLens`は`Lens[Map[String, Json]]`を所有するため、静的に型付けされたオブジェクトアクセスも提供します。集約検証はチェック専用の`LensTrait`トレイトオブジェクトを通じて両方を受け取り、すべてのチェックを評価し、成功または蓄積された問題だけを返します。呼び出し側で明示的な変換を行う必要はありません。検証成功後は、元のlensを通じて値を読み続けます。
+`Lens[T]`はプリミティブ値とraw JSON値の静的型情報の源です。`ObjectLens`は`Lens[Map[String, Json]]`を所有するため、静的に型付けされたオブジェクトアクセスも提供します。集約検証とJSON Schema生成は、型消去された`LensTrait`トレイトオブジェクトを通じて両方を受け取ります。検証はすべてのチェックを評価し、成功または蓄積された問題だけを返します。呼び出し側で明示的な変換を行う必要はありません。検証成功後は、元のlensを通じて値を読み続けます。
 
 この設計では、検証後のアクセスでトラバーサルとデコードが再度行われます。この重複を避けるには、異種型付きキャッシュまたはアプリケーションごとに生成されたコードが必要ですが、どちらも初期パッケージには属しません。
 
@@ -454,6 +454,7 @@ pub enum Validation {
 ```moonbit
 pub trait LensTrait {
   fn check(Self, Json) -> Unit raise LensError
+  fn to_json_schema(Self) -> Json
 }
 
 pub impl[T] LensTrait for Lens[T]
@@ -464,9 +465,11 @@ pub fn validate(
   Json,
   Array[&LensTrait],
 ) -> Validation
+
+pub fn json_schema(Array[&LensTrait]) -> Json
 ```
 
-`LensTrait`は意図的な型消去境界です。readonlyかつsealedであり、このパッケージだけが実装を定義できます。その唯一のメソッドはlensのトラバーサルとdecoderを実行し、成功した値を破棄し、発生した`Issue`を集約用に保持します。MoonBitは各異種結果型を保持する型パラメーター付きtrait objectを表現できないため、型付き`get`は`Lens[T]`と`ObjectLens]`に残ります。
+`LensTrait`は意図的な型消去境界です。readonlyかつsealedであり、このパッケージだけが実装を定義できます。`check`はlensのトラバーサルとdecoderを実行し、成功した値を破棄し、発生した`Issue`を集約用に保持します。`to_json_schema`はlensのパスと、lens構築時に保持されたschema shapeを描画します。MoonBitは各異種結果型を保持する型パラメーター付きtrait objectを表現できないため、型付き`get`は`Lens[T]`と`ObjectLens]`に残ります。
 
 ```moonbit
 let user = object("user")

--- a/mbt/package/lens/docs/design.ja.md
+++ b/mbt/package/lens/docs/design.ja.md
@@ -145,11 +145,11 @@ Lens::or_else        fallback to another location, if this feature is needed
 
 unknown-field検証は、オブジェクト境界と宣言されたキーを記録する明示的なobject-check表現を待つ必要があります。`strip_unknown`と`passthrough`はデータを変換または返すため、検証専用APIには属しません。
 
-### スキーマ生成には宣言的なデコーダーメタデータが必要
+### スキーマ生成では宣言的なデコーダーメタデータを使用する
 
 不透明なpredicateおよびtransformクロージャをJSON SchemaやOpenAPIへ確実に変換することはできません。pointerとdecoderの分離は実装構造を改善しますが、スキーマ生成には不十分です。
 
-後から宣言的な制約モデルが導入されない限り、スキーマ生成は非目標です。
+そのため、組み込みlens constructorはdecoderおよびencoderとともに最小限の宣言的schema shapeを保持します。これにより、object path、プリミティブJSON kind、配列、required property、nullable値をサポートします。将来のpredicate、alternative、transform APIでは、schema生成で表現する前に対応するメタデータを追加する必要があります。
 
 ## アーキテクチャ
 
@@ -606,7 +606,7 @@ JSON SchemaとOpenAPIの生成は、サポートされる制約ごとに宣言�
 - 宣言的オブジェクト境界。
 - Unknown-field拒否。
 
-JSON SchemaとOpenAPI生成は、サポートするすべての制約に宣言的メタデータが必要な、別の提案として扱います。
+OpenAPI生成とより豊富なJSON Schema制約は、サポートするすべての制約に宣言的メタデータが必要な、別の提案として扱います。
 
 ### マイルストーン5: Typed output construction
 

--- a/mbt/package/lens/docs/design.md
+++ b/mbt/package/lens/docs/design.md
@@ -11,13 +11,13 @@ This review targets MoonBit 0.10.4 and `moonbitlang/core` 0.10.4.
 ## Decision summary
 
 - Provide typed JSON access, builder construction, and aggregate validation.
-- Model a lens as a package-owned JSON Pointer plus a value decoder and encoder.
+- Model a lens as a package-owned JSON Pointer plus a value decoder, encoder, and minimal JSON Schema shape.
 - Use `Lens[T]` for typed values and `ObjectLens` for typed object values and paths that may create child property lenses.
 - Keep the package's pointer representation independent from `@json.JsonPath`.
 - Raise `LensError` from one lens and return a non-generic `Validation` from aggregate checks.
 - Preserve missing properties and explicit JSON `null` as different states.
 - Keep static result types on `Lens[T]` and `ObjectLens`; validation only reports success or accumulated issues.
-- Use a check-only `LensTrait` trait object to erase concrete lens types only at the aggregate validation boundary.
+- Use `LensTrait` to erase concrete lens types at the aggregate validation and JSON Schema boundaries.
 - Start with object properties and primitive decoders.
 - Delegate numeric parsing and conversion to MoonBit core APIs; do not maintain a package-specific number parser.
 - Build outbound objects through a mutable `JsonBuilder` that implements `ToJson`.
@@ -89,7 +89,7 @@ The name `CustomError` is too generic for a public package API. `LensError(Issue
 
 MoonBit cannot derive a compile-time result type from a runtime collection of validation definitions in the way TypeScript libraries can infer a type from a Zod schema expression. The validation API must not imitate that model with `Schema[T]`, fixed-arity builders, or a value-producing validation result.
 
-`Lens[T]` is the source of static type information for primitive and raw JSON values. `ObjectLens` owns a `Lens[Map[String, Json]]`, so it also provides statically typed object access. Aggregate validation accepts both through the check-only `LensTrait` trait object, evaluates all checks, and returns only success or accumulated issues. Callers do not perform an explicit conversion. After successful validation, they continue to read values through their original lenses.
+`Lens[T]` is the source of static type information for primitive and raw JSON values. `ObjectLens` owns a `Lens[Map[String, Json]]`, so it also provides statically typed object access. Aggregate validation and JSON Schema generation accept both through the type-erased `LensTrait` trait object. Validation evaluates all checks and returns only success or accumulated issues. Callers do not perform an explicit conversion. After successful validation, they continue to read values through their original lenses.
 
 This deliberately means that validation followed by access performs traversal and decoding again. Avoiding that duplication would require a heterogeneous typed cache or generated application-specific code, neither of which belongs in the initial package.
 
@@ -454,6 +454,7 @@ pub enum Validation {
 ```moonbit
 pub trait LensTrait {
   fn check(Self, Json) -> Unit raise LensError
+  fn to_json_schema(Self) -> Json
 }
 
 pub impl[T] LensTrait for Lens[T]
@@ -464,9 +465,11 @@ pub fn validate(
   Json,
   Array[&LensTrait],
 ) -> Validation
+
+pub fn json_schema(Array[&LensTrait]) -> Json
 ```
 
-`LensTrait` is the intentional type-erasure boundary. It is readonly and sealed so only this package can define implementations. Its only method runs a lens's traversal and decoder, discards the successful value, and preserves a raised `Issue` for aggregation. MoonBit cannot express a type-parameterized trait object that retains each heterogeneous result type, so typed `get` remains on `Lens[T]` and `ObjectLens`.
+`LensTrait` is the intentional type-erasure boundary. It is readonly and sealed so only this package can define implementations. `check` runs a lens's traversal and decoder, discards the successful value, and preserves a raised `Issue` for aggregation. `to_json_schema` renders the lens path and the schema shape retained when the lens is constructed. MoonBit cannot express a type-parameterized trait object that retains each heterogeneous result type, so typed `get` remains on `Lens[T]` and `ObjectLens`.
 
 ```moonbit
 let user = object("user")

--- a/mbt/package/lens/docs/design.md
+++ b/mbt/package/lens/docs/design.md
@@ -145,11 +145,11 @@ A validator composed only from independent `LensTrait` checks does not know the 
 
 Unknown-field validation must wait for an explicit object-check representation that records the object boundary and declared keys. `strip_unknown` and `passthrough` transform or return data, so they do not belong to a validation-only API.
 
-### Schema generation requires declarative decoder metadata
+### Schema generation uses declarative decoder metadata
 
 Opaque predicate and transform closures cannot be translated reliably into JSON Schema or OpenAPI. Pointer and decoder separation improves implementation structure, but it is not sufficient for schema generation.
 
-Schema generation is a non-goal unless a later design introduces a declarative constraint model.
+The built-in lens constructors therefore retain a minimal declarative schema shape alongside their decoder and encoder. This supports object paths, primitive JSON kinds, arrays, required properties, and nullable values. Future predicate, alternative, or transform APIs must add corresponding metadata before schema generation can represent them.
 
 ## Architecture
 
@@ -604,7 +604,7 @@ Exit criteria:
 - Declarative object boundaries.
 - Unknown-field rejection.
 
-JSON Schema and OpenAPI generation remain separate proposals that require declarative metadata for every supported constraint.
+OpenAPI generation and richer JSON Schema constraints remain separate proposals that require declarative metadata for every supported constraint.
 
 ### Milestone 5: Typed output construction
 

--- a/mbt/package/lens/src/check.mbt
+++ b/mbt/package/lens/src/check.mbt
@@ -1,7 +1,8 @@
 ///|
-/// A type-erased lens read used only for aggregate validation.
+/// A type-erased lens used for aggregate validation and JSON Schema generation.
 pub trait LensTrait {
   fn check(Self, Json) -> Unit raise LensError
+  fn to_json_schema(Self) -> Json
 }
 
 ///|
@@ -11,7 +12,17 @@ pub impl[T] LensTrait for Lens[T] with fn check(self, document) {
 }
 
 ///|
+pub impl[T] LensTrait for Lens[T] with fn to_json_schema(self) {
+  self.schema_fragment()
+}
+
+///|
 /// Erases this object lens's successful value while preserving its failure.
 pub impl LensTrait for ObjectLens with fn check(self, document) {
   self.get(document) |> ignore
+}
+
+///|
+pub impl LensTrait for ObjectLens with fn to_json_schema(self) {
+  self.lens.schema_fragment()
 }

--- a/mbt/package/lens/src/json_schema.mbt
+++ b/mbt/package/lens/src/json_schema.mbt
@@ -109,19 +109,137 @@ fn[T] Lens::schema_fragment(self : Lens[T]) -> Json {
 }
 
 ///|
+fn schema_type_names(value : Json) -> Array[String]? {
+  match value {
+    Json::String(name) => Some([name])
+    Json::Array(values) => {
+      let names : Array[String] = []
+      for value in values {
+        guard value is Json::String(name) else { return None }
+        names.push(name)
+      }
+      Some(names)
+    }
+    _ => None
+  }
+}
+
+///|
+fn intersect_schema_types(left : Json, right : Json) -> Json? {
+  guard schema_type_names(left) is Some(left_names) else { return None }
+  guard schema_type_names(right) is Some(right_names) else { return None }
+  match left_names.filter(name => right_names.contains(name)) {
+    [] => None
+    [name] => Some(name.to_json())
+    names => Some(Json::array(names.map(name => name.to_json())))
+  }
+}
+
+///|
+fn required_names(value : Json) -> Array[String]? {
+  guard value is Json::Array(values) else { return None }
+  let names : Array[String] = []
+  for value in values {
+    guard value is Json::String(name) else { return None }
+    names.push(name)
+  }
+  Some(names)
+}
+
+///|
+fn merge_required(left : Json, right : Json) -> Json? {
+  guard required_names(left) is Some(left_names) else { return None }
+  guard required_names(right) is Some(right_names) else { return None }
+  let names = right_names.fold(init=left_names, (names, name) => {
+    if names.contains(name) {
+      names
+    } else {
+      [..names, name]
+    }
+  })
+  Some(Json::array(names.map(name => name.to_json())))
+}
+
+///|
+fn merge_property_schemas(left : Json, right : Json) -> Json {
+  guard left is Json::Object(left_properties) else {
+    return Json::boolean(false)
+  }
+  guard right is Json::Object(right_properties) else {
+    return Json::boolean(false)
+  }
+  let properties = left_properties.copy()
+  for key, right_schema in right_properties {
+    properties[key] = match properties.get(key) {
+      Some(left_schema) => merge_schemas(left_schema, right_schema)
+      None => right_schema
+    }
+  }
+  Json::object(properties)
+}
+
+///|
+fn merge_schema_values(key : String, left : Json, right : Json) -> Json? {
+  match key {
+    "type" => intersect_schema_types(left, right)
+    "properties" => Some(merge_property_schemas(left, right))
+    "required" => merge_required(left, right)
+    "items" => Some(merge_schemas(left, right))
+    _ => if left == right { Some(left) } else { None }
+  }
+}
+
+///|
+fn merge_schema_objects(
+  left_properties : Map[String, Json],
+  right_properties : Map[String, Json],
+) -> Json {
+  let properties = left_properties.copy()
+  for key, right_value in right_properties {
+    match properties.get(key) {
+      None => properties[key] = right_value
+      Some(left_value) => {
+        guard merge_schema_values(key, left_value, right_value) is Some(value) else {
+          return Json::boolean(false)
+        }
+        properties[key] = value
+      }
+    }
+  }
+  Json::object(properties)
+}
+
+///|
+fn merge_schemas(left : Json, right : Json) -> Json {
+  match (left, right) {
+    (Json::False, _) | (_, Json::False) => Json::boolean(false)
+    (Json::True, schema) | (schema, Json::True) => schema
+    (Json::Object(left_properties), Json::Object(right_properties)) =>
+      merge_schema_objects(left_properties, right_properties)
+    _ => Json::boolean(false)
+  }
+}
+
+///|
 /// Generates a Draft 2020-12 JSON Schema for the same heterogeneous lens set
 /// accepted by `validate`.
 ///
-/// Each lens contributes one conjunct so incompatible duplicate declarations
-/// remain incompatible instead of overwriting one another.
+/// Compatible paths are merged into one object schema. Incompatible duplicate
+/// declarations become a `false` property schema.
 pub fn json_schema(lenses : Array[&LensTrait]) -> Json {
   let schema : Map[String, Json] = {
     "$schema": "https://json-schema.org/draft/2020-12/schema".to_json(),
   }
-  if !lenses.is_empty() {
-    schema["allOf"] = Json::array(
-      lenses.map(lens => LensTrait::to_json_schema(lens)),
-    )
+  let merged = lenses.fold(init=Json::empty_object(), (merged, lens) => {
+    merge_schemas(merged, LensTrait::to_json_schema(lens))
+  })
+  match merged {
+    Json::Object(properties) =>
+      for key, value in properties {
+        schema[key] = value
+      }
+    Json::False => return Json::boolean(false)
+    _ => ()
   }
   Json::object(schema)
 }

--- a/mbt/package/lens/src/json_schema.mbt
+++ b/mbt/package/lens/src/json_schema.mbt
@@ -1,0 +1,127 @@
+///|
+priv enum SchemaShape {
+  AnySchema
+  StringSchema
+  BooleanSchema
+  NumberSchema
+  ObjectSchema
+  ArraySchema(SchemaShape)
+  NullableSchema(SchemaShape)
+}
+
+///|
+fn SchemaShape::nullable(self : SchemaShape) -> SchemaShape {
+  match self {
+    AnySchema => AnySchema
+    NullableSchema(_) => self
+    _ => NullableSchema(self)
+  }
+}
+
+///|
+fn SchemaShape::type_names(self : SchemaShape) -> Array[String] {
+  match self {
+    AnySchema => []
+    StringSchema => ["string"]
+    BooleanSchema => ["boolean"]
+    NumberSchema => ["number"]
+    ObjectSchema => ["object"]
+    ArraySchema(_) => ["array"]
+    NullableSchema(shape) => [..shape.type_names(), "null"]
+  }
+}
+
+///|
+fn SchemaShape::items(self : SchemaShape) -> Json? {
+  match self {
+    ArraySchema(item_shape) => Some(item_shape.to_json())
+    NullableSchema(shape) => shape.items()
+    _ => None
+  }
+}
+
+///|
+fn SchemaShape::to_json(self : SchemaShape) -> Json {
+  let properties : Map[String, Json] = Map([])
+  let type_names = self.type_names()
+  match type_names {
+    [] => ()
+    [type_name] => properties["type"] = type_name.to_json()
+    _ =>
+      properties["type"] = Json::array(
+        type_names.map(type_name => type_name.to_json()),
+      )
+  }
+  match self.items() {
+    Some(items) => properties["items"] = items
+    None => ()
+  }
+  Json::object(properties)
+}
+
+///|
+fn property_schema(key : String, value_schema : Json, required : Bool) -> Json {
+  let properties : Map[String, Json] = Map([])
+  properties["type"] = "object".to_json()
+  let property_schemas : Map[String, Json] = Map([])
+  property_schemas[key] = value_schema
+  properties["properties"] = Json::object(property_schemas)
+  if required {
+    properties["required"] = Json::array([key.to_json()])
+  }
+  Json::object(properties)
+}
+
+///|
+fn indexed_schema(index : Int, value_schema : Json, required : Bool) -> Json {
+  let prefix_items = Array::makei(index + 1, item_index => {
+    if item_index == index {
+      value_schema
+    } else {
+      Json::empty_object()
+    }
+  })
+  let properties : Map[String, Json] = {
+    "type": "array".to_json(),
+    "prefixItems": Json::array(prefix_items),
+  }
+  if required {
+    properties["minItems"] = (index + 1).to_json()
+  }
+  Json::object(properties)
+}
+
+///|
+fn[T] Lens::schema_fragment(self : Lens[T]) -> Json {
+  let (_, schema) = self.pointer.segments.rev_fold(
+    init=(true, self.schema_shape.to_json()),
+    (state, segment) => {
+      let (is_leaf, child_schema) = state
+      let required = if is_leaf { self.schema_required } else { true }
+      let parent_schema = match segment {
+        Key(key) => property_schema(key, child_schema, required)
+        Index(index) => indexed_schema(index, child_schema, required)
+      }
+      (false, parent_schema)
+    },
+  )
+  schema
+}
+
+///|
+/// Generates a Draft 2020-12 JSON Schema for the same heterogeneous lens set
+/// accepted by `validate`.
+///
+/// Each lens contributes one conjunct so incompatible duplicate declarations
+/// remain incompatible instead of overwriting one another.
+pub fn json_schema(lenses : Array[&LensTrait]) -> Json {
+  let schema : Map[String, Json] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema".to_json(),
+  }
+  if !lenses.is_empty() {
+    schema["allOf"] = Json::array(
+      lenses.map(lens => LensTrait::to_json_schema(lens)),
+    )
+  }
+  Json::object(schema)
+}

--- a/mbt/package/lens/src/json_schema_test.mbt
+++ b/mbt/package/lens/src/json_schema_test.mbt
@@ -37,40 +37,19 @@ test "json_schema - combines heterogeneous validator checks" {
     ]),
     content={
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "allOf": [
-        {
+      "type": "object",
+      "properties": {
+        "user": {
           "type": "object",
           "properties": {
-            "user": {
-              "type": "object",
-              "properties": { "name": { "type": "string" } },
-              "required": ["name"],
-            },
+            "name": { "type": "string" },
+            "age": { "type": "number" },
+            "active": { "type": ["boolean", "null"] },
           },
-          "required": ["user"],
+          "required": ["name", "age"],
         },
-        {
-          "type": "object",
-          "properties": {
-            "user": {
-              "type": "object",
-              "properties": { "age": { "type": "number" } },
-              "required": ["age"],
-            },
-          },
-          "required": ["user"],
-        },
-        {
-          "type": "object",
-          "properties": {
-            "user": {
-              "type": "object",
-              "properties": { "active": { "type": ["boolean", "null"] } },
-            },
-          },
-          "required": ["user"],
-        },
-      ],
+      },
+      "required": ["user"],
     },
   )
 }
@@ -82,18 +61,37 @@ test "json_schema - renders object and unconstrained raw JSON checks" {
     @lens.json_schema([root.object("payload"), root.json("metadata")]),
     content={
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "allOf": [
-        {
-          "type": "object",
-          "properties": { "payload": { "type": "object" } },
-          "required": ["payload"],
-        },
-        {
-          "type": "object",
-          "properties": { "metadata": Json::empty_object() },
-          "required": ["metadata"],
-        },
-      ],
+      "type": "object",
+      "properties": {
+        "payload": { "type": "object" },
+        "metadata": Json::empty_object(),
+      },
+      "required": ["payload", "metadata"],
+    },
+  )
+}
+
+///|
+test "json_schema - intersects compatible declarations at one property" {
+  let name = @lens.root().string("name")
+  @json.json_inspect(@lens.json_schema([name.nullable(), name]), content={
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "name": { "type": "string" } },
+    "required": ["name"],
+  })
+}
+
+///|
+test "json_schema - renders incompatible declarations as false" {
+  let root = @lens.root()
+  @json.json_inspect(
+    @lens.json_schema([root.string("value"), root.bool("value")]),
+    content={
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "value": false },
+      "required": ["value"],
     },
   )
 }

--- a/mbt/package/lens/src/json_schema_test.mbt
+++ b/mbt/package/lens/src/json_schema_test.mbt
@@ -1,0 +1,106 @@
+///|
+test "LensTrait to_json_schema - renders a nested required string" {
+  @json.json_inspect(@lens.object("user").string("name").to_json_schema(), content={
+    "type": "object",
+    "properties": {
+      "user": {
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"],
+      },
+    },
+    "required": ["user"],
+  })
+}
+
+///|
+test "LensTrait to_json_schema - renders optional nullable array items" {
+  @json.json_inspect(
+    @lens.root().string("tags").array().nullable().optional().to_json_schema(),
+    content={
+      "type": "object",
+      "properties": {
+        "tags": { "type": ["array", "null"], "items": { "type": "string" } },
+      },
+    },
+  )
+}
+
+///|
+test "json_schema - combines heterogeneous validator checks" {
+  let user = @lens.object("user")
+  @json.json_inspect(
+    @lens.json_schema([
+      user.string("name"),
+      user.int("age"),
+      user.bool("active").nullish(),
+    ]),
+    content={
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "user": {
+              "type": "object",
+              "properties": { "name": { "type": "string" } },
+              "required": ["name"],
+            },
+          },
+          "required": ["user"],
+        },
+        {
+          "type": "object",
+          "properties": {
+            "user": {
+              "type": "object",
+              "properties": { "age": { "type": "number" } },
+              "required": ["age"],
+            },
+          },
+          "required": ["user"],
+        },
+        {
+          "type": "object",
+          "properties": {
+            "user": {
+              "type": "object",
+              "properties": { "active": { "type": ["boolean", "null"] } },
+            },
+          },
+          "required": ["user"],
+        },
+      ],
+    },
+  )
+}
+
+///|
+test "json_schema - renders object and unconstrained raw JSON checks" {
+  let root = @lens.root()
+  @json.json_inspect(
+    @lens.json_schema([root.object("payload"), root.json("metadata")]),
+    content={
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "allOf": [
+        {
+          "type": "object",
+          "properties": { "payload": { "type": "object" } },
+          "required": ["payload"],
+        },
+        {
+          "type": "object",
+          "properties": { "metadata": Json::empty_object() },
+          "required": ["metadata"],
+        },
+      ],
+    },
+  )
+}
+
+///|
+test "json_schema - renders an unconstrained empty validator" {
+  @json.json_inspect(@lens.json_schema([]), content={
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+  })
+}

--- a/mbt/package/lens/src/lens.mbt
+++ b/mbt/package/lens/src/lens.mbt
@@ -11,6 +11,8 @@ pub struct Lens[T] {
   priv decoder : Decoder[T]
   priv encoder : Encoder[T]
   priv on_missing : (() -> T)?
+  priv schema_shape : SchemaShape
+  priv schema_required : Bool
 }
 
 ///|
@@ -29,6 +31,8 @@ pub fn root() -> ObjectLens {
       decoder: object_decoder(),
       encoder: object_encoder(),
       on_missing: None,
+      schema_shape: ObjectSchema,
+      schema_required: true,
     },
   }
 }
@@ -48,6 +52,8 @@ pub fn ObjectLens::object(self : ObjectLens, key : String) -> ObjectLens {
       decoder: object_decoder(),
       encoder: object_encoder(),
       on_missing: None,
+      schema_shape: ObjectSchema,
+      schema_required: true,
     },
   }
 }
@@ -60,6 +66,8 @@ pub fn ObjectLens::string(self : ObjectLens, key : String) -> Lens[String] {
     decoder: string_decoder(),
     encoder: string_encoder(),
     on_missing: None,
+    schema_shape: StringSchema,
+    schema_required: true,
   }
 }
 
@@ -71,6 +79,8 @@ pub fn ObjectLens::bool(self : ObjectLens, key : String) -> Lens[Bool] {
     decoder: bool_decoder(),
     encoder: bool_encoder(),
     on_missing: None,
+    schema_shape: BooleanSchema,
+    schema_required: true,
   }
 }
 
@@ -82,6 +92,8 @@ pub fn ObjectLens::number(self : ObjectLens, key : String) -> Lens[Double] {
     decoder: number_decoder(),
     encoder: number_encoder(),
     on_missing: None,
+    schema_shape: NumberSchema,
+    schema_required: true,
   }
 }
 
@@ -93,6 +105,9 @@ pub fn ObjectLens::int(self : ObjectLens, key : String) -> Lens[Int] {
     decoder: int_decoder(),
     encoder: int_encoder(),
     on_missing: None,
+    // The decoder accepts every JSON number and applies Double::to_int.
+    schema_shape: NumberSchema,
+    schema_required: true,
   }
 }
 
@@ -104,6 +119,8 @@ pub fn ObjectLens::json(self : ObjectLens, key : String) -> Lens[Json] {
     decoder: json_decoder(),
     encoder: json_encoder(),
     on_missing: None,
+    schema_shape: AnySchema,
+    schema_required: true,
   }
 }
 
@@ -115,6 +132,8 @@ pub fn[T] Lens::array(self : Lens[T]) -> Lens[Array[T]] {
     decoder: array_decoder(self.decoder),
     encoder: array_encoder(self.encoder),
     on_missing: None,
+    schema_shape: ArraySchema(self.schema_shape),
+    schema_required: true,
   }
 }
 
@@ -126,6 +145,8 @@ pub fn[T] Lens::nullable(self : Lens[T]) -> Lens[T?] {
     decoder: nullable_decoder(self.decoder),
     encoder: nullable_encoder(self.encoder),
     on_missing: None,
+    schema_shape: self.schema_shape.nullable(),
+    schema_required: true,
   }
 }
 
@@ -137,6 +158,8 @@ pub fn[T] Lens::optional(self : Lens[T]) -> Lens[T?] {
     decoder: optional_decoder(self.decoder),
     encoder: optional_encoder(self.encoder),
     on_missing: Some(() => None),
+    schema_shape: self.schema_shape,
+    schema_required: false,
   }
 }
 
@@ -156,6 +179,8 @@ pub fn[T] Lens::nullish(
       Some(Omit) | None => optional_encoder(self.encoder)
     },
     on_missing: Some(() => None),
+    schema_shape: self.schema_shape.nullable(),
+    schema_required: false,
   }
 }
 


### PR DESCRIPTION
## PR概要

- `LensTrait`にJSON Schema生成を追加し、レンズのパスと宣言的な型情報からDraft 2020-12 Schemaを生成します。
- 複数レンズの互換なパスを再帰的に統合し、required順序を保持します。
- 同一パスで型が競合する場合は`false`スキーマを出力します。
- API仕様と設計ドキュメントを更新します。

```mermaid
flowchart TD
  A[異種Lens配列] --> B[LensTrait::to_json_schema]
  B --> C[各レンズのパスとSchema shapeを描画]
  C --> D[Schemaを再帰的にマージ]
  D --> E{宣言が互換}
  E -->|はい| F[型・properties・required・itemsを統合]
  E -->|いいえ| G[競合箇所をfalse Schemaにする]
  F --> H[Draft 2020-12 Schemaを返す]
  G --> H
```

## Testing

- ネストしたrequired stringの生成を確認
- optional nullable arrayとarray itemsの生成を確認
- 異種Lensの統合、raw JSONの無制約Schema、空のLens配列を確認
- 同一プロパティでnullable型を統合できることを確認
- 同一プロパティでstringとbooleanが競合した場合に`false`を出力することを確認

```mermaid
flowchart TD
  A[テスト開始] --> B[単一LensのSchema生成]
  B --> C[ネスト・required・nullable・arrayを確認]
  C --> D[複数LensのSchema統合]
  D --> E[互換な宣言]
  D --> F[raw JSON・空配列]
  D --> G[競合する宣言]
  E --> H[統合結果を確認]
  F --> H
  G --> I[false Schemaを確認]
  H --> J[テスト完了]
  I --> J
```

- `mbt/package/lens`のユニットテストを追加・更新しました。