### PR TITLE
MoonBitライブラリの依存関係と公開バージョンを更新

### DIFF
--- a/mbt/app/bw/moon.mod
+++ b/mbt/app/bw/moon.mod
@@ -1,17 +1,17 @@
 name = "totto2727/bw"
 
-version = "0.2.0"
+version = "0.2.1"
 
 preferred_target = "native"
 
 supported_targets = "native"
 
 import {
-  "totto2727/admiral@0.6.0",
+  "totto2727/admiral@0.6.1",
   "totto2727/lens@0.4.0",
-  "moonbitlang/x@0.4.38",
-  "moonbitlang/async@0.19.2",
-  "gmlewis/base64@0.16.10",
+  "moonbitlang/x@0.4.47",
+  "moonbitlang/async@0.20.3",
+  "gmlewis/base64@0.16.11",
 }
 
 readme = "README.md"

--- a/mbt/app/c-plugin/moon.mod
+++ b/mbt/app/c-plugin/moon.mod
@@ -1,17 +1,17 @@
 name = "totto2727/c-plugin"
 
-version = "0.2.0"
+version = "0.2.1"
 
 preferred_target = "native"
 
 supported_targets = "native"
 
 import {
-  "totto2727/admiral@0.6.0",
+  "totto2727/admiral@0.6.1",
   "totto2727/lens@0.4.0",
-  "totto2727/target-file-discovery@0.2.0",
-  "moonbitlang/x@0.4.38",
-  "moonbitlang/async@0.19.2",
+  "totto2727/target-file-discovery@0.2.1",
+  "moonbitlang/x@0.4.47",
+  "moonbitlang/async@0.20.3",
 }
 
 readme = "README.md"

--- a/mbt/app/mdt/moon.mod
+++ b/mbt/app/mdt/moon.mod
@@ -1,16 +1,16 @@
 name = "totto2727/mdt"
 
-version = "0.1.5"
+version = "0.1.6"
 
 preferred_target = "native"
 
 supported_targets = "native"
 
 import {
-  "moonbitlang/async@0.20.1",
-  "moonbitlang/x@0.4.38",
-  "totto2727/admiral@0.6.0",
-  "totto2727/opencode-sdk@0.2.1",
+  "moonbitlang/async@0.20.3",
+  "moonbitlang/x@0.4.47",
+  "totto2727/admiral@0.6.1",
+  "totto2727/opencode-sdk@0.2.2",
 }
 
 readme = "README.md"

--- a/mbt/app/wt/moon.mod
+++ b/mbt/app/wt/moon.mod
@@ -1,15 +1,15 @@
 name = "totto2727/wt"
 
-version = "0.1.1"
+version = "0.1.2"
 
 preferred_target = "native"
 
 supported_targets = "native"
 
 import {
-  "totto2727/admiral@0.6.0",
+  "totto2727/admiral@0.6.1",
   "totto2727/lens@0.4.0",
-  "moonbitlang/async@0.19.2",
+  "moonbitlang/async@0.20.3",
 }
 
 readme = "README.md"

