### PR TITLE
c-plugin v2の段階的デリバリー方針を定義

### DIFF
--- a/c-plugin-v2/README.ja.md
+++ b/c-plugin-v2/README.ja.md
@@ -1,0 +1,458 @@
+# c-plugin v2
+
+このディレクトリには、c-pluginをゼロから再実装するための設計契約を記録します。設計文書はリポジトリルートの`c-plugin-v2/`に維持し、段階的な実装はMoon module `totto2727/c-plugin-v2`として`mbt/app/c-plugin-v2`以下に配置します。
+
+## 共存時のID
+
+段階的な提供中はnative executableとNix attributeを一時的に`c-plugin-v2`とし、Admiralが表示するapplication名とhelp名は引き続き`c-plugin`とします。明示的に承認されたcutoverまではv1実装へ変更を加えません。両方が存在する間、同じロックスコープに対してv1とv2を実行してはならず、別のproject rootまたは仮のhomeを使用します。
+
+この共存layoutは一時的なcontrol-plane stateであり、第2のproduct IDではありません。現時点ではv1 lock migrationを実装しません。下記のlock version規則に従う将来の明示的なmigration milestoneは追加できますが、cutover時にmigrationをdecoderや通常command実行へ紛れ込ませてはいけません。
+
+## 目標
+
+- 現在のユーザー向け機能を維持しながら、c-pluginをMoonBitで再実装する。
+- 将来拡張可能なリソース名前空間を中心にコマンド体系を整理し、現在のMoonBit移植版より前に存在していた対話的な選択を復元する。
+- 型付きパス、厳格なロックファイルのデコード、ライブラリによるGit操作、決定論的なテストを最初から採用する。
+- プロジェクト単位とグローバルのインストールを分離し、`init`以外のすべての操作を冪等にする。
+
+機能的な等価性には、公開された`c-plugin skill`名前空間の維持を含めます。内部関数は再設計して構いません。
+
+## 技術スタック
+
+| 対象 | 方針 |
+| --- | --- |
+| 言語とターゲット | MoonBit、nativeターゲットのみ |
+| CLI解析 | `totto2727/admiral` |
+| 対話入力 | `mizchi/tui` |
+| Git | `mizchi/bit`モジュールをライブラリとして使用し、主に`mizchi/bit_lib`などのライブラリパッケージを利用する。`git`や`bit` CLIは起動しない |
+| パス | `moonbitlang/x/path.Path` |
+| ロック探索 | `totto2727/target-file-discovery` |
+| JSON | `totto2727/lens`と標準の`FromJson`、`ToJson`トレイト |
+| 非同期I/O | `moonbitlang/async` |
+| 単体テスト | テストごとの一時ルートを使用するMoonBitブラックボックス・ホワイトボックステスト |
+| E2Eテスト | `src/e2e/`以下のShell駆動Dockerテスト |
+
+すべての依存関係は、互換性を確認した正確なバージョンに固定します。最初の実装ゲートでは、Admiral、TUI、bit、Lens、target-file-discovery、async、`moonbitlang/x/path`を同時にimportする最小構成のnativeビルドを行います。未検証の依存関係の組み合わせでは実装を進めません。
+
+`mizchi/bit`は現在、自身を実験的実装と説明し、リポジトリ破損の可能性を警告しています。そのため、c-pluginではキャッシュしたcloneを破棄可能なデータとして扱い、依存バージョンを固定し、使用するclone、fetch、checkout、HEAD解決APIを正確にテストします。
+
+## コマンド体系
+
+スキル管理は引き続き`skill`名前空間に配置します。これにより、将来的に`hook`や`mcp`などのトップレベルリソース名前空間を追加できます。インストールコマンドと分離するため、作者向けのマーケットプレイス変換は`dev`以下に残します。
+
+```text
+c-plugin
+├── init
+├── skill
+│   ├── add
+│   ├── remove
+│   ├── sync
+│   ├── update
+│   └── target
+│       ├── add
+│       └── remove
+└── dev
+    └── marketplace
+        └── sync
+```
+
+末端コマンドの契約は次のとおりです。
+
+| コマンド | 契約 |
+| --- | --- |
+| `c-plugin init [-g]` | 空のロックファイルを排他的に作成する。すでに存在する場合は変更せず失敗する。 |
+| `c-plugin skill add [<owner/repo> | --local <./path>] [-g] [--kind <kind>] [--skill <plugin/skill>...]` | GitHubまたはローカルのマーケットプレイスを追加し、マーケットプレイス種別と有効化するスキルを選択し、GitHubの状態を固定し、ロックを書き込んでリンクを同期する。GitHubの位置引数と`--local`のどちらか一方だけを受け付ける。 |
+| `c-plugin skill remove [-g] [--skill <repo/plugin/skill>...]` | 選択したインストール済みスキルを削除する。最後のスキルを削除した後に、空になったプラグインエントリ、空になったリポジトリエントリ、破棄可能なGitキャッシュを削除する。 |
+| `c-plugin skill sync [-g | -r]` | Gitの固定状態を変更せず、ロックの状態から管理対象リンクを調整する。 |
+| `c-plugin skill update [-g | -r]` | GitHubリポジトリをfetchし、固定状態を進め、ロックを書き換えてリンクを同期する。ローカルリポジトリはfetchしない。 |
+| `c-plugin skill target add <path> [-g]` | 追加のスキルリンクルートを登録して同期する。解決後のパスが重複している場合は正常なno-opとする。 |
+| `c-plugin skill target remove [-g] [--target <path>...]` | 選択した追加ルートをロックの状態から削除し、そのルートからc-plugin管理下のリンクだけを削除する。 |
+| `c-plugin dev marketplace sync <claude|cursor|codex>` | 選択したマーケットプレイス種別を入力元として、他のマーケットプレイスmanifestと、存在するプラグインごとの`plugin.json`を再生成する。 |
+
+`-g`と`-r`は同時に指定できません。再帰モードは`sync`と`update`だけに適用します。
+
+### 対話入力と非対話入力
+
+stdinがTTYであり、明示的な選択オプションが省略されている場合、`mizchi/tui`が選択UIを提供します。
+
+- `skill add`は、対応する種別が複数存在するとき、マーケットプレイス種別の単一選択を表示する。
+- `skill add`は`plugin/skill`エントリの複数選択を表示し、すでに有効なスキルを事前選択する。
+- `skill remove`はインストール済みの`repository > plugin/skill`エントリの複数選択を表示する。
+- `skill target remove`は登録済みの追加ターゲットディレクトリの複数選択を表示する。
+
+stdinがTTYでない場合は、対応する`--kind`、繰り返し可能な`--skill`、または繰り返し可能な`--target`オプションを必須とします。非対話実行では、すべての項目を暗黙に選択したり、対話ユーザーが通常選択する既定値を暗黙に受け入れたりしません。
+
+キャンセルと空の選択は正常なno-opとし、ロックファイルを書き換えません。
+
+TUIは選択状態を扱うアダプターであり、コマンドのビジネスロジックには含めません。コマンドハンドラーは型付きの選択結果を受け取るため、単体テストでは実端末を操作せずに決定論的な選択を注入できます。
+
+## 機能等価性の基準
+
+次の機能を維持した時点で再実装完了とします。
+
+- `owner/repository`形式で記録するGitHubマーケットプレイスソースと、`./`から始まるローカルマーケットプレイスソース。
+- Claude、Cursor、Codexマーケットプレイスの検出と解析。
+- 検出されたすべてのスキルの暗黙インストールではなく、プラグインごとの明示的なスキル有効化。
+- GitHub commitの固定と、固定したcommitでの再現可能な同期。
+- リモートのデフォルトブランチへの更新と、それに続くロックとリンクの更新。
+- `.agents/skills`以下の主リンクと、0個以上の追加リンクターゲット。
+- 最も近い親のプロジェクトロック探索、home直下のグローバルロック探索、再帰的な子孫ロック探索。
+- `totto2727/target-file-discovery`による`.gitignore`を考慮した再帰探索。
+- 複数リポジトリ同期の耐障害性。1つのリポジトリが利用できない場合は報告してスキップし、独立した他のリポジトリの同期を妨げない。
+- 現在の動作と同じく、ロック順で最後のリポジトリエントリを採用する決定論的なスキル名重複解決。
+- Claude、Cursor、Codex形式間のマーケットプレイス変換。
+- 正規化された`./plugins/...`パスと`policy.installation = "INSTALLED_BY_DEFAULT"`を持つCodexのローカルsource object。
+- 入力元種別のプラグインに`plugin.json`が存在する場合、対象種別へコピーする。
+
+新しいロック形式はv1とは別にバージョン管理します。機能等価性には、不正なv1ドキュメントの受け入れや寛容なデコーダーの不具合の維持は含みません。
+
+現時点の実装では、ロックmigrationを明示的に対象外とします。c-plugin v2は自動migrationも`migrate`コマンドも提供せず、decoderが旧versionをv2として再解釈してはいけません。既存ロックが未対応versionを宣言している場合、そのロックを読み込むすべてのコマンドはロックを書き換えず、link、cache、ownership stateも変更せずに失敗します。`init`も既存ロックを置換せず、従来どおり拒否します。
+
+将来、明示的な承認を受けた独立マイルストーンとしてmigration経路を追加しても構いません。その場合はversion間の変換規則、atomicな永続化、書き込み成功後の同期、専用の単体テストとE2E coverageを持つ明示的な操作とし、通常のロックdecode内の寛容なfallbackとして追加してはいけません。最上位のlock versionを必須のまま維持することで、現時点ではmigrationを実装せずに将来の拡張点を残します。
+
+## スコープとパスの規則
+
+ロックファイル名は`c-plugin-lock.json`のまま維持します。
+
+| スコープ | ロックパス | 主な管理対象スキルルート |
+| --- | --- | --- |
+| プロジェクト | ユーザーのhomeを境界として探索した最も近い祖先の`<root>/c-plugin-lock.json` | `<root>/.agents/skills` |
+| グローバル（`-g`） | 厳密に`~/c-plugin-lock.json` | `~/.agents/skills` |
+
+グローバルロックファイルは意図的に`~/.agents/`以下へ配置しません。
+
+`init`は現在の作業ディレクトリをプロジェクトルートとして使用し、`-g`では注入されたhomeディレクトリを使用します。その他のスコープ付きコマンドはすべて、`totto2727/target-file-discovery`で既存のロックを探索し、別のルートを推測しません。
+
+再帰探索は、最も近いプロジェクトロックを含むディレクトリから開始し、そのロックと子孫のロックを含みます。グローバルモードでは再帰探索を行いません。
+
+キャッシュルートは既定で`~/.cache/c-plugin/repositories`とし、テストでは実行時境界から差し替えられるようにします。キャッシュの内容は正とせず、ロックファイルを正とします。
+
+### キャッシュIDとロックの分離
+
+リポジトリキャッシュは、それを所有するロックファイル単位でスコープを分離します。2つのプロジェクトロックが同じGitHubリポジトリを異なるcommitに固定する可能性があるため、owner/repositoryだけのキャッシュキーは禁止します。
+
+ロックパスを絶対`Path`へ正規化した後、キャッシュのスコープキーを次のように導出します。
+
+```text
+scope_key = lowercase_hex(sha256(utf8("lock\0" + normalized_absolute_lock_path)))
+cache_path = cache_root / scope_key / lowercase(owner) / lowercase(repository)
+```
+
+完全な64文字のSHA-256 digestを使用し、言語runtimeのhash値や短縮digestは使用しません。プロジェクトモードでは探索済みの絶対プロジェクトロックパスをhash入力とし、グローバルモードでは注入されたhomeディレクトリ以下の絶対`~/c-plugin-lock.json`パスをhash入力とします。
+
+各スコープディレクトリには、format versionとhash入力に使用した正確な正規化済み絶対ロックパスを記録する生成metadata、`c-plugin-cache-scope.json`を配置します。ディレクトリを再利用する前に、c-pluginはそのmetadataを厳格に検証しなければなりません。記録が存在しない場合や一致しない場合はディレクトリを共有せずエラーとするため、digestの衝突や手動でコピーされたcacheによって2つのロックスコープが暗黙に統合されることはありません。
+
+GitHubのownerとrepository componentは、それぞれのdomain constructorで検証し、スコープパスへ結合する前に小文字へcanonicalizeします。未解析の`owner/repository`入力を1つのパス文字列として追加してはいけません。GitHubは両方のroute componentで大文字と小文字を区別しないため、大小文字だけが異なる入力を同じIDへ変換することを意図しています。
+
+この規則により、次の動作となります。
+
+- 1つのロック内で同じリポジトリを参照する場合、1つのcacheと固定済みworking treeを共有する。
+- 異なるプロジェクトロックまたはグローバルロックは、同じリポジトリを参照しても異なるcacheを使用し、checkout、update、削除によって別のロックが生成したskillを変更しない。
+- cache変更はowner/repositoryだけではなく、スコープを含む完全なcache `Path`単位で直列化する。
+- あるロックから最後の参照を削除した場合、そのロックにスコープされたリポジトリcacheだけを削除してよい。
+- プロジェクトを移動すると正規化済みロックパスが変わるため、スコープキーも変わる。古いcacheは破棄可能な孤立dataとし、新しいスコープが暗黙に採用してはならない。
+
+### パスの型付け
+
+- CLI文字列、環境変数文字列、JSON文字列は、それらを所有する境界ですぐに`Path`へ変換する。
+- コマンド、アプリケーション、探索、ロック、ファイルシステム、キャッシュ、マーケットプレイス、シンボリックリンクのロジックでは`Path`を受け渡す。
+- MoonBit非同期ファイルシステム呼び出し、LensのJSON encoding、現在のbit APIなど、文字列を要求する末端のライブラリ呼び出しでのみ`Path`を`String`へ変換する。
+- GitHubリポジトリは制約のないパス風文字列ではなく、検証済みの`GitHubRepository { owner, name }`として表現する。
+- 相対ローカルマーケットプレイスパスとターゲットパスは、constructorが制約を保証する型付きドメイン値として保持する。
+- パスは比較前に正規化する。ユーザーが入力したパス表記を直接比較しない。
+
+`totto2727/target-file-discovery`は現在、文字列ベースのpublic関数を公開しています。その変換は1つの探索アダプターに閉じ込め、型なしパスをc-pluginの他の領域へ漏らしません。後からこのライブラリにPathベースAPIを追加しても構いませんが、別の探索実装を作るための必須条件とはしません。
+
+## Git方針
+
+- `mizchi/bit`モジュールを宣言し、そのライブラリパッケージを直接呼び出す。
+- Git操作に`moonbitlang/async/process`を使用せず、インストール済みの`git`や`bit`実行ファイルへフォールバックしない。
+- 1つの狭い`BitRepositoryStore`アダプターを通じて、HTTPS GitHub clone、fetch、デフォルトブランチ解決、固定commitのcheckout、HEAD object ID解決を提供する。
+- bitが現在要求する文字列パスはそのアダプター内部だけで扱い、c-plugin向けpublic APIは`Path`と型付きobject IDを受け渡す。
+- リポジトリは、上で定義した決定論的なロックスコープ付きキャッシュパスに保存する。
+- 同じキャッシュリポジトリを操作する変更は直列化する。独立した読み取り専用の解決は並行実行してよい。
+- ユーザーのソースリポジトリにworking tree変更を適用しない。すべてのGit変更は破棄可能なc-pluginキャッシュディレクトリだけで行う。
+
+## ファイルシステムと冪等性の方針
+
+`init`によるロック作成だけを排他的な作成操作とします。既存のロックファイルを上書きしてはいけません。
+
+その他の操作はすべて`mkdir -p`相当の規則に従います。
+
+- 期待する既存ディレクトリを受け入れる。
+- 既存のsource、skill、正規化済みtargetの再登録は、正常なno-opまたはmergeとする。
+- c-pluginが管理する既存ファイルとシンボリックリンクは、ロックに従って更新または削除してよい。
+- 出力先にある管理外ファイル、ディレクトリ、または管理外シンボリックリンクは変更せず、スキップしたことを報告する。
+- Syncでディレクトリ全体を消去せず、c-pluginの管理対象と判明しているリンクだけを削除する。
+- マーケットプレイス生成では、自身の対象manifestとコピー済み`plugin.json`を置換してよいが、既存ディレクトリの無関係なファイルは削除しない。
+
+### シンボリックリンクの所有state
+
+シンボリックリンク自体には、作成したprocessを識別できる信頼性のあるmetadataがありません。ロックは共有可能な望ましい状態を記録するため、他者がロックを変更した後に古くなったリンクを、ロックだけから識別することはできません。そのため、c-pluginは生成したリンクについて、ロックとは別にmachine-localな所有stateを維持します。
+
+| スコープ | 所有stateのパス |
+| --- | --- |
+| プロジェクト | `<root>/.agents/c-plugin-state.json` |
+| グローバル（`-g`） | `~/.agents/c-plugin-state.json` |
+
+所有stateは生成されたruntime stateであり、共有設定でも、望ましい状態を表す第2のsource of truthでもありません。各entryには、絶対link path、シンボリックリンクへ書き込んだliteral target、正規化済みresolved target、source repository、plugin、skill identityを記録します。後からロックから削除されたtarget root内のリンクも維持します。
+
+`sync`は望ましいロックと以前の所有stateを次のように調整します。
+
+1. ロックと所有stateの両方を読み込み、厳格に検証する。
+2. ロックから望ましいリンクを計算し、`以前の所有link - 望ましいlink`から古いリンクを計算する。
+3. 古いpathが現在もシンボリックリンクであり、そのresolved targetが記録済みtargetと一致する場合だけ削除する。
+4. pathがfile、directory、または別のsymlinkへ置き換えられている場合は変更せず、所有権を失ったことを報告し、次の所有stateから除外する。
+5. 事前に存在する未記録のsymlinkは、現在のresolved targetが望ましいtargetと一致していても自動的に採用しない。
+6. 不足している望ましいリンクを調整した後、c-pluginが引き続き検証可能な形で所有するリンクから所有stateを構築し、atomicに書き込む。
+
+このstateは外部からのロック変更後も残るため、後から`c-plugin skill sync`を実行すると、削除されたskillやtarget登録に対応するリンクを削除できます。所有権はロックごとに分離し、recursive syncで別のロックが所有するリンクを削除してはいけません。
+
+安全規則は次のとおりです。
+
+- 所有stateが存在しない、または壊れている場合、既存リンクの削除を無効にする。衝突しない不足リンクを作成して新しいstateを開始してよいが、scanによる所有権の推測や自動採用を行わない。
+- 所有stateから読み込んだすべてのpathは、filesystemを変更する前に、記録済みmanaged rootに含まれることを検証する。
+- 現在のpublic `moonbitlang/async/fs` APIはsymlinkを考慮する`kind`と`realpath`を公開していますが、literalな`readlink`値を公開していないため、壊れたsymlinkのtargetを検証できない。そのようなリンクは変更せず報告する。壊れたリンクのcleanupが必要になった場合は、後から小さな`readlink` filesystem adapterを追加してよい。
+- 所有stateの書き込みには同じディレクトリの一時ファイルとatomic renameを使用する。所有stateの書き込みによって`sync`を再帰的に起動しない。`sync`を起動するのはロック変更だけとする。
+- 破棄可能なGit cacheは、古い管理対象リンクを調整した後に削除し、リンク削除時にtargetを検証できる状態を維持する。
+
+### ロック変更の不変条件
+
+既存ロックファイルの変更が成功した場合、コマンドが終了する前に、永続化したロックの値と完全に同じ値を使用して通常の`sync`調整を必ず実行します。この規則はrepository、plugin、enabled skill、target、marketplace kind、commit pin、および将来追加するresourceの変更に適用します。
+
+- `init`は既存ロックの更新ではなく新しい空ロックを作成するため、唯一の例外とする。
+- キャンセルまたは意味的なno-opとなるコマンドはロックを書き込まず、`sync`も不要とする。
+- コマンドworkflowは1つの`persist_and_sync` application boundaryを使用し、lock writerを直接呼び出して調整せずに終了してはならない。
+- 永続化が成功した後に`sync`が失敗した場合、コマンドは非0 statusを返し、`c-plugin skill sync`の再実行によって永続化済み状態を調整できることを報告する。
+- 再帰操作では、変更する各ロックにこの不変条件を個別に適用する。
+
+ロック書き込みには同じディレクトリの一時ファイルと、その後のatomic renameを使用します。メモリ上の候補は永続化前に完全に検証します。ロック変更は次の順序で行います。
+
+1. 完全な候補状態を解決して検証する。
+2. ロックをatomicに書き込む。
+3. 管理対象リンクと破棄可能なキャッシュ状態を調整する。
+
+手順2より前の失敗では以前の状態を維持します。手順2より後の失敗は`sync`の再実行で復旧可能にします。
+
+## ロックファイルモデル
+
+v2ロックは厳格に扱い、データを持つEnum variantには最上位のdiscriminatorを使用します。
+
+```json
+{
+  "version": 2,
+  "targets": ["~/.claude/skills"],
+  "repositories": [
+    {
+      "type": "github",
+      "repository": "totto2727-org/monorepo",
+      "marketplaceKind": "claude",
+      "commit": "0123456789abcdef",
+      "plugins": [
+        {
+          "name": "totto2727-coding",
+          "path": "plugins/totto2727-coding",
+          "enabledSkills": ["c-plugin"]
+        }
+      ]
+    },
+    {
+      "type": "local",
+      "path": "./",
+      "marketplaceKind": "codex",
+      "plugins": []
+    }
+  ]
+}
+```
+
+JSONの規則は次のとおりです。
+
+- すべてのロックフィールドをLensで定義する。
+- Lensで選択した値は、Lensから導出した`JsonPath`を渡して標準の`FromJson`でデコードする。
+- 標準の`ToJson`、Lensの`JsonBuilder`、`set_or_abort`でエンコードする。
+- `LockRepository`のデコードでは、最上位の`type`を一度読み取ってから、完全な`github`または`local` payload decoderへ委譲する。
+- `LockRepository`のエンコードでは、Enumを一度だけmatchし、variant object全体を出力する。
+- `commit`、`repository`、`path`の有無からvariantを推測せず、propertyごとに個別の分岐を行わない。
+- `MarketplaceKind`のようなscalar closed enumは、厳格な文字列表現を使用してよい。
+- 必須フィールドの欠落、未知のEnum値、不正な型、不正なパス、無効なリポジトリ名、identityの重複、未対応バージョンはエラーとする。
+- 壊れたJSONを空のロックとして扱ったり、不正なリポジトリエントリを暗黙に除外したり、不正な値を寛容な既定値へ置き換えたりしない。
+- 決定論的な出力と重複解決のため、repository、plugin、skill、targetの順序を維持する。
+
+ロックcodecには、canonical encodingをデコードすると同じドメイン値へ戻るという1つのround-trip propertyを持たせます。整形出力は2スペースindentと末尾の改行を使用します。
+
+## 内部構造
+
+実装は小さく保ち、大規模なframeworkではなく明示的な境界アダプターを使用します。
+
+```text
+src/
+├── cli/            Admiral command definitions and argv-to-domain parsing
+├── interaction/    mizchi/tui selection views and pure selection state
+├── command/        Add, remove, sync, update, target, init, and dev workflows
+├── domain/         Lock, repository, marketplace, skill, target, and validated identifier types
+├── adapter/        Lens lock and ownership-state stores, target discovery, bit Git, async filesystem, and symlinks
+├── e2e/            Dockerfile, one shell test per leaf command, and an explicit runner
+└── main/           Executable entry point
+```
+
+直接的な関数と、注入が必要な箇所の小さなcallback recordを使用します。テストで利用する実際の外部境界を置き換えない限り、service、repository、trait layerを作りません。
+
+## 単体テスト方針
+
+単体テストは必須とし、通常のMoonBitテストコマンドで実行します。
+
+- テストごとに新しい一時ルートを作成し、テスト後に削除する。
+- 仮のhome、working directory、lock、`.agents`、cache、marketplace、target directoryをすべて一時ルート以下に置く。
+- 実行時パスを注入し、テストから実ユーザーのhome、working tree、cache、global lock、global skill targetを読み取らない。
+- 仮のhomeを使用して`-g`をテストする。分離できないプラットフォーム固有のcaseだけ省略できるが、その理由を該当テストsuiteの近くに記録する。
+- 単体テストでbitを使用する場合は、一時ルート以下の破棄可能なリポジトリだけを操作する。
+- lockのround trip、厳格な失敗、最上位Enum dispatch、canonical ordering、JSON error pathをテストする。
+- 未対応のlock versionが、ロックの正確なbytesを維持し、link、cache、ownership stateを変更しないことをテストする。
+- Pathの正規化、project/global/recursive discovery、local sourceの制約、targetの重複排除、ロックスコープキーの導出、スコープmetadata不一致の拒否、同じリポジトリを異なるcommitに固定する2つのロック間のcache分離をテストする。
+- 純粋なTUI selection stateをテストし、command testにはscripted selectionを注入する。
+- 冪等なコマンド再実行、管理外パスとの衝突、管理対象リンクの置換、skill重複時の優先順位、一部リポジトリの失敗、永続化前の状態維持をテストする。
+- 既存ロックを変更するすべての経路が永続化した候補を`sync`へ渡し、`init`、キャンセル、意味的なno-opでは不要な調整を実行しないことをテストする。
+- 外部からのロック変更、削除済みtarget root、置換済みlink、欠落または破損したstate、壊れたsymlink、recursive sync対象ロック間の分離について、所有stateによるcleanupをテストする。
+- テストファイル名は、対象とする実装ファイル名に合わせる。
+
+## E2Eテスト方針
+
+E2Eテストは必須とし、`src/e2e/`以下へ配置し、`vp test`と`moon test`のどちらからも除外します。
+
+```text
+src/e2e/
+├── Dockerfile
+├── run.sh
+├── init.sh
+├── add.sh
+├── remove.sh
+├── sync.sh
+├── update.sh
+├── target_add.sh
+├── target_remove.sh
+└── dev_marketplace_sync.sh
+```
+
+`src/e2e/`には`moon.pkg`を配置せず、E2EファイルにMoonBitのテストsuffixを使用しません。E2Eは`src/e2e/run.sh`または明示的に命名したCI taskからのみ実行します。
+
+runnerの契約は次のとおりです。
+
+1. リポジトリルートからDocker imageを1つビルドする。
+2. image内で`moon install`を1回実行し、実際のnative c-plugin executableを1回だけビルドする。
+3. テスト対象の動作を迂回しない範囲で、再利用可能なJSONとrepository fixtureをimage内に用意する。
+4. そのimageから末端コマンドのテストごとに個別の`docker run --rm` containerを実行する。
+5. コマンドテスト内でexecutableを再ビルドしない。
+
+すべてのテストcontainerは、分離された一時`HOME`、working directory、cache root、target directoryを使用します。したがって、global modeのcaseがhost userへ影響することはありません。
+
+通常のE2E coverageで使用するGitHub marketplace sourceは`totto2727-org/monorepo`自身とします。少なくとも`add`と`update`は実際のbit-backed GitHub pathを実行します。他のコマンドテストは、テスト契約で許可されているとおり、事前構築したcanonical lock JSONと再利用可能なcached repository fixtureから開始しても構いません。
+
+各末端コマンドファイルは少なくとも1つの正常系を扱い、そのコマンドに関連するfilesystem state、lock JSON、command output、exit statusをassertします。`sync.sh`では、生成済みのロックを外部から編集し、古くなった所有linkが削除されることと、置換された管理外pathが維持されることを検証します。`update.sh`では、同じリポジトリを異なるcommitに固定した2つのプロジェクトロックを使用し、一方のロックをupdateしても他方のロックのcacheとlinkが変化しないことを検証します。対話状態は主に単体テストで検証し、Docker実行を決定論的にするため、E2Eでは明示的な非対話selection optionを使用します。
+
+## 段階的な提供方針
+
+c-plugin v2は一度に全面的に書き換えず、独立してレビュー可能なマイルストーンの連続として実装します。各マイルストーンでは、利用可能な1つの垂直スライスを追加し、同じ変更内にテストを含め、次のマイルストーンへ進む前に報告して停止します。
+
+Milestone 0は完了済みの本設計契約です。Milestone 1から7では、次の安定した原子的単位IDを使用します。同じwave内のcomma区切りだけを並行化候補とし、arrowは厳密な順序制約とします。原子的単位`M1`はMilestone 3に属し、Milestone 1のparent issueとは別です。
+
+| マイルストーン | 原子的な単位 | 依存関係と並行wave |
+| --- | --- | --- |
+| 1. Bootstrap | `B0` v1共存identity/layout契約、`B1` native dependency compatibilityと正確な`mizchi/bit` APIを証明してからCLI skeleton・help・versionを作成、`B2` `c-plugin-v2` Nix packageを追加 | `B0 -> B1 -> B2` |
+| 2. 状態基盤 | `F0` runtime path、`F1` domain/lock model、`F2` lock codec、`F3` ownership codec、`F4` atomic store、`F5` cache scope、`F6` discovery、`F7` runtime composition、`C-init` init、`E0` Docker/init E2E | `F0,F1 -> F2,F3,F5,F6 -> F4,F7 -> C-init -> E0` |
+| 3. ローカルライフサイクル | `M0` marketplace解析、`M1` local/skill解決、`R1` reconciliation、`C-sync`、`A1` `persist_and_sync`、`C-sync-r`、`C-add-local`、`C-remove`、`C-target-add`、`C-target-remove` | `M0,M1 -> R1 -> C-sync -> A1,C-sync-r -> C-add-local,C-target-add -> C-remove,C-target-remove` |
+| 4. GitHubライフサイクル | `G0` freeze済みbit contract/adapterの前提条件、`G1` clone/checkout/HEAD、`G2` fetch/default branch、`G-add`、`G-update`、`G-update-r`、`G-cleanup` | `G0 -> G1 -> G2 -> G-add,G-cleanup -> G-update -> G-update-r` |
+| 5. 対話入力 | `I1` selection state/TUI adapter、`I2` TTY方針、`I-add-kind`、`I-add-skill`、`I-remove`、`I-target-remove` | `I1 -> I2 -> I-add-kind,I-add-skill,I-remove,I-target-remove` |
+| 6. マーケットプレイス作者向け機能 | `D0` 共通read model、`D1` format変換、`D2` 決定論的write、`C-dev-sync` | `D0 -> D1 -> D2 -> C-dev-sync` |
+| 7. 最終等価性とcutover | `P1` 完全parity matrix、`P2` 文書/parity audit、`P3` cutover | `P1 -> P2 -> 明示的なcutover承認 -> P3` |
+
+### 単位ごとの検証契約
+
+各原子的な単位では、動作とテストを同じ変更に含めます。`B0`では文書化したv1/v2のpathとidentity、v1が未変更であること、両versionが同じlock scopeを共有しないことを検証します。`B1`では固定した全dependencyと正確な`mizchi/bit` APIを使用するnative buildを証明してから、対象を絞ったcheck・format・parser test・native buildを実行し、実際の`--help`/`--version`とAdmiral名`c-plugin`を確認します。`B2`では`c-plugin-v2` Nix packageをbuild/evaluateし、そのexecutableが動作してv1 packageが未変更であることを検証します。`F0`と`F1`ではconstructor・normalization・拒否・仮home、`F2`ではcanonical round trip・JSON path・strict failure・未対応versionのbyte維持・最上位dispatch、`F3`では厳格なownership-state round trip、`F4`ではexclusive create・temporary-sibling rename・永続化前後の失敗、`F5`では完全SHA-256 vector・metadata不一致・canonicalization・lock移動・2ロックcache分離、`F6`ではnearest project・exact global・ignore/recursive descendant・home境界・`-g`/`-r`、`F7`では全runtime boundaryの注入と実ユーザーpathの非使用をテストします。`C-init`ではproject/global正常系・既存fileのbyte維持・不正scope・繰り返しをテストし、`E0`ではimage/executableを1回だけbuildして、分離したproject/global initのstatus・output・lock JSON・host stateをassertします。
+
+`M0`と`M1`ではClaude/Cursor/Codexとlocal fixtureを使い、明示的なkind/skill選択・重複ID・ordering・不正manifest・正規化pathをテストします。`R1`では不足・古い・管理外・置換済み・壊れたlink、欠落/破損ownership state、優先順位、削除target、一部失敗、冪等性、ロック間分離を網羅します。`C-sync`と`C-sync-r`ではunit flowとclean-container E2Eを追加し、外部編集したlockとignore対象のrecursive descendantも検証します。`A1`では成功した全mutationが永続化済みcandidateと同じ値をsyncし、cancel/no-opはwriteもsyncも行わず、write後のsync失敗から復旧できることを証明します。`C-add-local`、`C-remove`、`C-target-add`、`C-target-remove`は、それぞれunitと独立したclean-container E2Eで、該当するstatus/output、canonical lock、link/state、繰り返しまたは選択、cleanup、管理外path維持をassertします。
+
+`G0`では`B1`で証明済みの正確なAPIを使用し、bit adapter contractをfreezeして、その型付きboundaryと注入したfailure behaviorをテストします。Dependency/API compatibilityの証明は繰り返しません。`G1`と`G2`ではscoped serialization、pin、fetch/default branch、一部失敗、2ロック分離をテストします。`G-add`では実際のbit-backed `totto2727-org/monorepo` unit/E2Eでlock・cache・link・output・statusをassertします。`G-update`と`G-update-r`ではpin更新、local source非fetch、recursive/failure分離、永続化済み状態のsync、兄弟lock/cache/link不変のunit/E2Eを追加します。`G-cleanup`ではlink調整後に所有lockの最終参照だけがcacheを削除することを証明します。
+
+`I1`と`I2`ではchoose・preselection・cancel・empty selection・TTY検出・必須非対話optionをテストします。`I-add-kind`、`I-add-skill`、`I-remove`、`I-target-remove`ではprompt-to-domain mappingを個別にテストして実TTYを手動観察し、非TTY regressionで暗黙defaultと全選択を禁止します。`D0`と`D1`では全format、正規化済みCodex local source、installation policy、不正input、変換、orderingをfixture testします。`D2`では一時root上で所有outputの置換と無関係fileの維持をテストします。`C-dev-sync`ではsource kindごとのunitとclean-container E2Eで、生成/copy/維持file・output・statusをassertします。`P1`では全対象check/format/build/unit testと分離Docker scope横断matrixを実行し、`P2`ではexecutableの証拠に対して全受け入れ条件を監査して両文書を同時更新します。明示承認後だけ`P3`でrollbackを維持しながらexecutable/Nix entryを切り替え、cutover surfaceで`P1`を再実行し、v1/v2が同じlock scopeを共有しなかったことを証明します。Lock migrationは含めません。
+
+### Linearとnative stackのcontrol plane
+
+- 1つのumbrella Linear issueとMilestone 1から7の7つのparentを使用し、各milestone parentを前のmilestoneによって順次`blockedBy`する。
+- Activeな原子的単位ごとにchildを厳密に1つ作る。将来のatomic issueを先に作らず、前のmilestoneの承認後、対象milestone開始直前にjust-in-timeで展開する。
+- 1 atomic unitを1 commit、1 native stack layer、1 PRに対応させる。Branch名は`codex/cpv2-m<N>-<unit>-<slug>`とし、base-to-tip順を維持する。
+- Native GitHub stacked PR submissionをhard gateとする。Submission直前にversion `2026-03-10`のREST APIとinstalled `gh` extension listを再確認する。現在観測済みの`404`はsubmissionをblockする。
+- 通常のdependent PR chainへ暗黙にfallbackしたり、それをnative stackと呼んだりしない。`gh-stack`を暗黙にinstallしない。対応後は下記の公式`gh stack` commandだけを使用する。
+- Team modeは、上表のcomma区切りの並行waveで共有contractをfreezeした後だけ、workerごとに分離worktreeを使用して実行できる。Arrowは順次のまま維持する。
+
+### マイルストーンの規則
+
+- 現在のマイルストーンが未完了またはユーザーレビュー待ちの間は、後続マイルストーンを開始しない。
+- 各マイルストーンの完了後に停止し、次のマイルストーンを実装する前に明示的な承認を待つ。
+- 各マイルストーンを1つの一貫したレビュー可能な変更単位に保つ。将来のコマンドstub、未使用のabstraction、推測的なcompatibility code、無関係なcleanupを前のマイルストーンへ持ち込まない。
+- 保護対象のproduction behaviorと同じ変更内で単体テストを追加する。テストを最終マイルストーンへ先送りしない。
+- Milestone 2でDocker harnessを追加し、末端コマンドが最初に利用可能になった時点でE2Eファイルを追加する。Milestone 7では、すべてのE2Eテストを一度に作成するのではなく、完成したmatrixを実行して監査する。
+- 各マイルストーンで、それ以前に提供したすべてのマイルストーンをgreenに保つ。
+- 依存関係またはupstream APIの非互換は、現在のマイルストーンだけをblockする。workaroundを選択する前に証拠を記録し、この設計を修正する。
+- 中間コマンドが利用可能でも、Milestone 7を通過するまではc-plugin全体の機能等価性を主張しない。
+- `P2`後に停止する。`P1`と`P2`はcutover承認を意味せず、明示的なユーザー承認後だけ`P3`を開始する。
+
+### マイルストーンの完了ゲート
+
+マイルストーンの対象範囲について、次のすべてを満たした場合だけ完了とします。
+
+1. 文書化した動作を、将来向けplaceholderなしで実装している。
+2. 変更したMoonBit packageが、対象を絞ったcheck、format、build、unit test commandを通過している。
+3. その時点までに追加したすべての末端コマンドが、clean containerでE2E正常系を通過している。
+4. マイルストーンで追加したユーザー向けcommand surfaceを通じて、実際のexecutableを操作している。
+5. マイルストーン報告を作成し、完了した動作と先送りした動作を明確に分離している。
+
+### マイルストーン報告形式
+
+各マイルストーンの引き渡しでは次を報告します。
+
+- マイルストーン番号と結果。
+- 新たに利用可能になったユーザー向け動作。
+- 追加または変更したファイルとarchitecture boundary。
+- 実行した単体テスト、build、E2Eの正確なコマンドと結果。
+- ビルド済みexecutableに対して行った手動CLI確認。
+- 既知の制限と意図的に先送りしたコマンド。
+- 発見した依存関係またはupstreamのrisk。
+- 次のマイルストーンで提案する対象範囲。
+
+報告では、マイルストーンの境界で作業を停止したことを明記します。先送りした動作を部分的に実装済みと表現したり、自動的に次のマイルストーンへ進んだりしません。
+
+## 受け入れ条件
+
+- コマンド体系が`c-plugin skill`を公開スキル管理名前空間として維持し、文書化したすべての末端コマンドを生成済みhelpとversion outputとともに公開する。
+- Project、recursive、`-g`の各scopeが文書どおりに解決される。
+- Global lockは`~/c-plugin-lock.json`であり、global linkは`~/.agents/skills`以下のままである。
+- 明示的な文字列境界を除き、内部のpath valueに`Path`を使用している。
+- リポジトリcacheは、正規化済みの絶対所有ロックパスから導出した完全なSHA-256キーで分離し、スコープmetadataによって衝突やロック間の暗黙の再利用を防止する。
+- Git subprocessを一切起動せず、clone、fetch、checkout、HEAD解決に`mizchi/bit`ライブラリを使用している。
+- Lock JSONが厳格でLens-backedかつcanonicalであり、`FromJson`と`ToJson`を通じてround tripする。
+- 未対応のlock versionは変更を行わず失敗し、自動migrationとmigrationコマンドは現時点の実装対象に含めない。
+- データを持つEnumが最上位の`type`フィールドで一度だけdispatchする。
+- 既存directoryと管理対象outputを冪等に扱い、管理外pathを上書きまたは削除しない。
+- Machine-localな所有stateにより、外部からのロック変更後に古くなったc-plugin linkを`sync`で削除でき、置換済みまたは未所有のpathは削除しない。
+- 既存ロックの変更が成功した場合、終了前に永続化した値と完全に同じ値を使用して必ず`sync`を実行する。
+- 復元したすべての対話selectionが実TTYで動作し、対応する非対話optionがすべて決定論的に動作する。
+- すべての状態を一時directory以下へ分離した単体テストが通過する。
+- Docker E2E imageを1回だけビルドし、各末端テストを破棄可能なcontainerで実行し、すべての正常系が通過する。
+
+## 一次資料
+
+- MoonBit toolchainと`moon install`: https://docs.moonbitlang.com/en/latest/toolchain/moon/commands.html
+- `moonbitlang/x/path.Path` public API: https://github.com/moonbitlang/x/blob/main/path/pkg.generated.mbti
+- Admiral: https://github.com/totto2727/admiral
+- mizchi/tui: https://github.com/mizchi/tui.mbt
+- mizchi/bit: https://github.com/bit-vcs/bit
+- GitHub REST repository path parameter: https://docs.github.com/en/rest/repos/contents
+- NIST Secure Hash Standard（FIPS 180-4）: https://csrc.nist.gov/pubs/fips/180-4/upd1/final
+- MoonBit async filesystem API: https://github.com/moonbitlang/async/blob/main/src/fs/pkg.generated.mbti
+- Lens: https://github.com/totto2727-org/monorepo/tree/main/mbt/package/lens
+- target-file-discovery: https://github.com/totto2727-org/monorepo/tree/main/mbt/package/target-file-discovery
+- GitHub stacked pull request public preview発表: https://github.blog/changelog/2026-07-30-stacked-pull-requests-are-now-in-public-preview/
+- GitHub stacked pull request概要: https://docs.github.com/en/pull-requests/get-started/about-stacked-prs
+- 公式stacked PR CLI command: https://docs.github.com/en/pull-requests/reference/stacked-prs-cli-commands
+- GitHub REST pull-request stacks API（`2026-03-10`）: https://docs.github.com/en/rest/pulls/stacks?apiVersion=2026-03-10

