### PR TITLE
agent-cli-sdkのJSONLイベント配送を型付き化

### DIFF
--- a/mbt/app/mdt/moon.mod
+++ b/mbt/app/mdt/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/mdt"
 
-version = "0.1.4"
+version = "0.1.5"
 
 preferred_target = "native"
 
@@ -10,7 +10,7 @@ import {
   "moonbitlang/async@0.20.1",
   "moonbitlang/x@0.4.38",
   "totto2727/admiral@0.6.0",
-  "totto2727/opencode-sdk@0.2.0",
+  "totto2727/opencode-sdk@0.2.1",
 }
 
 readme = "README.md"

--- a/mbt/package/agent-cli-sdk/README.mbt.md
+++ b/mbt/package/agent-cli-sdk/README.mbt.md
@@ -2,17 +2,21 @@
 
 `agent-cli-sdk` provides the shared native process lifecycle for MoonBit SDKs that run agent CLIs and consume JSONL events.
 
-Provider SDKs remain responsible for building CLI arguments and environment variables, decoding provider-specific events, and aggregating turns. This package owns stdin delivery, ordered JSONL parsing, stderr capture, exit status reporting, callback-requested termination, and cancellation-safe child cleanup.
+Provider SDKs remain responsible for building CLI arguments and environment variables, defining provider-specific event types with `FromJson`, and aggregating turns. This package owns stdin delivery, ordered JSONL parsing and typed decoding, stderr capture, exit status reporting, callback-requested termination, and cancellation-safe child cleanup.
 
 ```moonbit
+struct Event {
+  message : String
+} derive(FromJson)
+
 let result = @agent_cli.run(
   @agent_cli.Invocation::new(
     command="agent",
     arguments=["run", "--format", "json"],
     input="Hello",
   ),
-  async fn(line) {
-    println(line.value.stringify())
+  async fn(event : Event) {
+    println(event.message)
     true
   },
 )

--- a/mbt/package/agent-cli-sdk/moon.mod
+++ b/mbt/package/agent-cli-sdk/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/agent-cli-sdk"
 
-version = "0.1.1"
+version = "0.2.0"
 
 preferred_target = "native"
 

--- a/mbt/package/agent-cli-sdk/src/agent_cli.mbt
+++ b/mbt/package/agent-cli-sdk/src/agent_cli.mbt
@@ -21,13 +21,6 @@ pub fn Invocation::new(
 }
 
 ///|
-/// One JSONL record with both its original text and parsed JSON value.
-pub(all) struct JsonLine {
-  raw : String
-  value : Json
-} derive(Debug, Eq)
-
-///|
 /// The process-level outcome of an agent CLI invocation.
 pub(all) enum RunResult {
   Completed
@@ -36,7 +29,7 @@ pub(all) enum RunResult {
 } derive(Debug, Eq)
 
 ///|
-/// Errors raised while reading the JSONL protocol.
+/// Errors raised while reading or decoding the JSONL protocol.
 pub(all) suberror AgentCliError {
   InvalidJson(line~ : String, cause~ : String)
 } derive(Debug, Eq)
@@ -48,14 +41,14 @@ priv enum ChildExit {
 }
 
 ///|
-/// Run an agent CLI, write its stdin, and stream parsed JSONL events in order.
+/// Run an agent CLI, write its stdin, and stream decoded JSONL events in order.
 ///
 /// Returning `false` from `on_event` terminates the child and returns `Stopped`.
 /// A nonzero child exit is returned as `Failed`; process and callback errors are
 /// raised after all child resources have been cleaned up.
-pub async fn run(
+pub async fn[T : @json.FromJson] run(
   invocation : Invocation,
-  on_event : async (JsonLine) -> Bool,
+  on_event : async (T) -> Bool,
 ) -> RunResult {
   let stop_requested = Ref(false)
   @async.with_task_group(async fn(group) {
@@ -84,10 +77,13 @@ pub async fn run(
     let stdout_task = group.spawn(async fn() {
       defer output_reader.close()
       while output_reader.read_until("\n") is Some(line) {
-        let event = @json.parse(line) catch {
+        let json = @json.parse(line) catch {
           error => raise AgentCliError::InvalidJson(line~, cause="\{error}")
         }
-        if !on_event({ raw: line, value: event }) {
+        let event : T = @json.from_json(json) catch {
+          error => raise AgentCliError::InvalidJson(line~, cause="\{error}")
+        }
+        if !on_event(event) {
           stop_requested.val = true
           child.cancel()
           break

--- a/mbt/package/agent-cli-sdk/src/agent_cli_test.mbt
+++ b/mbt/package/agent-cli-sdk/src/agent_cli_test.mbt
@@ -6,6 +6,11 @@ priv struct FakeAgentCli {
 }
 
 ///|
+priv struct SequenceEvent {
+  sequence : Int
+} derive(FromJson)
+
+///|
 async fn create_fake_agent_cli() -> FakeAgentCli {
   let root = @fs.tmpdir(prefix="agent-cli-sdk-test-")
   let executable = "\{root}/agent"
@@ -89,21 +94,18 @@ fn fake_agent_cli_script() -> String {
 }
 
 ///|
-async test "run streams ordered JSON events and preserves invocation data" {
+async test "run decodes ordered JSON events and preserves invocation data" {
   with_fake_agent_cli(async fn(fixture) {
     let events = ["{\"sequence\":1}", "{\"sequence\":2}"].join("\n")
-    let received : Array[String] = []
+    let received : Array[Int] = []
     let result = run(fixture.invocation(events, { "CUSTOM_ENV": "custom" }), fn(
-      event,
+      event : SequenceEvent,
     ) {
-      received.push(event.value.stringify())
+      received.push(event.sequence)
       true
     })
     debug_inspect(result, content="Completed")
-    debug_inspect(
-      received,
-      content="[\"{\\\"sequence\\\":1}\", \"{\\\"sequence\\\":2}\"]",
-    )
+    debug_inspect(received, content="[1, 2]")
     let expected_arguments =
       #|run
       #|--format
@@ -133,7 +135,7 @@ async test "run returns nonzero exit status and stderr" {
         "FAKE_AGENT_STDERR": "agent failed",
         "FAKE_AGENT_EXIT_CODE": "17",
       }),
-      fn(_) { true },
+      fn(_ : Json) { true },
     )
     debug_inspect(result, content="Failed(code=17, stderr=\"agent failed\")")
   })
@@ -144,7 +146,7 @@ async test "run rejects malformed JSONL and terminates the child" {
   with_fake_agent_cli(async fn(fixture) {
     let invocation = fixture.invocation("{not-json", { "FAKE_AGENT_PAUSE": "1" })
     let message = try {
-      run(invocation, fn(_) { true }) |> ignore
+      run(invocation, fn(_ : Json) { true }) |> ignore
       "no error"
     } catch {
       AgentCliError::InvalidJson(line~, cause~) => "\{line}:\{cause}"
@@ -160,13 +162,35 @@ async test "run rejects malformed JSONL and terminates the child" {
 }
 
 ///|
+async test "run rejects JSON events that do not match the requested type" {
+  with_fake_agent_cli(async fn(fixture) {
+    let invocation = fixture.invocation("{\"unexpected\":true}", {
+      "FAKE_AGENT_PAUSE": "1",
+    })
+    let message = try {
+      run(invocation, fn(_ : SequenceEvent) { true }) |> ignore
+      "no error"
+    } catch {
+      AgentCliError::InvalidJson(line~, cause~) => "\{line}:\{cause}"
+      error => "unexpected: \{error}"
+    }
+    assert_true(message.has_prefix("{\"unexpected\":true}:"))
+    let pid = @string.parse_int(
+      @fs.read_file("\{fixture.record_directory}/pid").text().trim(),
+      base=10,
+    )
+    assert_false(process_is_running(pid))
+  })
+}
+
+///|
 async test "run stops the child when the callback returns false" {
   with_fake_agent_cli(async fn(fixture) {
     let result = run(
       fixture.invocation("{\"sequence\":1}\n{\"sequence\":2}", {
         "FAKE_AGENT_PAUSE": "1",
       }),
-      fn(_) { false },
+      fn(_ : Json) { false },
     )
     debug_inspect(result, content="Stopped")
     let pid = @string.parse_int(
@@ -186,7 +210,7 @@ async test "run cancellation terminates the child" {
         async fn() {
           run(
             fixture.invocation("{\"started\":true}", { "FAKE_AGENT_PAUSE": "1" }),
-            async fn(_) {
+            async fn(_ : Json) {
               started.put(())
               true
             },

--- a/mbt/package/codex-sdk/moon.mod
+++ b/mbt/package/codex-sdk/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/codex-sdk"
 
-version = "0.1.0"
+version = "0.1.1"
 
 preferred_target = "native"
 
@@ -9,7 +9,7 @@ supported_targets = "native"
 import {
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.20.1",
-  "totto2727/agent-cli-sdk@0.1.1",
+  "totto2727/agent-cli-sdk@0.2.0",
   "totto2727/copy@0.2.0",
   "totto2727/lens@0.3.0",
 }

--- a/mbt/package/codex-sdk/src/exec.mbt
+++ b/mbt/package/codex-sdk/src/exec.mbt
@@ -76,14 +76,14 @@ fn CodexExec::CodexExec(
 
 ///| Upstream: https://github.com/openai/codex/blob/f201c30c52a35f819262865a53df94b6f4ea7a50/sdk/typescript/src/exec.ts#L86-L243
 
-///| Async type difference: MoonBit has no AsyncGenerator, so each output line is delivered to an async callback returning whether iteration should continue.
+///| Async type difference: MoonBit has no AsyncGenerator, so each decoded event is delivered to an async callback returning whether iteration should continue.
 
 ///|
 /// Cancellation type difference: cancelling the owning MoonBit task replaces the upstream AbortSignal.
 async fn CodexExec::run(
   self : CodexExec,
   args : CodexExecArgs,
-  on_line : async (@agent_cli.JsonLine) -> Bool,
+  on_event : async (ThreadEvent) -> Bool,
 ) -> Unit {
   let command_args = ["exec", "--experimental-json"]
   if self.config_overrides is Some(config) {
@@ -187,7 +187,7 @@ async fn CodexExec::run(
       inherit_environment~,
       input=args.input,
     ),
-    on_line,
+    on_event,
   ) catch {
     @agent_cli.AgentCliError::InvalidJson(line~, cause~) =>
       raise InvalidEvent(

--- a/mbt/package/codex-sdk/src/thread.mbt
+++ b/mbt/package/codex-sdk/src/thread.mbt
@@ -140,13 +140,7 @@ async fn Thread::run_streamed_internal(
         web_search_enabled: options.web_search_enabled,
         approval_policy: options.approval_policy,
       },
-      async fn(line) {
-        let event : ThreadEvent = @json.from_json(line.value) catch {
-          error =>
-            raise InvalidEvent(
-              message="Failed to parse item: \{line.raw}; cause: \{@debug.to_string(error)}",
-            )
-        }
+      async fn(event) {
         if event is ThreadStarted(started) {
           self.id_value = Some(started.thread_id)
         }

--- a/mbt/package/moon-agent-graph/moon.mod
+++ b/mbt/package/moon-agent-graph/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/moon-agent-graph"
 
-version = "0.1.0"
+version = "0.1.1"
 
 readme = "README.md"
 
@@ -23,8 +23,8 @@ import {
   "DC-Z-lab/moonllm@0.1.0",
   "moonbitlang/async@0.20.1",
   "moonbitlang/x@0.4.38",
-  "totto2727/codex-sdk@0.1.0",
-  "totto2727/opencode-sdk@0.2.0",
+  "totto2727/codex-sdk@0.1.1",
+  "totto2727/opencode-sdk@0.2.1",
 }
 
 preferred_target = "native"

--- a/mbt/package/opencode-sdk/README.mbt.md
+++ b/mbt/package/opencode-sdk/README.mbt.md
@@ -26,7 +26,7 @@ Add the package to a MoonBit project and import it with an alias:
 
 ```mbt
 import {
-  "totto2727/opencode-sdk@0.1.1",
+  "totto2727/opencode-sdk@0.2.1",
 }
 ```
 

--- a/mbt/package/opencode-sdk/moon.mod
+++ b/mbt/package/opencode-sdk/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/opencode-sdk"
 
-version = "0.2.0"
+version = "0.2.1"
 
 preferred_target = "native"
 
@@ -9,7 +9,7 @@ supported_targets = "native"
 import {
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.20.1",
-  "totto2727/agent-cli-sdk@0.1.1",
+  "totto2727/agent-cli-sdk@0.2.0",
   "totto2727/copy@0.2.0",
   "totto2727/lens@0.3.0",
 }

--- a/mbt/package/opencode-sdk/src/exec.mbt
+++ b/mbt/package/opencode-sdk/src/exec.mbt
@@ -38,11 +38,11 @@ fn OpenCodeExec::OpenCodeExec(
 }
 
 ///|
-/// Execute the OpenCode CLI and deliver each JSONL line to `on_line`.
+/// Execute the OpenCode CLI and deliver each decoded event to `on_event`.
 async fn OpenCodeExec::run(
   self : OpenCodeExec,
   args : OpenCodeExecArgs,
-  on_line : async (@agent_cli.JsonLine) -> Bool,
+  on_event : async (ThreadEvent) -> Bool,
 ) -> Unit {
   let command_args = ["run", "--format", "json"]
   if args.session_id is Some(session_id) {
@@ -93,7 +93,7 @@ async fn OpenCodeExec::run(
       inherit_environment~,
       input=args.input,
     ),
-    on_line,
+    on_event,
   ) catch {
     @agent_cli.AgentCliError::InvalidJson(line~, cause~) =>
       raise InvalidEvent(

--- a/mbt/package/opencode-sdk/src/thread.mbt
+++ b/mbt/package/opencode-sdk/src/thread.mbt
@@ -89,13 +89,7 @@ async fn Thread::run_streamed_internal(
         title: options.title,
         thinking: options.thinking,
       },
-      async fn(line) {
-        let event : ThreadEvent = @json.from_json(line.value) catch {
-          @json.JsonDecodeError((_, message)) =>
-            raise InvalidEvent(
-              message="Failed to parse OpenCode event: \{line.raw}; cause: \{message}",
-            )
-        }
+      async fn(event) {
         if self.id_value is None && event.session_id() is Some(session_id) {
           self.id_value = Some(session_id)
         }


### PR DESCRIPTION
## 概要

`agent-cli-sdk` のJSONLイベント配送を標準 `FromJson` 制約の型付きAPIへ変更し、Codex/OpenCodeのprovider層へ `ThreadEvent` を直接渡すようにしました。公開 `JsonLine` とraw互換APIは削除し、入力行はdecode失敗時の診断情報としてのみ内部保持します。

## 変更内容

- `run[T : @json.FromJson]` でJSONLをparse後、共有境界で `T` へdecode
- Codex/OpenCodeの重複decodeを削除し、exec callbackを `ThreadEvent` に統一
- 利用箇所のない `AgentEvent` / `extenum` は追加しない
- 型付き成功、schema不一致、壊れたJSON、stop/cancelの回帰テストを更新
- README例とMoonBit package version・exact dependencyを同期

## 処理フロー

```mermaid
flowchart LR
  CLI["Agent CLI JSONL"] --> Parse["agent-cli-sdk: Json parse"]
  Parse --> Decode["FromJsonでTへdecode"]
  Decode --> Provider["Codex/OpenCode: ThreadEvent"]
  Provider --> Callback["利用側callback"]
  Parse -->|"構文エラー"| Error["InvalidJson: raw line付き"]
  Decode -->|"schemaエラー"| Error