--- a/mbt/package/admiral/README.mbt.md
+++ b/mbt/package/admiral/README.mbt.md
@@ -20,8 +20,8 @@ Add to `moon.mod`:
 
 ```moonbit
 import {
-  "totto2727/admiral@0.6.0",
-  "moonbitlang/async@0.19.2",
+  "totto2727/admiral@0.6.1",
+  "moonbitlang/async@0.20.3",
 }
 
 preferred_target = "native"

--- a/mbt/package/admiral/moon.mod
+++ b/mbt/package/admiral/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/admiral"
 
-version = "0.6.0"
+version = "0.6.1"
 
 readme = "README.md"
 
@@ -13,7 +13,7 @@ keywords = [ "cli", "argparse", "moonbit" ]
 description = "Async-first declarative CLI builder for MoonBit, inspired by gunshi"
 
 import {
-  "moonbitlang/async@0.20.1",
+  "moonbitlang/async@0.20.3",
   "mizchi/tui@0.10.0",
   "totto2727/lens@0.4.0",
 }

--- a/mbt/package/agent-cli-sdk/moon.mod
+++ b/mbt/package/agent-cli-sdk/moon.mod
@@ -1,13 +1,13 @@
 name = "totto2727/agent-cli-sdk"
 
-version = "0.2.0"
+version = "0.2.1"
 
 preferred_target = "native"
 
 supported_targets = "native"
 
 import {
-  "moonbitlang/async@0.20.1",
+  "moonbitlang/async@0.20.3",
 }
 
 readme = "README.md"

--- a/mbt/package/codex-sdk/moon.mod
+++ b/mbt/package/codex-sdk/moon.mod
@@ -1,15 +1,15 @@
 name = "totto2727/codex-sdk"
 
-version = "0.1.1"
+version = "0.1.2"
 
 preferred_target = "native"
 
 supported_targets = "native"
 
 import {
-  "moonbitlang/x@0.4.38",
-  "moonbitlang/async@0.20.1",
-  "totto2727/agent-cli-sdk@0.2.0",
+  "moonbitlang/x@0.4.47",
+  "moonbitlang/async@0.20.3",
+  "totto2727/agent-cli-sdk@0.2.1",
   "totto2727/copy@0.2.0",
   "totto2727/lens@0.4.0",
 }

--- a/mbt/package/geo-mbt/moon.mod
+++ b/mbt/package/geo-mbt/moon.mod
@@ -1,9 +1,9 @@
 name = "totto2727/geo-mbt"
 
-version = "0.1.1"
+version = "0.1.2"
 
 import {
-  "moonbitlang/x@0.4.38",
+  "moonbitlang/x@0.4.47",
 }
 
 readme = "README.mbt.md"

--- a/mbt/package/moon-agent-graph/moon.mod
+++ b/mbt/package/moon-agent-graph/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/moon-agent-graph"
 
-version = "0.1.1"
+version = "0.1.2"
 
 readme = "README.md"
 
@@ -22,11 +22,11 @@ description = "Native asynchronous agent graph runtime with Mermaid visualizatio
 import {
   "DC-Z-lab/moonllm@0.1.0",
   "Yoorkin/any@0.2.1",
-  "moonbitlang/async@0.20.1",
-  "moonbitlang/x@0.4.38",
+  "moonbitlang/async@0.20.3",
+  "moonbitlang/x@0.4.47",
   "totto2727/any-collection@0.2.0",
-  "totto2727/codex-sdk@0.1.1",
-  "totto2727/opencode-sdk@0.2.1",
+  "totto2727/codex-sdk@0.1.2",
+  "totto2727/opencode-sdk@0.2.2",
 }
 
 preferred_target = "native"

--- a/mbt/package/opencode-sdk/README.mbt.md
+++ b/mbt/package/opencode-sdk/README.mbt.md
@@ -26,7 +26,7 @@ Add the package to a MoonBit project and import it with an alias:
 
 ```mbt
 import {
-  "totto2727/opencode-sdk@0.2.1",
+  "totto2727/opencode-sdk@0.2.2",
 }
 ```
 

--- a/mbt/package/opencode-sdk/moon.mod
+++ b/mbt/package/opencode-sdk/moon.mod
@@ -1,15 +1,15 @@
 name = "totto2727/opencode-sdk"
 
-version = "0.2.1"
+version = "0.2.2"
 
 preferred_target = "native"
 
 supported_targets = "native"
 
 import {
-  "moonbitlang/x@0.4.38",
-  "moonbitlang/async@0.20.1",
-  "totto2727/agent-cli-sdk@0.2.0",
+  "moonbitlang/x@0.4.47",
+  "moonbitlang/async@0.20.3",
+  "totto2727/agent-cli-sdk@0.2.1",
   "totto2727/copy@0.2.0",
   "totto2727/lens@0.4.0",
 }

--- a/mbt/package/opencode-server-sdk/moon.mod
+++ b/mbt/package/opencode-server-sdk/moon.mod
@@ -1,6 +1,6 @@
 name = "totto2727/opencode-server-sdk"
 
-version = "0.2.0"
+version = "0.2.1"
 
 readme = "README.md"
 
@@ -13,7 +13,7 @@ keywords = [ "opencode", "sdk", "server", "process" ]
 description = "Native MoonBit SDK for starting and managing an OpenCode server"
 
 import {
-  "moonbitlang/async@0.20.1",
+  "moonbitlang/async@0.20.3",
   "totto2727/lens@0.4.0",
 }
 

--- a/mbt/package/target-file-discovery/moon.mod
+++ b/mbt/package/target-file-discovery/moon.mod
@@ -1,14 +1,14 @@
 name = "totto2727/target-file-discovery"
 
-version = "0.2.0"
+version = "0.2.1"
 
 preferred_target = "native"
 
 supported_targets = "native"
 
 import {
-  "moonbitlang/x@0.4.38",
-  "moonbitlang/async@0.19.2",
+  "moonbitlang/x@0.4.47",
+  "moonbitlang/async@0.20.3",
 }
 
 readme = "README.md"


### PR DESCRIPTION
## 概要

MoonBitワークスペースで利用している外部依存を更新し、差分が生じた12モジュールのパッチバージョンと内部依存参照を同期しました。対象バージョンはすでにMooncakesへ公開済みです。

## 変更内容

- `moonbitlang/async`を`0.20.3`へ更新
- `moonbitlang/x`を現在のMoonBit v0.10.4で利用できる最新互換版`0.4.47`へ更新
- `gmlewis/base64`を`0.16.11`へ更新
- 変更対象12モジュールのパッチバージョンを更新
- `moon work sync`でワークスペース内依存バージョンを同期
- AdmiralとOpenCode SDKのREADMEに記載する導入バージョンを更新

`moonbitlang/x@0.4.48`は2026-08-03に導入された`guard!`構文を含み、このリポジトリで固定しているMoonBit v0.10.4ではコンパイルできないため、`0.4.47`に固定しています。

## 公開バージョン

- `totto2727/admiral@0.6.1`
- `totto2727/agent-cli-sdk@0.2.1`
- `totto2727/codex-sdk@0.1.2`
- `totto2727/geo-mbt@0.1.2`
- `totto2727/moon-agent-graph@0.1.2`
- `totto2727/opencode-sdk@0.2.2`
- `totto2727/opencode-server-sdk@0.2.1`
- `totto2727/target-file-discovery@0.2.1`
- `totto2727/bw@0.2.1`
- `totto2727/c-plugin@0.2.1`
- `totto2727/mdt@0.1.6`
- `totto2727/wt@0.1.2`

## 処理フロー

```mermaid
flowchart TD
  A["Mooncakesレジストリ索引を更新"] --> B["外部依存を最新互換版へ更新"]
  B --> C["変更モジュールのパッチ版を更新"]
  C --> D["moon work syncで内部依存を同期"]
  D --> E["check・build・testを実行"]
  E --> F["vp run -r publishで公開"]
```

## 検証

- `vp run --no-cache mbt:check`
- `vp run --no-cache mbt:build`
- `vp run --no-cache mbt:test`
  - wasm-gc: 579件成功
  - native: 371件成功
- `vp run -r publish`
  - 更新した12モジュールすべて`Server status: 200 OK`
  - Mooncakes APIで全公開バージョンを確認済み