--- a/c-plugin-v2/README.ja.md
+++ b/c-plugin-v2/README.ja.md
@@ -19,18 +19,18 @@
 
 ## 技術スタック
 
-| 対象 | 方針 |
-| --- | --- |
-| 言語とターゲット | MoonBit、nativeターゲットのみ |
-| CLI解析 | `totto2727/admiral` |
-| 対話入力 | `mizchi/tui` |
-| Git | `mizchi/bit`モジュールをライブラリとして使用し、主に`mizchi/bit_lib`などのライブラリパッケージを利用する。`git`や`bit` CLIは起動しない |
-| パス | `moonbitlang/x/path.Path` |
-| ロック探索 | `totto2727/target-file-discovery` |
-| JSON | `totto2727/lens`と標準の`FromJson`、`ToJson`トレイト |
-| 非同期I/O | `moonbitlang/async` |
-| 単体テスト | テストごとの一時ルートを使用するMoonBitブラックボックス・ホワイトボックステスト |
-| E2Eテスト | `src/e2e/`以下のShell駆動Dockerテスト |
+| 対象             | 方針                                                                                                                                   |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 言語とターゲット | MoonBit、nativeターゲットのみ                                                                                                          |
+| CLI解析          | `totto2727/admiral`                                                                                                                    |
+| 対話入力         | `mizchi/tui`                                                                                                                           |
+| Git              | `mizchi/bit`モジュールをライブラリとして使用し、主に`mizchi/bit_lib`などのライブラリパッケージを利用する。`git`や`bit` CLIは起動しない |
+| パス             | `moonbitlang/x/path.Path`                                                                                                              |
+| ロック探索       | `totto2727/target-file-discovery`                                                                                                      |
+| JSON             | `totto2727/lens`と標準の`FromJson`、`ToJson`トレイト                                                                                   |
+| 非同期I/O        | `moonbitlang/async`                                                                                                                    |
+| 単体テスト       | テストごとの一時ルートを使用するMoonBitブラックボックス・ホワイトボックステスト                                                        |
+| E2Eテスト        | `src/e2e/`以下のShell駆動Dockerテスト                                                                                                  |
 
 すべての依存関係は、互換性を確認した正確なバージョンに固定します。最初の実装ゲートでは、Admiral、TUI、bit、Lens、target-file-discovery、async、`moonbitlang/x/path`を同時にimportする最小構成のnativeビルドを行います。未検証の依存関係の組み合わせでは実装を進めません。
 