```

## バージョン更新

- `agent-cli-sdk`: `0.1.1` → `0.2.0`
- `codex-sdk`: `0.1.0` → `0.1.1`
- `opencode-sdk`: `0.2.0` → `0.2.1`
- `moon-agent-graph`: `0.1.0` → `0.1.1`
- `mdt`: `0.1.4` → `0.1.5`

## 検証

- [x] `vp run w:setup`
- [x] `vp run --parallel ci`
- [x] MoonBit: wasm-gc 575/575、native 362/362
- [x] 独立QA: agent-cli-sdkの型付き成功・schema不一致・壊れたJSON・stop・cancel
- [x] 独立QA: Codex 37/37、OpenCode 8/8
- [x] 5レーンレビュー: goal / QA / code quality / security / context がすべてPASS
- [x] HTMLレポートを実ブラウザで確認: HTTP 200、横方向overflowなし、console errorなし

HTMLレポートは依頼どおりコミット対象外です。

## 参考資料

- [MoonBit extensible enum](https://docs.moonbitlang.com/en/latest/language/fundamentals.html#extensible-enum)
- [MoonBit deriving](https://docs.moonbitlang.com/en/stable/language/derive.html)
- [MoonBit core/json FromJson](https://mooncakes.io/assets/moonbitlang/core/json/from_json.mbt.html)
