### PR TITLE
Use canonical MoonBit metadata in Nix packages

### DIFF
--- a/mbt/app/bw/moon.mod
+++ b/mbt/app/bw/moon.mod
@@ -24,4 +24,4 @@ keywords = [ "cloudflare", "browser-rendering", "cli" ]
 
 description = "Native MoonBit CLI for Cloudflare Browser Rendering API"
 
-source = "./src"
+source = "src"

--- a/mbt/app/bw/package.nix
+++ b/mbt/app/bw/package.nix
@@ -22,27 +22,10 @@ let
     cp -R ${packageSrc}/. "$out/"
     cp ${moonWork} "$out/moon.work"
   '';
-  moonModJson = builtins.toFile "bw-moon.mod.json" (
-    builtins.toJSON {
-      name = "totto2727/bw";
-      version = "0.1.7";
-      deps = {
-        "gmlewis/base64" = "0.16.10";
-        "totto2727/admiral" = "0.5.0";
-        "moonbitlang/async" = "0.19.2";
-        "moonbitlang/x" = "0.4.38";
-      };
-      description = "Native MoonBit CLI for Cloudflare Browser Rendering API";
-      license = "MIT";
-      "preferred-target" = "native";
-      repository = "https://github.com/totto2727-org/monorepo";
-      source = "src";
-      "supported-targets" = "native";
-    }
-  );
 in
 moonPlatform.buildMoonPackage {
-  inherit src moonModJson moonRegistryIndex;
+  inherit src moonRegistryIndex;
+  moonMod = ./moon.mod;
   moonFlags = [ "app/bw/src" ];
   doCheck = false;
   meta.mainProgram = "bw";

--- a/mbt/app/c-plugin/moon.mod
+++ b/mbt/app/c-plugin/moon.mod
@@ -24,4 +24,4 @@ keywords = [ "claude", "cursor", "codex", "plugin", "cli" ]
 
 description = "Native MoonBit Claude/Cursor/Codex plugin skill manager"
 
-source = "./src"
+source = "src"

--- a/mbt/app/c-plugin/package.nix
+++ b/mbt/app/c-plugin/package.nix
@@ -25,26 +25,10 @@ let
     cp -R ${packageSrc}/. "$out/"
     cp ${moonWork} "$out/moon.work"
   '';
-  moonModJson = builtins.toFile "c-plugin-moon.mod.json" (
-    builtins.toJSON {
-      name = "totto2727/c-plugin";
-      version = "0.1.0";
-      deps = {
-        "totto2727/admiral" = "0.5.0";
-        "moonbitlang/async" = "0.19.2";
-        "moonbitlang/x" = "0.4.38";
-      };
-      description = "Native MoonBit Claude/Cursor/Codex plugin skill manager";
-      license = "MIT";
-      "preferred-target" = "native";
-      repository = "https://github.com/totto2727-org/monorepo";
-      source = "src";
-      "supported-targets" = "native";
-    }
-  );
 in
 moonPlatform.buildMoonPackage {
-  inherit src moonModJson moonRegistryIndex;
+  inherit src moonRegistryIndex;
+  moonMod = ./moon.mod;
   moonFlags = [ "app/c-plugin/src" ];
   doCheck = false;
   meta.mainProgram = "c-plugin";

--- a/mbt/app/mdt/moon.mod
+++ b/mbt/app/mdt/moon.mod
@@ -23,4 +23,4 @@ keywords = [ "markdown", "translation", "opencode", "cli" ]
 
 description = "Native MoonBit CLI for translating Markdown with OpenCode"
 
-source = "./src"
+source = "src"

--- a/mbt/app/mdt/package.nix
+++ b/mbt/app/mdt/package.nix
@@ -12,6 +12,8 @@ let
       ./src
       ../../package/admiral/moon.mod
       ../../package/admiral/src
+      ../../package/lens/moon.mod
+      ../../package/lens/src
       ../../package/opencode-sdk/moon.mod
       ../../package/opencode-sdk/src
     ];
@@ -20,6 +22,7 @@ let
     members = [
       "./app/mdt",
       "./package/admiral",
+      "./package/lens",
       "./package/opencode-sdk",
     ]
   '';
@@ -28,25 +31,10 @@ let
     cp -R ${packageSrc}/. "$out/"
     cp ${moonWork} "$out/moon.work"
   '';
-  moonModJson = builtins.toFile "mdt-moon.mod.json" (
-    builtins.toJSON {
-      name = "totto2727/mdt";
-      version = "0.1.3";
-      deps = {
-        "moonbitlang/async" = "0.20.1";
-        "moonbitlang/x" = "0.4.38";
-      };
-      description = "Native MoonBit CLI for translating Markdown with OpenCode";
-      license = "MIT";
-      "preferred-target" = "native";
-      repository = "https://github.com/totto2727-org/monorepo";
-      source = "src";
-      "supported-targets" = "native";
-    }
-  );
 in
 moonPlatform.buildMoonPackage {
-  inherit src moonModJson moonRegistryIndex;
+  inherit src moonRegistryIndex;
+  moonMod = ./moon.mod;
   moonFlags = [ "app/mdt/src" ];
   doCheck = false;
   meta.mainProgram = "mdt";

--- a/mbt/app/wt/moon.mod
+++ b/mbt/app/wt/moon.mod
@@ -22,4 +22,4 @@ keywords = [ "git", "worktree", "github", "cli" ]
 
 description = "Native MoonBit Git worktree manager with PR awareness"
 
-source = "./src"
+source = "src"

--- a/mbt/app/wt/package.nix
+++ b/mbt/app/wt/package.nix
@@ -22,25 +22,10 @@ let
     cp -R ${packageSrc}/. "$out/"
     cp ${moonWork} "$out/moon.work"
   '';
-  moonModJson = builtins.toFile "wt-moon.mod.json" (
-    builtins.toJSON {
-      name = "totto2727/wt";
-      version = "0.1.0";
-      deps = {
-        "totto2727/admiral" = "0.5.0";
-        "moonbitlang/async" = "0.19.2";
-      };
-      description = "Native MoonBit Git worktree manager with PR awareness";
-      license = "MIT";
-      "preferred-target" = "native";
-      repository = "https://github.com/totto2727-org/monorepo";
-      source = "src";
-      "supported-targets" = "native";
-    }
-  );
 in
 moonPlatform.buildMoonPackage {
-  inherit src moonModJson moonRegistryIndex;
+  inherit src moonRegistryIndex;
+  moonMod = ./moon.mod;
   moonFlags = [ "app/wt/src" ];
   doCheck = false;
   meta.mainProgram = "wt";

--- a/mbt/flake.lock
+++ b/mbt/flake.lock
@@ -3,11 +3,11 @@
     "moon-registry": {
       "flake": false,
       "locked": {
-        "lastModified": 1784655133,
-        "narHash": "sha256-MPjHsc43liJKEPLrjQ/Jx7I3uA7sD0UYTPZYKnIvEQs=",
+        "lastModified": 1785640913,
+        "narHash": "sha256-dxO7mBcUrR31v4ONiCLObVwjUY4McoJI3/X452rDx4g=",
         "ref": "refs/heads/main",
-        "rev": "fec6443d5fdc1545a4aa6312587e20c37a43ea1e",
-        "revCount": 11133,
+        "rev": "ba095b24e2b972f430c4b5df42b4cf71d10ce58b",
+        "revCount": 11797,
         "type": "git",
         "url": "https://mooncakes.io/git/index"
       },
@@ -24,11 +24,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784541274,
-        "narHash": "sha256-jtOcz5r6V/7U89ySbicd+0SWD+LqlWrWP9Qd+GZRQuI=",
+        "lastModified": 1785646155,
+        "narHash": "sha256-YJ3h+lLqHj25vGq/xS9yVJ1ap03Avn9Fzm078lXQc1I=",
         "owner": "totto2727",
         "repo": "moonbit-overlay",
-        "rev": "bdae408fa509726dd819c962c4e712cc0d0380af",
+        "rev": "1424434f0ef134b99aaa71bd446d1bf0306dbe65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要

- Nixパッケージで生成した`moon.mod.json`を使用せず、各アプリケーションの`moon.mod`を直接参照するように変更
- MoonBitの`source`指定を`src`に統一
- `mdt`のLens依存関係とワークスペースメンバーを追加
- Moon registryとmoonbit-overlayのロックを更新

```mermaid
flowchart TD
    A[moon.mod] --> B[moonPlatform.buildMoonPackage]
    B --> C[moonMod = ./moon.mod]
    C --> D[MoonBit package build]
    E[moon registry lock update] --> D
```

## Testing

- Not run (not requested)