@@ -58,16 +58,16 @@ c-plugin
 
 末端コマンドの契約は次のとおりです。
 
-| コマンド | 契約 |
-| --- | --- |
-| `c-plugin init [-g]` | 空のロックファイルを排他的に作成する。すでに存在する場合は変更せず失敗する。 |
-| `c-plugin skill add [<owner/repo> | --local <./path>] [-g] [--kind <kind>] [--skill <plugin/skill>...]` | GitHubまたはローカルのマーケットプレイスを追加し、マーケットプレイス種別と有効化するスキルを選択し、GitHubの状態を固定し、ロックを書き込んでリンクを同期する。GitHubの位置引数と`--local`のどちらか一方だけを受け付ける。 |
-| `c-plugin skill remove [-g] [--skill <repo/plugin/skill>...]` | 選択したインストール済みスキルを削除する。最後のスキルを削除した後に、空になったプラグインエントリ、空になったリポジトリエントリ、破棄可能なGitキャッシュを削除する。 |
-| `c-plugin skill sync [-g | -r]` | Gitの固定状態を変更せず、ロックの状態から管理対象リンクを調整する。 |
-| `c-plugin skill update [-g | -r]` | GitHubリポジトリをfetchし、固定状態を進め、ロックを書き換えてリンクを同期する。ローカルリポジトリはfetchしない。 |
-| `c-plugin skill target add <path> [-g]` | 追加のスキルリンクルートを登録して同期する。解決後のパスが重複している場合は正常なno-opとする。 |
-| `c-plugin skill target remove [-g] [--target <path>...]` | 選択した追加ルートをロックの状態から削除し、そのルートからc-plugin管理下のリンクだけを削除する。 |
-| `c-plugin dev marketplace sync <claude|cursor|codex>` | 選択したマーケットプレイス種別を入力元として、他のマーケットプレイスmanifestと、存在するプラグインごとの`plugin.json`を再生成する。 |
+| コマンド                                                                                                 | 契約                                                                                                                                                                                                                      |
+| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `c-plugin init [-g]`                                                                                     | 空のロックファイルを排他的に作成する。すでに存在する場合は変更せず失敗する。                                                                                                                                              |
+| `c-plugin skill add [<owner/repo> \| --local <./path>] [-g] [--kind <kind>] [--skill <plugin/skill>...]` | GitHubまたはローカルのマーケットプレイスを追加し、マーケットプレイス種別と有効化するスキルを選択し、GitHubの状態を固定し、ロックを書き込んでリンクを同期する。GitHubの位置引数と`--local`のどちらか一方だけを受け付ける。 |
+| `c-plugin skill remove [-g] [--skill <repo/plugin/skill>...]`                                            | 選択したインストール済みスキルを削除する。最後のスキルを削除した後に、空になったプラグインエントリ、空になったリポジトリエントリ、破棄可能なGitキャッシュを削除する。                                                     |
+| `c-plugin skill sync [-g \| -r]`                                                                         | Gitの固定状態を変更せず、ロックの状態から管理対象リンクを調整する。                                                                                                                                                       |
+| `c-plugin skill update [-g \| -r]`                                                                       | GitHubリポジトリをfetchし、固定状態を進め、ロックを書き換えてリンクを同期する。ローカルリポジトリはfetchしない。                                                                                                          |
+| `c-plugin skill target add <path> [-g]`                                                                  | 追加のスキルリンクルートを登録して同期する。解決後のパスが重複している場合は正常なno-opとする。                                                                                                                           |
+| `c-plugin skill target remove [-g] [--target <path>...]`                                                 | 選択した追加ルートをロックの状態から削除し、そのルートからc-plugin管理下のリンクだけを削除する。                                                                                                                          |
+| `c-plugin dev marketplace sync <claude\|cursor\|codex>`                                                  | 選択したマーケットプレイス種別を入力元として、他のマーケットプレイスmanifestと、存在するプラグインごとの`plugin.json`を再生成する。                                                                                       |
 
 `-g`と`-r`は同時に指定できません。再帰モードは`sync`と`update`だけに適用します。
 
@@ -114,10 +114,10 @@ TUIは選択状態を扱うアダプターであり、コマンドのビジネ�
 
 ロックファイル名は`c-plugin-lock.json`のまま維持します。
 
-| スコープ | ロックパス | 主な管理対象スキルルート |
-| --- | --- | --- |
-| プロジェクト | ユーザーのhomeを境界として探索した最も近い祖先の`<root>/c-plugin-lock.json` | `<root>/.agents/skills` |
-| グローバル（`-g`） | 厳密に`~/c-plugin-lock.json` | `~/.agents/skills` |
+| スコープ           | ロックパス                                                                  | 主な管理対象スキルルート |
+| ------------------ | --------------------------------------------------------------------------- | ------------------------ |
+| プロジェクト       | ユーザーのhomeを境界として探索した最も近い祖先の`<root>/c-plugin-lock.json` | `<root>/.agents/skills`  |
+| グローバル（`-g`） | 厳密に`~/c-plugin-lock.json`                                                | `~/.agents/skills`       |
 
 グローバルロックファイルは意図的に`~/.agents/`以下へ配置しません。
 
@@ -190,10 +190,10 @@ GitHubのownerとrepository componentは、それぞれのdomain constructorで�
 
 シンボリックリンク自体には、作成したprocessを識別できる信頼性のあるmetadataがありません。ロックは共有可能な望ましい状態を記録するため、他者がロックを変更した後に古くなったリンクを、ロックだけから識別することはできません。そのため、c-pluginは生成したリンクについて、ロックとは別にmachine-localな所有stateを維持します。
 
-| スコープ | 所有stateのパス |
-| --- | --- |
-| プロジェクト | `<root>/.agents/c-plugin-state.json` |
-| グローバル（`-g`） | `~/.agents/c-plugin-state.json` |
+| スコープ           | 所有stateのパス                      |
+| ------------------ | ------------------------------------ |
+| プロジェクト       | `<root>/.agents/c-plugin-state.json` |
+| グローバル（`-g`） | `~/.agents/c-plugin-state.json`      |
 
 所有stateは生成されたruntime stateであり、共有設定でも、望ましい状態を表す第2のsource of truthでもありません。各entryには、絶対link path、シンボリックリンクへ書き込んだliteral target、正規化済みresolved target、source repository、plugin、skill identityを記録します。後からロックから削除されたtarget root内のリンクも維持します。
 
@@ -356,15 +356,15 @@ c-plugin v2は一度に全面的に書き換えず、独立してレビュー可
 
 Milestone 0は完了済みの本設計契約です。Milestone 1から7では、次の安定した原子的単位IDを使用します。同じwave内のcomma区切りだけを並行化候補とし、arrowは厳密な順序制約とします。原子的単位`M1`はMilestone 3に属し、Milestone 1のparent issueとは別です。
 
-| マイルストーン | 原子的な単位 | 依存関係と並行wave |
-| --- | --- | --- |
-| 1. Bootstrap | `B0` v1共存identity/layout契約、`B1` native dependency compatibilityと正確な`mizchi/bit` APIを証明してからCLI skeleton・help・versionを作成、`B2` `c-plugin-v2` Nix packageを追加 | `B0 -> B1 -> B2` |
-| 2. 状態基盤 | `F0` runtime path、`F1` domain/lock model、`F2` lock codec、`F3` ownership codec、`F4` atomic store、`F5` cache scope、`F6` discovery、`F7` runtime composition、`C-init` init、`E0` Docker/init E2E | `F0,F1 -> F2,F3,F5,F6 -> F4,F7 -> C-init -> E0` |
-| 3. ローカルライフサイクル | `M0` marketplace解析、`M1` local/skill解決、`R1` reconciliation、`C-sync`、`A1` `persist_and_sync`、`C-sync-r`、`C-add-local`、`C-remove`、`C-target-add`、`C-target-remove` | `M0,M1 -> R1 -> C-sync -> A1,C-sync-r -> C-add-local,C-target-add -> C-remove,C-target-remove` |
-| 4. GitHubライフサイクル | `G0` freeze済みbit contract/adapterの前提条件、`G1` clone/checkout/HEAD、`G2` fetch/default branch、`G-add`、`G-update`、`G-update-r`、`G-cleanup` | `G0 -> G1 -> G2 -> G-add,G-cleanup -> G-update -> G-update-r` |
-| 5. 対話入力 | `I1` selection state/TUI adapter、`I2` TTY方針、`I-add-kind`、`I-add-skill`、`I-remove`、`I-target-remove` | `I1 -> I2 -> I-add-kind,I-add-skill,I-remove,I-target-remove` |
-| 6. マーケットプレイス作者向け機能 | `D0` 共通read model、`D1` format変換、`D2` 決定論的write、`C-dev-sync` | `D0 -> D1 -> D2 -> C-dev-sync` |
-| 7. 最終等価性とcutover | `P1` 完全parity matrix、`P2` 文書/parity audit、`P3` cutover | `P1 -> P2 -> 明示的なcutover承認 -> P3` |
+| マイルストーン                    | 原子的な単位                                                                                                                                                                                         | 依存関係と並行wave                                                                             |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 1. Bootstrap                      | `B0` v1共存identity/layout契約、`B1` native dependency compatibilityと正確な`mizchi/bit` APIを証明してからCLI skeleton・help・versionを作成、`B2` `c-plugin-v2` Nix packageを追加                    | `B0 -> B1 -> B2`                                                                               |
+| 2. 状態基盤                       | `F0` runtime path、`F1` domain/lock model、`F2` lock codec、`F3` ownership codec、`F4` atomic store、`F5` cache scope、`F6` discovery、`F7` runtime composition、`C-init` init、`E0` Docker/init E2E | `F0,F1 -> F2,F3,F5,F6 -> F4,F7 -> C-init -> E0`                                                |
+| 3. ローカルライフサイクル         | `M0` marketplace解析、`M1` local/skill解決、`R1` reconciliation、`C-sync`、`A1` `persist_and_sync`、`C-sync-r`、`C-add-local`、`C-remove`、`C-target-add`、`C-target-remove`                         | `M0,M1 -> R1 -> C-sync -> A1,C-sync-r -> C-add-local,C-target-add -> C-remove,C-target-remove` |
+| 4. GitHubライフサイクル           | `G0` freeze済みbit contract/adapterの前提条件、`G1` clone/checkout/HEAD、`G2` fetch/default branch、`G-add`、`G-update`、`G-update-r`、`G-cleanup`                                                   | `G0 -> G1 -> G2 -> G-add,G-cleanup -> G-update -> G-update-r`                                  |
+| 5. 対話入力                       | `I1` selection state/TUI adapter、`I2` TTY方針、`I-add-kind`、`I-add-skill`、`I-remove`、`I-target-remove`                                                                                           | `I1 -> I2 -> I-add-kind,I-add-skill,I-remove,I-target-remove`                                  |
+| 6. マーケットプレイス作者向け機能 | `D0` 共通read model、`D1` format変換、`D2` 決定論的write、`C-dev-sync`                                                                                                                               | `D0 -> D1 -> D2 -> C-dev-sync`                                                                 |
+| 7. 最終等価性とcutover            | `P1` 完全parity matrix、`P2` 文書/parity audit、`P3` cutover                                                                                                                                         | `P1 -> P2 -> 明示的なcutover承認 -> P3`                                                        |
 
 ### 単位ごとの検証契約
 

--- a/c-plugin-v2/README.md
+++ b/c-plugin-v2/README.md
@@ -19,18 +19,18 @@ Functional equivalence includes preserving the public `c-plugin skill` namespace
 
 ## Technology stack
 
-| Concern | Decision |
-| --- | --- |
-| Language and target | MoonBit, native target only |
-| CLI parsing | `totto2727/admiral` |
-| Interactive input | `mizchi/tui` |
-| Git | The `mizchi/bit` module used as a library, primarily through its library packages such as `mizchi/bit_lib`; never spawn `git` or the `bit` CLI |
-| Paths | `moonbitlang/x/path.Path` |
-| Lock discovery | `totto2727/target-file-discovery` |
-| JSON | `totto2727/lens` plus the standard `FromJson` and `ToJson` traits |
-| Async I/O | `moonbitlang/async` |
-| Unit tests | MoonBit black-box and white-box tests using per-test temporary roots |
-| E2E tests | Shell-driven Docker tests under `src/e2e/` |
+| Concern             | Decision                                                                                                                                       |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Language and target | MoonBit, native target only                                                                                                                    |
+| CLI parsing         | `totto2727/admiral`                                                                                                                            |
+| Interactive input   | `mizchi/tui`                                                                                                                                   |
+| Git                 | The `mizchi/bit` module used as a library, primarily through its library packages such as `mizchi/bit_lib`; never spawn `git` or the `bit` CLI |
+| Paths               | `moonbitlang/x/path.Path`                                                                                                                      |
+| Lock discovery      | `totto2727/target-file-discovery`                                                                                                              |
+| JSON                | `totto2727/lens` plus the standard `FromJson` and `ToJson` traits                                                                              |
+| Async I/O           | `moonbitlang/async`                                                                                                                            |
+| Unit tests          | MoonBit black-box and white-box tests using per-test temporary roots                                                                           |
+| E2E tests           | Shell-driven Docker tests under `src/e2e/`                                                                                                     |
 
 All dependencies must be pinned to exact compatible versions. The first implementation gate is a minimal native build importing Admiral, TUI, bit, Lens, target-file-discovery, async, and `moonbitlang/x/path` together. Implementation must not proceed on an unverified dependency combination.
 
@@ -58,16 +58,16 @@ c-plugin
 
 The leaf-command contract is:
 
-| Command | Contract |
-| --- | --- |
-| `c-plugin init [-g]` | Exclusively create an empty lock file. Fail without modifying it if it already exists. |
-| `c-plugin skill add [<owner/repo> | --local <./path>] [-g] [--kind <kind>] [--skill <plugin/skill>...]` | Add a GitHub or local marketplace, select its marketplace kind and enabled skills, pin GitHub state, write the lock, and synchronize links. Exactly one of the GitHub positional or `--local` is accepted. |
-| `c-plugin skill remove [-g] [--skill <repo/plugin/skill>...]` | Remove selected installed skills. Remove an empty plugin entry, an empty repository entry, and the disposable Git cache only after its final skill is removed. |
-| `c-plugin skill sync [-g | -r]` | Reconcile managed links from lock state without changing Git pins. |
-| `c-plugin skill update [-g | -r]` | Fetch GitHub repositories, advance pins, rewrite the lock, and synchronize links. Local repositories are not fetched. |
-| `c-plugin skill target add <path> [-g]` | Register an additional skill-link root and synchronize it. Duplicate resolved paths are a successful no-op. |
-| `c-plugin skill target remove [-g] [--target <path>...]` | Remove selected additional roots from lock state and remove only c-plugin-managed links from those roots. |
-| `c-plugin dev marketplace sync <claude|cursor|codex>` | Use the selected marketplace kind as the source and regenerate the other marketplace manifests and available per-plugin `plugin.json` files. |
+| Command                                                                                                  | Contract                                                                                                                                                                                                   |
+| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `c-plugin init [-g]`                                                                                     | Exclusively create an empty lock file. Fail without modifying it if it already exists.                                                                                                                     |
+| `c-plugin skill add [<owner/repo> \| --local <./path>] [-g] [--kind <kind>] [--skill <plugin/skill>...]` | Add a GitHub or local marketplace, select its marketplace kind and enabled skills, pin GitHub state, write the lock, and synchronize links. Exactly one of the GitHub positional or `--local` is accepted. |
+| `c-plugin skill remove [-g] [--skill <repo/plugin/skill>...]`                                            | Remove selected installed skills. Remove an empty plugin entry, an empty repository entry, and the disposable Git cache only after its final skill is removed.                                             |
+| `c-plugin skill sync [-g \| -r]`                                                                         | Reconcile managed links from lock state without changing Git pins.                                                                                                                                         |
+| `c-plugin skill update [-g \| -r]`                                                                       | Fetch GitHub repositories, advance pins, rewrite the lock, and synchronize links. Local repositories are not fetched.                                                                                      |
+| `c-plugin skill target add <path> [-g]`                                                                  | Register an additional skill-link root and synchronize it. Duplicate resolved paths are a successful no-op.                                                                                                |
+| `c-plugin skill target remove [-g] [--target <path>...]`                                                 | Remove selected additional roots from lock state and remove only c-plugin-managed links from those roots.                                                                                                  |
+| `c-plugin dev marketplace sync <claude\|cursor\|codex>`                                                  | Use the selected marketplace kind as the source and regenerate the other marketplace manifests and available per-plugin `plugin.json` files.                                                               |
 
 `-g` and `-r` are mutually exclusive. Recursive mode applies only to `sync` and `update`.
 
@@ -114,10 +114,10 @@ A migration path may be added later as a separate, explicitly approved milestone
 
 The lock filename remains `c-plugin-lock.json`.
 
-| Scope | Lock path | Primary managed skill root |
-| --- | --- | --- |
-| Project | Nearest ancestor `<root>/c-plugin-lock.json`, bounded by the user's home | `<root>/.agents/skills` |
-| Global (`-g`) | `~/c-plugin-lock.json` exactly | `~/.agents/skills` |
+| Scope         | Lock path                                                                | Primary managed skill root |
+| ------------- | ------------------------------------------------------------------------ | -------------------------- |
+| Project       | Nearest ancestor `<root>/c-plugin-lock.json`, bounded by the user's home | `<root>/.agents/skills`    |
+| Global (`-g`) | `~/c-plugin-lock.json` exactly                                           | `~/.agents/skills`         |
 
 The global lock file is deliberately not stored under `~/.agents/`.
 
@@ -190,10 +190,10 @@ All other operations follow `mkdir -p` semantics:
 
 A symlink does not carry reliable metadata identifying the process that created it. The lock records desired portable state, so it cannot by itself identify links that became stale after another person edited the lock. c-plugin therefore maintains a separate machine-local ownership file for materialized links:
 
-| Scope | Ownership state path |
-| --- | --- |
-| Project | `<root>/.agents/c-plugin-state.json` |
-| Global (`-g`) | `~/.agents/c-plugin-state.json` |
+| Scope         | Ownership state path                 |
+| ------------- | ------------------------------------ |
+| Project       | `<root>/.agents/c-plugin-state.json` |
+| Global (`-g`) | `~/.agents/c-plugin-state.json`      |
 
 The ownership state is generated runtime state, not shared configuration and not a second source of desired state. Each entry records the absolute link path, the literal target written into the symlink, the normalized resolved target, and the source repository, plugin, and skill identity. It also retains links in target roots that were later removed from the lock.
 
@@ -356,15 +356,15 @@ c-plugin v2 is implemented as a sequence of independently reviewable milestones,
 
 Milestone 0 is this completed design contract. Milestones 1 through 7 use the following stable atomic-unit IDs. Commas in one wave are the only planned overlap; arrows are hard ordering constraints. The atomic unit `M1` belongs to Milestone 3 and is distinct from the Milestone 1 parent issue.
 
-| Milestone | Atomic units | Dependency and parallel waves |
-| --- | --- | --- |
-| 1. Bootstrap | `B0` v1 coexistence identity/layout contract; `B1` prove native dependency compatibility and the exact `mizchi/bit` API, then create the CLI skeleton, help, and version; `B2` add the `c-plugin-v2` Nix package | `B0 -> B1 -> B2` |
-| 2. State foundation | `F0` runtime paths; `F1` domain/lock model; `F2` lock codec; `F3` ownership codec; `F4` atomic stores; `F5` cache scope; `F6` discovery; `F7` runtime composition; `C-init` init; `E0` Docker/init E2E | `F0,F1 -> F2,F3,F5,F6 -> F4,F7 -> C-init -> E0` |
-| 3. Local lifecycle | `M0` marketplace parsing; `M1` local/skill resolution; `R1` reconciliation; `C-sync`; `A1` `persist_and_sync`; `C-sync-r`; `C-add-local`; `C-remove`; `C-target-add`; `C-target-remove` | `M0,M1 -> R1 -> C-sync -> A1,C-sync-r -> C-add-local,C-target-add -> C-remove,C-target-remove` |
-| 4. GitHub lifecycle | `G0` frozen bit contract/adapter precondition; `G1` clone/checkout/HEAD; `G2` fetch/default branch; `G-add`; `G-update`; `G-update-r`; `G-cleanup` | `G0 -> G1 -> G2 -> G-add,G-cleanup -> G-update -> G-update-r` |
-| 5. Interactive input | `I1` selection state/TUI adapter; `I2` TTY policy; `I-add-kind`; `I-add-skill`; `I-remove`; `I-target-remove` | `I1 -> I2 -> I-add-kind,I-add-skill,I-remove,I-target-remove` |
-| 6. Marketplace authoring | `D0` common read model; `D1` format conversion; `D2` deterministic writes; `C-dev-sync` | `D0 -> D1 -> D2 -> C-dev-sync` |
-| 7. Final parity and cutover | `P1` full parity matrix; `P2` documentation/parity audit; `P3` cutover | `P1 -> P2 -> explicit cutover approval -> P3` |
+| Milestone                   | Atomic units                                                                                                                                                                                                     | Dependency and parallel waves                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 1. Bootstrap                | `B0` v1 coexistence identity/layout contract; `B1` prove native dependency compatibility and the exact `mizchi/bit` API, then create the CLI skeleton, help, and version; `B2` add the `c-plugin-v2` Nix package | `B0 -> B1 -> B2`                                                                               |
+| 2. State foundation         | `F0` runtime paths; `F1` domain/lock model; `F2` lock codec; `F3` ownership codec; `F4` atomic stores; `F5` cache scope; `F6` discovery; `F7` runtime composition; `C-init` init; `E0` Docker/init E2E           | `F0,F1 -> F2,F3,F5,F6 -> F4,F7 -> C-init -> E0`                                                |
+| 3. Local lifecycle          | `M0` marketplace parsing; `M1` local/skill resolution; `R1` reconciliation; `C-sync`; `A1` `persist_and_sync`; `C-sync-r`; `C-add-local`; `C-remove`; `C-target-add`; `C-target-remove`                          | `M0,M1 -> R1 -> C-sync -> A1,C-sync-r -> C-add-local,C-target-add -> C-remove,C-target-remove` |
+| 4. GitHub lifecycle         | `G0` frozen bit contract/adapter precondition; `G1` clone/checkout/HEAD; `G2` fetch/default branch; `G-add`; `G-update`; `G-update-r`; `G-cleanup`                                                               | `G0 -> G1 -> G2 -> G-add,G-cleanup -> G-update -> G-update-r`                                  |
+| 5. Interactive input        | `I1` selection state/TUI adapter; `I2` TTY policy; `I-add-kind`; `I-add-skill`; `I-remove`; `I-target-remove`                                                                                                    | `I1 -> I2 -> I-add-kind,I-add-skill,I-remove,I-target-remove`                                  |
+| 6. Marketplace authoring    | `D0` common read model; `D1` format conversion; `D2` deterministic writes; `C-dev-sync`                                                                                                                          | `D0 -> D1 -> D2 -> C-dev-sync`                                                                 |
+| 7. Final parity and cutover | `P1` full parity matrix; `P2` documentation/parity audit; `P3` cutover                                                                                                                                           | `P1 -> P2 -> explicit cutover approval -> P3`                                                  |
 
 ### Per-unit verification contract
 

--- a/c-plugin-v2/README.md
+++ b/c-plugin-v2/README.md
@@ -1,0 +1,458 @@
+# c-plugin v2
+
+This directory records the design contract for the ground-up c-plugin rewrite. The design documents remain at the repository-root `c-plugin-v2/` path, while staged implementation lives under `mbt/app/c-plugin-v2` in the Moon module `totto2727/c-plugin-v2`.
+
+## Coexistence identity
+
+During staged delivery, the native executable and Nix attribute are temporarily named `c-plugin-v2`, while Admiral must continue to render the application and help name as `c-plugin`. The v1 implementation remains untouched until an explicitly approved cutover. Operators must never run v1 and v2 against the same lock scope; use separate project roots or synthetic homes while both exist.
+
+This coexistence layout is temporary control-plane state, not a second product identity. No v1 lock migration is implemented now. A future explicit migration milestone remains possible under the lock-version rules below, but cutover must not smuggle migration into decoding or normal command execution.
+
+## Goals
+
+- Reimplement c-plugin in MoonBit while preserving the current user-visible capabilities.
+- Organize the command tree around extensible resource namespaces and restore the interactive choices that were present before the current MoonBit port.
+- Use typed paths, strict lock-file decoding, library-based Git operations, and deterministic tests from the start.
+- Keep project and global installations isolated and make all non-`init` operations idempotent.
+
+Functional equivalence includes preserving the public `c-plugin skill` namespace, while allowing internal functions to be redesigned.
+
+## Technology stack
+
+| Concern | Decision |
+| --- | --- |
+| Language and target | MoonBit, native target only |
+| CLI parsing | `totto2727/admiral` |
+| Interactive input | `mizchi/tui` |
+| Git | The `mizchi/bit` module used as a library, primarily through its library packages such as `mizchi/bit_lib`; never spawn `git` or the `bit` CLI |
+| Paths | `moonbitlang/x/path.Path` |
+| Lock discovery | `totto2727/target-file-discovery` |
+| JSON | `totto2727/lens` plus the standard `FromJson` and `ToJson` traits |
+| Async I/O | `moonbitlang/async` |
+| Unit tests | MoonBit black-box and white-box tests using per-test temporary roots |
+| E2E tests | Shell-driven Docker tests under `src/e2e/` |
+
+All dependencies must be pinned to exact compatible versions. The first implementation gate is a minimal native build importing Admiral, TUI, bit, Lens, target-file-discovery, async, and `moonbitlang/x/path` together. Implementation must not proceed on an unverified dependency combination.
+
+`mizchi/bit` currently describes itself as experimental and warns about possible repository corruption. c-plugin therefore treats cached clones as disposable data, pins the dependency, and tests the exact clone, fetch, checkout, and HEAD-resolution APIs it uses.
+
+## Command model
+
+The `skill` namespace remains the home of skill management. This preserves room for future top-level resource namespaces such as `hook` and `mcp`. Author-only marketplace conversion stays under `dev` so it remains separate from installation commands.
+
+```text
+c-plugin
+├── init
+├── skill
+│   ├── add
+│   ├── remove
+│   ├── sync
+│   ├── update
+│   └── target
+│       ├── add
+│       └── remove
+└── dev
+    └── marketplace
+        └── sync
+```
+
+The leaf-command contract is:
+
+| Command | Contract |
+| --- | --- |
+| `c-plugin init [-g]` | Exclusively create an empty lock file. Fail without modifying it if it already exists. |
+| `c-plugin skill add [<owner/repo> | --local <./path>] [-g] [--kind <kind>] [--skill <plugin/skill>...]` | Add a GitHub or local marketplace, select its marketplace kind and enabled skills, pin GitHub state, write the lock, and synchronize links. Exactly one of the GitHub positional or `--local` is accepted. |
+| `c-plugin skill remove [-g] [--skill <repo/plugin/skill>...]` | Remove selected installed skills. Remove an empty plugin entry, an empty repository entry, and the disposable Git cache only after its final skill is removed. |
+| `c-plugin skill sync [-g | -r]` | Reconcile managed links from lock state without changing Git pins. |
+| `c-plugin skill update [-g | -r]` | Fetch GitHub repositories, advance pins, rewrite the lock, and synchronize links. Local repositories are not fetched. |
+| `c-plugin skill target add <path> [-g]` | Register an additional skill-link root and synchronize it. Duplicate resolved paths are a successful no-op. |
+| `c-plugin skill target remove [-g] [--target <path>...]` | Remove selected additional roots from lock state and remove only c-plugin-managed links from those roots. |
+| `c-plugin dev marketplace sync <claude|cursor|codex>` | Use the selected marketplace kind as the source and regenerate the other marketplace manifests and available per-plugin `plugin.json` files. |
+
+`-g` and `-r` are mutually exclusive. Recursive mode applies only to `sync` and `update`.
+
+### Interactive and non-interactive input
+
+When stdin is a TTY and an explicit selection option is absent, `mizchi/tui` provides the selection UI:
+
+- `skill add` shows a single-select marketplace-kind prompt when multiple supported kinds exist.
+- `skill add` shows a multi-select list of `plugin/skill` entries, with already-enabled skills preselected.
+- `skill remove` shows a multi-select list of installed `repository > plugin/skill` entries.
+- `skill target remove` shows a multi-select list of registered additional target directories.
+
+When stdin is not a TTY, the corresponding `--kind`, repeatable `--skill`, or repeatable `--target` options are required. Non-interactive execution must never silently select every item or accept a default that an interactive user would normally choose.
+
+Cancel and empty selection are successful no-ops and must not rewrite the lock file.
+
+The TUI is an adapter around selection state, not part of command business logic. Command handlers consume typed selection results so unit tests can inject deterministic choices without controlling a real terminal.
+
+## Functional parity baseline
+
+The rewrite is complete only when it preserves these capabilities:
+
+- GitHub marketplace sources written as `owner/repository` and local marketplace sources beginning with `./`.
+- Claude, Cursor, and Codex marketplace detection and parsing.
+- Explicit skill enablement per plugin rather than implicit installation of every discovered skill.
+- GitHub commit pinning and repeatable synchronization at the pinned commit.
+- Update to the remote default branch followed by lock and link refresh.
+- Primary links under `.agents/skills` plus zero or more additional link targets.
+- Nearest-parent project lock discovery, exact home-level global lock discovery, and recursive descendant lock discovery.
+- `.gitignore`-aware recursive traversal through `totto2727/target-file-discovery`.
+- Tolerant multi-repository synchronization: one unavailable repository is reported and skipped without preventing independent repositories from being synchronized.
+- Deterministic duplicate skill-name resolution using the last repository entry in lock order, matching the current behavior.
+- Marketplace conversion among Claude, Cursor, and Codex formats.
+- Codex local source objects with normalized `./plugins/...` paths and `policy.installation = "INSTALLED_BY_DEFAULT"`.
+- Copying a base-kind plugin's `plugin.json` to target kinds when the base file exists.
+
+The new lock format is versioned separately from v1. Capability parity does not imply accepting malformed v1 documents or preserving tolerant-decoder bugs.
+
+Lock migration is intentionally out of scope for the current implementation. c-plugin v2 provides neither automatic migration nor a `migrate` command, and its decoder must not reinterpret an older version as v2. When an existing lock declares an unsupported version, every command that loads that lock fails without rewriting it or changing links, cache, or ownership state. `init` also continues to reject any existing lock rather than replacing it.
+
+A migration path may be added later as a separate, explicitly approved milestone. It must be an explicit operation with version-to-version conversion rules, atomic persistence, synchronization after a successful write, and dedicated unit and E2E coverage; it must not be introduced as a permissive fallback inside normal lock decoding. Keeping the top-level lock version mandatory preserves this future extension point without implementing migration now.
+
+## Scope and path rules
+
+The lock filename remains `c-plugin-lock.json`.
+
+| Scope | Lock path | Primary managed skill root |
+| --- | --- | --- |
+| Project | Nearest ancestor `<root>/c-plugin-lock.json`, bounded by the user's home | `<root>/.agents/skills` |
+| Global (`-g`) | `~/c-plugin-lock.json` exactly | `~/.agents/skills` |
+
+The global lock file is deliberately not stored under `~/.agents/`.
+
+`init` uses the current working directory as the project root or the injected home directory for `-g`. Every other scoped command locates an existing lock with `totto2727/target-file-discovery`; it does not guess a different root.
+
+Recursive discovery starts at the directory containing the nearest project lock and includes that lock plus descendant locks. Global mode never performs recursive discovery.
+
+The cache root defaults to `~/.cache/c-plugin/repositories` and is configurable at the runtime boundary for tests. Cache contents are never authoritative; the lock file is authoritative.
+
+### Cache identity and lock isolation
+
+Repository caches are scoped by the lock file that owns them. An owner/repository-only cache key is forbidden because two project locks may pin the same GitHub repository to different commits.
+
+After the lock path is normalized to an absolute `Path`, derive its cache scope key as follows:
+
+```text
+scope_key = lowercase_hex(sha256(utf8("lock\0" + normalized_absolute_lock_path)))
+cache_path = cache_root / scope_key / lowercase(owner) / lowercase(repository)
+```
+
+The complete 64-character SHA-256 digest is used; language-runtime hash values and shortened digests are not allowed. Project mode hashes the discovered absolute project lock path, while global mode hashes the absolute `~/c-plugin-lock.json` path under the injected home directory.
+
+Each scope directory contains `c-plugin-cache-scope.json`, generated metadata recording the format version and the exact normalized absolute lock path used as the hash input. Before reusing the directory, c-plugin must strictly validate that metadata. A missing or mismatched record is an error rather than permission to share the directory, so even a digest collision or manually copied cache cannot silently combine two lock scopes.
+
+GitHub owner and repository components are validated by their domain constructors and canonicalized to lowercase before joining them to the scope path. Raw `owner/repository` input is never appended as one path string. This canonicalization intentionally maps case variants to the same identity because GitHub treats both route components as case-insensitive.
+
+The consequences are:
+
+- References to the same repository from one lock share one cache and one pinned working tree.
+- Different project or global locks use different caches even when they reference the same repository, so checkout, update, and deletion cannot change another lock's materialized skills.
+- Cache mutations are serialized by the complete scoped cache `Path`, not only by owner/repository.
+- Removing the last reference in one lock may delete only that lock's scoped repository cache.
+- Moving a project changes its normalized lock path and therefore its scope key. The old cache is disposable orphaned data and must never be adopted implicitly by the new scope.
+
+### Path typing
+
+- Convert CLI strings, environment strings, and JSON strings to `Path` immediately at their owning boundary.
+- Pass `Path` through command, application, discovery, lock, filesystem, cache, marketplace, and symlink logic.
+- Convert `Path` to `String` only at terminal library calls that currently require strings, including MoonBit async filesystem calls, Lens JSON encoding, and current bit APIs.
+- Represent a GitHub repository as a validated `GitHubRepository { owner, name }`, not as an unrestricted path-like string.
+- Store relative local marketplace paths and target paths as typed domain values whose constructors enforce their constraints.
+- Normalize before comparing paths. Do not compare user-provided path spellings directly.
+
+`totto2727/target-file-discovery` currently exposes string-based public functions. Its conversion is confined to one discovery adapter so untyped paths do not leak into the rest of c-plugin. A Path-based API may be added to that library later, but it is not required to create a second discovery implementation.
+
+## Git policy
+
+- Declare the `mizchi/bit` module and call its library packages directly.
+- Do not use `moonbitlang/async/process` for Git and do not fall back to an installed `git` or `bit` executable.
+- Support HTTPS GitHub clone, fetch, default-branch resolution, checkout of a pinned commit, and HEAD object-id resolution through one narrow `BitRepositoryStore` adapter.
+- Keep bit's current string paths inside that adapter; its public c-plugin-facing API accepts and returns `Path` and typed object IDs.
+- Store repositories under the deterministic lock-scoped cache path defined above.
+- Serialize mutations that address the same cached repository. Independent read-only resolution may run concurrently.
+- Never apply working-tree mutations to the user's source repository. All Git mutations occur only in disposable c-plugin cache directories.
+
+## Filesystem and idempotence policy
+
+`init` lock creation is the only exclusive creation operation. It must not overwrite an existing lock file.
+
+All other operations follow `mkdir -p` semantics:
+
+- Existing expected directories are accepted.
+- Re-registering an existing source, skill, or normalized target is a successful no-op or merge.
+- Existing c-plugin-managed files and symlinks may be refreshed or removed according to the lock.
+- A foreign file, directory, or non-managed symlink at a desired output path is left untouched and reported as skipped.
+- Sync never clears a directory wholesale; it removes only links known to be managed by c-plugin.
+- Marketplace generation may replace its own target manifest and copied `plugin.json`, but never removes unrelated files from existing directories.
+
+### Symlink ownership state
+
+A symlink does not carry reliable metadata identifying the process that created it. The lock records desired portable state, so it cannot by itself identify links that became stale after another person edited the lock. c-plugin therefore maintains a separate machine-local ownership file for materialized links:
+
+| Scope | Ownership state path |
+| --- | --- |
+| Project | `<root>/.agents/c-plugin-state.json` |
+| Global (`-g`) | `~/.agents/c-plugin-state.json` |
+
+The ownership state is generated runtime state, not shared configuration and not a second source of desired state. Each entry records the absolute link path, the literal target written into the symlink, the normalized resolved target, and the source repository, plugin, and skill identity. It also retains links in target roots that were later removed from the lock.
+
+`sync` reconciles the desired lock with the previous ownership state as follows:
+
+1. Read and strictly validate both the lock and ownership state.
+2. Compute desired links from the lock and stale links from `previously owned - desired`.
+3. Delete a stale path only when it is still a symlink and its resolved target matches the recorded target.
+4. If the path is now a file, directory, or different symlink, leave it untouched, report that ownership was lost, and omit it from the next ownership state.
+5. Do not automatically adopt a pre-existing unrecorded symlink, even when it currently resolves to the desired target.
+6. Reconcile missing desired links, then atomically write ownership state from the links c-plugin still verifiably owns.
+
+This state survives external lock edits, so a later `c-plugin skill sync` can remove links for deleted skills and deleted target registrations. Ownership is scoped per lock; recursive sync must not let one lock delete links owned by another lock.
+
+Safety rules:
+
+- Missing or corrupt ownership state disables deletion of pre-existing links. Sync may create missing non-conflicting links and start a new state, but it must not infer or adopt ownership by scanning.
+- Every path loaded from ownership state must be validated against its recorded managed root before any filesystem mutation.
+- A broken symlink cannot be target-verified with the current public `moonbitlang/async/fs` API because it exposes symlink-aware `kind` and `realpath`, but not the literal `readlink` value. Leave such a link untouched and report it. A small `readlink` filesystem adapter may be added later if broken-link cleanup becomes required.
+- Ownership state writes use a temporary sibling and atomic rename. Ownership-state writes do not recursively trigger `sync`; only lock mutations do.
+- Disposable Git cache deletion happens after stale managed links are reconciled so their targets remain verifiable during deletion.
+
+### Lock-mutation invariant
+
+Every successful mutation of an existing lock file must run the normal `sync` reconciliation against the exact persisted lock value before the command returns. This applies to repository, plugin, enabled-skill, target, marketplace-kind, commit-pin, and future resource changes.
+
+- `init` is the only exception because it creates a new empty lock rather than updating an existing lock.
+- A cancelled or semantic no-op command neither writes the lock nor needs to run `sync`.
+- Command workflows must use one `persist_and_sync` application boundary; they must not call the lock writer directly and return without reconciliation.
+- If persistence succeeds but `sync` fails, the command returns a non-zero status and reports that rerunning `c-plugin skill sync` will reconcile the persisted state.
+- Recursive operations apply this invariant independently to every lock they mutate.
+
+Lock writes use a temporary sibling file followed by an atomic rename. The in-memory candidate is fully validated before persistence. Lock mutations use this order:
+
+1. Resolve and validate the complete candidate state.
+2. Write the lock atomically.
+3. Reconcile managed links and disposable cache state.
+
+A failure before step 2 preserves the previous state. A failure after step 2 is recoverable by rerunning `sync`.
+
+## Lock-file model
+
+The v2 lock is strict and uses a top-level discriminator for data-carrying enum variants.
+
+```json
+{
+  "version": 2,
+  "targets": ["~/.claude/skills"],
+  "repositories": [
+    {
+      "type": "github",
+      "repository": "totto2727-org/monorepo",
+      "marketplaceKind": "claude",
+      "commit": "0123456789abcdef",
+      "plugins": [
+        {
+          "name": "totto2727-coding",
+          "path": "plugins/totto2727-coding",
+          "enabledSkills": ["c-plugin"]
+        }
+      ]
+    },
+    {
+      "type": "local",
+      "path": "./",
+      "marketplaceKind": "codex",
+      "plugins": []
+    }
+  ]
+}
+```
+
+JSON rules:
+
+- Define every lock field with Lens.
+- Decode Lens-selected values through standard `FromJson` with the Lens-derived `JsonPath`.
+- Encode with standard `ToJson`, Lens `JsonBuilder`, and `set_or_abort`.
+- Decode `LockRepository` by reading its top-level `type` once, then delegate to the complete `github` or `local` payload decoder.
+- Encode `LockRepository` by matching the enum once and emitting its complete variant object.
+- Do not infer a variant from the presence of `commit`, `repository`, or `path`, and do not branch independently for each property.
+- Scalar closed enums such as `MarketplaceKind` may use a strict string representation.
+- Missing required fields, unknown enum values, wrong types, malformed paths, invalid repository names, duplicate identities, and unsupported versions are errors.
+- Never treat corrupt JSON as an empty lock, silently filter invalid repository entries, or replace invalid values with permissive defaults.
+- Preserve repository, plugin, skill, and target ordering for deterministic output and duplicate resolution.
+
+The lock codec has one round-trip property: decoding the canonical encoded form returns the same domain value. Pretty output uses two-space indentation and a trailing newline.
+
+## Internal structure
+
+The implementation should stay small and use explicit boundary adapters rather than a large framework:
+
+```text
+src/
+├── cli/            Admiral command definitions and argv-to-domain parsing
+├── interaction/    mizchi/tui selection views and pure selection state
+├── command/        Add, remove, sync, update, target, init, and dev workflows
+├── domain/         Lock, repository, marketplace, skill, target, and validated identifier types
+├── adapter/        Lens lock and ownership-state stores, target discovery, bit Git, async filesystem, and symlinks
+├── e2e/            Dockerfile, one shell test per leaf command, and an explicit runner
+└── main/           Executable entry point
+```
+
+Use direct functions and small records of callbacks where injection is needed. Do not create a service, repository, or trait layer unless it replaces an actual external boundary used by tests.
+
+## Unit-test policy
+
+Unit tests are mandatory and run through normal MoonBit test commands.
+
+- Create a fresh temporary root per test and clean it after the test.
+- Place synthetic home, working directory, lock, `.agents`, cache, marketplace, and target directories under that temporary root.
+- Inject runtime paths; never read the real user's home, working tree, cache, global lock, or global skill targets from a test.
+- Test `-g` with a synthetic home. Omit only a platform-specific case that cannot be isolated, and record the reason next to that test suite.
+- Use bit only against disposable repositories under the temporary root in unit tests.
+- Test lock round trips, strict failures, top-level enum dispatch, canonical ordering, and JSON error paths.
+- Test that unsupported lock versions preserve the exact lock bytes and do not mutate links, cache, or ownership state.
+- Test Path normalization, project/global/recursive discovery, local-source constraints, target deduplication, lock-scope key derivation, scope-metadata mismatch rejection, and cache isolation for two locks that pin the same repository differently.
+- Test pure TUI selection state and inject scripted selections into command tests.
+- Test idempotent repeated commands, foreign path collisions, managed-link replacement, duplicate skill precedence, partial repository failure, and state preservation before persistence.
+- Test that every existing-lock mutation passes its persisted candidate to `sync`, while `init`, cancellation, and semantic no-op paths do not trigger unnecessary reconciliation.
+- Test ownership-state cleanup after external lock edits, removed target roots, replaced links, missing or corrupt state, broken symlinks, and isolation between recursively synchronized locks.
+- Name test files after the implementation file they exercise.
+
+## E2E-test policy
+
+E2E tests are mandatory, live under `src/e2e/`, and are excluded from both `vp test` and `moon test`.
+
+```text
+src/e2e/
+├── Dockerfile
+├── run.sh
+├── init.sh
+├── add.sh
+├── remove.sh
+├── sync.sh
+├── update.sh
+├── target_add.sh
+├── target_remove.sh
+└── dev_marketplace_sync.sh
+```
+
+There is no `moon.pkg` in `src/e2e/`, and E2E files do not use MoonBit test suffixes. E2E runs only through `src/e2e/run.sh` or an explicitly named CI task.
+
+The runner contract is:
+
+1. Build one Docker image from the repository root.
+2. Inside the image, run `moon install` once and build the actual native c-plugin executable once.
+3. Prepare reusable JSON and repository fixtures in the image where doing so does not bypass the behavior under test.
+4. Run every leaf-command test with a separate `docker run --rm` container from that image.
+5. Never rebuild the executable inside a command test.
+
+Every test container uses an isolated temporary `HOME`, working directory, cache root, and target directories. Global-mode cases therefore cannot affect the host user.
+
+The GitHub marketplace source for normal E2E coverage is `totto2727-org/monorepo` itself. At least `add` and `update` exercise the real bit-backed GitHub path. Other command tests may start from preconstructed canonical lock JSON and a reusable cached-repository fixture, as allowed by the test contract.
+
+Each leaf-command file covers at least one successful flow and asserts filesystem state, lock JSON, command output, and exit status relevant to that command. The `sync.sh` scenario must edit a previously materialized lock externally, verify stale owned links are removed, and verify replaced foreign paths are preserved. The `update.sh` scenario must use two project locks that pin the same repository differently and verify that updating one lock does not change the other lock's cache or links. Interactive state is primarily unit-tested; E2E uses explicit non-interactive selection options so Docker runs are deterministic.
+
+## Incremental delivery policy
+
+c-plugin v2 is implemented as a sequence of independently reviewable milestones, not as one large rewrite. Each milestone adds one usable vertical slice, includes its tests in the same change, and stops with a report before the next milestone begins.
+
+Milestone 0 is this completed design contract. Milestones 1 through 7 use the following stable atomic-unit IDs. Commas in one wave are the only planned overlap; arrows are hard ordering constraints. The atomic unit `M1` belongs to Milestone 3 and is distinct from the Milestone 1 parent issue.
+
+| Milestone | Atomic units | Dependency and parallel waves |
+| --- | --- | --- |
+| 1. Bootstrap | `B0` v1 coexistence identity/layout contract; `B1` prove native dependency compatibility and the exact `mizchi/bit` API, then create the CLI skeleton, help, and version; `B2` add the `c-plugin-v2` Nix package | `B0 -> B1 -> B2` |
+| 2. State foundation | `F0` runtime paths; `F1` domain/lock model; `F2` lock codec; `F3` ownership codec; `F4` atomic stores; `F5` cache scope; `F6` discovery; `F7` runtime composition; `C-init` init; `E0` Docker/init E2E | `F0,F1 -> F2,F3,F5,F6 -> F4,F7 -> C-init -> E0` |
+| 3. Local lifecycle | `M0` marketplace parsing; `M1` local/skill resolution; `R1` reconciliation; `C-sync`; `A1` `persist_and_sync`; `C-sync-r`; `C-add-local`; `C-remove`; `C-target-add`; `C-target-remove` | `M0,M1 -> R1 -> C-sync -> A1,C-sync-r -> C-add-local,C-target-add -> C-remove,C-target-remove` |
+| 4. GitHub lifecycle | `G0` frozen bit contract/adapter precondition; `G1` clone/checkout/HEAD; `G2` fetch/default branch; `G-add`; `G-update`; `G-update-r`; `G-cleanup` | `G0 -> G1 -> G2 -> G-add,G-cleanup -> G-update -> G-update-r` |
+| 5. Interactive input | `I1` selection state/TUI adapter; `I2` TTY policy; `I-add-kind`; `I-add-skill`; `I-remove`; `I-target-remove` | `I1 -> I2 -> I-add-kind,I-add-skill,I-remove,I-target-remove` |
+| 6. Marketplace authoring | `D0` common read model; `D1` format conversion; `D2` deterministic writes; `C-dev-sync` | `D0 -> D1 -> D2 -> C-dev-sync` |
+| 7. Final parity and cutover | `P1` full parity matrix; `P2` documentation/parity audit; `P3` cutover | `P1 -> P2 -> explicit cutover approval -> P3` |
+
+### Per-unit verification contract
+
+Each atomic unit includes its behavior and tests in the same change. `B0` verifies the documented v1/v2 paths and identities, that v1 remains untouched, and that the two versions never share a lock scope. `B1` proves one native build with all exact pinned dependencies and the exact `mizchi/bit` APIs, then runs targeted check, format, parser tests, and native build and observes real `--help`/`--version`, including the Admiral name `c-plugin`. `B2` builds and evaluates the `c-plugin-v2` Nix package and verifies that its executable runs while the v1 package remains unchanged. `F0` and `F1` test constructors, normalization, rejection, and synthetic homes; `F2` tests canonical round trip, JSON paths, strict failures, unsupported-version byte preservation, and top-level dispatch; `F3` tests strict ownership-state round trip; `F4` tests exclusive create, temporary-sibling rename, and failures before and after persistence; `F5` tests full SHA-256 vectors, metadata mismatch, canonicalization, moved locks, and two-lock cache isolation; `F6` tests nearest project, exact global, ignored/recursive descendants, the home boundary, and `-g`/`-r`; `F7` proves all runtime boundaries are injected and no real user path is touched; `C-init` tests project/global success, existing-file byte preservation, invalid scope, and repetition; `E0` builds the image/executable once and asserts isolated project/global init status, output, lock JSON, and host state.
+
+`M0` and `M1` use Claude/Cursor/Codex and local fixtures to test explicit kind/skill selection, duplicate identity, ordering, malformed manifests, and normalized paths. `R1` covers missing, stale, foreign, replaced, and broken links; missing/corrupt ownership state; precedence; removed targets; partial failure; idempotence; and cross-lock isolation. `C-sync` and `C-sync-r` add unit flows and clean-container E2E, including an externally edited lock and ignored recursive descendants. `A1` proves every successful mutation synchronizes the exact persisted candidate while cancel/no-op neither writes nor syncs, and that post-write sync failure is recoverable. `C-add-local`, `C-remove`, `C-target-add`, and `C-target-remove` each add unit and separate clean-container E2E asserting relevant status/output, canonical lock, links/state, repetition or selection, cleanup, and foreign-path preservation.
+
+`G0` consumes the exact APIs proved by `B1`, freezes the bit adapter contract, and tests its typed boundary and injected failure behavior without repeating dependency/API compatibility proof. `G1` and `G2` test scoped serialization, pins, fetch/default branch, partial failure, and two-lock isolation. `G-add` runs real bit-backed `totto2727-org/monorepo` unit/E2E and asserts lock, cache, links, output, and status. `G-update` and `G-update-r` add unit/E2E for pin advancement, local-source non-fetch, recursive/failure isolation, persisted synchronization, and unchanged sibling lock/cache/links. `G-cleanup` proves only the owning lock's final reference removes its cache, after link reconciliation.
+
+`I1` and `I2` test choose, preselection, cancel, empty selection, TTY detection, and required non-interactive options. `I-add-kind`, `I-add-skill`, `I-remove`, and `I-target-remove` each test prompt-to-domain mapping and receive a real-TTY manual observation; non-TTY regression tests forbid implicit defaults and select-all. `D0` and `D1` fixture-test all formats, normalized Codex local sources, installation policy, malformed input, conversion, and ordering. `D2` temporary-root tests owned-output replacement and unrelated-file preservation. `C-dev-sync` adds unit plus one clean-container E2E per source kind for generated/copy/preserved files, output, and status. `P1` runs every targeted check/format/build/unit test and the completed isolated Docker cross-scope matrix. `P2` audits every acceptance criterion against executable evidence and updates both documents together. Only after explicit approval, `P3` switches the executable/Nix entry with rollback, reruns `P1` against the cutover surface, and proves v1/v2 never shared a lock scope; it does not migrate locks.
+
+### Linear and native stack control plane
+
+- Use one umbrella Linear issue plus seven parents for Milestones 1 through 7. Each milestone parent is sequentially `blockedBy` its predecessor.
+- Create exactly one child for each active atomic unit. Do not pre-create future atomic issues; expand them just in time immediately before that milestone, after approval of its predecessor.
+- One atomic unit equals one commit, one native stack layer, and one PR. Use `codex/cpv2-m<N>-<unit>-<slug>` branches and preserve base-to-tip order.
+- Native GitHub stacked PR submission is a hard gate. Immediately before submission, recheck the REST API at version `2026-03-10` and the installed `gh` extension list. The currently observed `404` blocks submission.
+- Never silently fall back to conventional dependent PR chains or call them native stacks. Never install `gh-stack` silently. Once supported, use only the official `gh stack` commands referenced below.
+- Use team mode only for the comma-separated overlapping waves above, after shared contracts freeze, with an isolated worktree per worker. Arrows remain sequential.
+
+### Milestone rules
+
+- Do not begin a later milestone while the current milestone is incomplete or awaiting user review.
+- Stop after every milestone and wait for explicit approval before implementing the next one.
+- Keep each milestone as one coherent, reviewable change set. Do not pull future command stubs, unused abstractions, speculative compatibility code, or unrelated cleanup into an earlier milestone.
+- Add unit tests with the production behavior they protect. Testing is not deferred to the final milestone.
+- Add the Docker harness with Milestone 2 and add one E2E file whenever its leaf command first becomes available. Milestone 7 runs and audits the completed matrix rather than writing all E2E tests at once.
+- Every milestone must keep all previously delivered milestones green.
+- A dependency or upstream API incompatibility blocks only the active milestone. Record the evidence and revise this design before choosing a workaround.
+- Do not claim full c-plugin parity until Milestone 7 passes, even when an intermediate command is usable.
+- Stop after `P2`; `P1` and `P2` do not imply cutover approval, and `P3` starts only after explicit user approval.
+
+### Milestone completion gate
+
+A milestone is complete only when all of the following are true for its scope:
+
+1. The documented behavior is implemented without future-facing placeholders.
+2. Changed MoonBit packages pass targeted check, format, build, and unit-test commands.
+3. Every leaf command introduced so far passes its clean-container E2E success case.
+4. The real executable has been exercised through the user-facing command surface introduced by the milestone.
+5. The milestone report is written and clearly separates completed behavior from deferred behavior.
+
+### Milestone report format
+
+Every milestone handoff reports:
+
+- Milestone number and result.
+- User-visible behavior now available.
+- Files and architectural boundaries added or changed.
+- Exact unit, build, and E2E commands with their results.
+- Manual CLI observation performed against the built executable.
+- Known limitations and intentionally deferred commands.
+- Any dependency or upstream risk discovered.
+- The proposed scope of the next milestone.
+
+The report must state that work stopped at the milestone boundary. It must not describe deferred behavior as partially implemented or automatically continue into the next milestone.
+
+## Acceptance criteria
+
+- The command tree preserves `c-plugin skill` as the public skill-management namespace and exposes every documented leaf command with generated help and version output.
+- Project, recursive, and `-g` scopes resolve exactly as documented.
+- The global lock is `~/c-plugin-lock.json`, while global links remain under `~/.agents/skills`.
+- Internal path values are `Path` except at explicit string boundaries.
+- Repository caches are isolated by a full SHA-256 key derived from the normalized absolute owning lock path, and scope metadata prevents silent collision or cross-lock reuse.
+- No Git subprocess is invoked; clone, fetch, checkout, and HEAD resolution use the `mizchi/bit` library.
+- Lock JSON is strict, Lens-backed, canonical, and round-trips through `FromJson` and `ToJson`.
+- Unsupported lock versions fail without mutation; automatic migration and a migration command are not part of the current implementation.
+- Data-carrying enums dispatch once on their top-level `type` field.
+- Existing directories and managed outputs are idempotent, and foreign paths are never overwritten or deleted.
+- Machine-local ownership state lets `sync` remove stale c-plugin links after external lock edits without deleting replaced or unowned paths.
+- Every successful existing-lock mutation runs `sync` against the exact persisted value before returning.
+- All restored interactive selections work in a real TTY and all corresponding non-interactive options are deterministic.
+- Unit tests pass with all state isolated under temporary directories.
+- The Docker E2E image builds once, every leaf test runs in a discarded container, and every successful flow passes against the real executable.
+
+## Primary references
+
+- MoonBit toolchain and `moon install`: https://docs.moonbitlang.com/en/latest/toolchain/moon/commands.html
+- `moonbitlang/x/path.Path` public API: https://github.com/moonbitlang/x/blob/main/path/pkg.generated.mbti
+- Admiral: https://github.com/totto2727/admiral
+- mizchi/tui: https://github.com/mizchi/tui.mbt
+- mizchi/bit: https://github.com/bit-vcs/bit
+- GitHub REST repository path parameters: https://docs.github.com/en/rest/repos/contents
+- NIST Secure Hash Standard (FIPS 180-4): https://csrc.nist.gov/pubs/fips/180-4/upd1/final
+- MoonBit async filesystem API: https://github.com/moonbitlang/async/blob/main/src/fs/pkg.generated.mbti
+- Lens: https://github.com/totto2727-org/monorepo/tree/main/mbt/package/lens
+- target-file-discovery: https://github.com/totto2727-org/monorepo/tree/main/mbt/package/target-file-discovery
+- GitHub stacked pull requests public preview: https://github.blog/changelog/2026-07-30-stacked-pull-requests-are-now-in-public-preview/
+- GitHub stacked pull requests overview: https://docs.github.com/en/pull-requests/get-started/about-stacked-prs
+- Official stacked PR CLI commands: https://docs.github.com/en/pull-requests/reference/stacked-prs-cli-commands
+- GitHub REST pull-request stacks API (`2026-03-10`): https://docs.github.com/en/rest/pulls/stacks?apiVersion=2026-03-10


### PR DESCRIPTION
## 概要

c-plugin v2の技術方針、コマンド体系、ロック・所有権・キャッシュ契約、段階的マイルストーン、atomic Issue/commit/PR運用を英語版と日本語版で定義します。

Linear: [TOT-77](https://linear.app/totto2727/issue/TOT-77)

## 処理フロー

```mermaid
flowchart TD
  A["要件と既存v1の挙動"] --> B["v2の不変条件を定義"]
  B --> C["atomic unitと依存関係を定義"]
  C --> D["マイルストーン承認境界を定義"]
```

## 確認

```mermaid
flowchart TD
  A["README英語版"] --> C["方針が一致"]
  B["README日本語版"] --> C
  C --> D["実装前契約として利用可能"]
```

- 英語版と日本語版の内容対応を確認
- mdtは使用せず手動翻訳
- 新バージョンへのmigrateは現時点で対象外

## CI status

- Latest commit SHA: `7e3ad85`
- Latest `check` job: success (run id: `31019344435`, attempt: 2)
- Retry history:
  - commit `f2cdab4`: attempt 1 failure (Markdown format) -> fix push `7e3ad85` attempt 2 success