### PR TITLE
c-plugin v2のlock discovery adapterを実装

### DIFF
--- a/mbt/app/c-plugin-v2/src/lock_discovery.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_discovery.mbt
@@ -1,0 +1,115 @@
+///|
+pub(all) enum LockDiscoveryScope {
+  Project
+  Global
+} derive(Debug, Eq)
+
+///|
+pub struct LockDiscoveryOptions {
+  scope : LockDiscoveryScope
+  recursive : Bool
+}
+
+///|
+pub fn LockDiscoveryOptions::LockDiscoveryOptions(
+  scope : LockDiscoveryScope,
+  recursive : Bool,
+) -> LockDiscoveryOptions {
+  { scope, recursive }
+}
+
+///|
+pub(all) suberror LockDiscoveryError {
+  GlobalRecursiveUnsupported
+  LockFileNotFound(scope~ : LockDiscoveryScope, boundary~ : @path.Path)
+} derive(Debug)
+
+///|
+let lock_file_name = "c-plugin-lock.json"
+
+///|
+fn path_is_within(base : @path.Path, target : @path.Path) -> Bool {
+  let normalized_base = base.normalize()
+  let mut current = target.normalize()
+  while current != normalized_base {
+    let parent = current.dirname()
+    if parent == current {
+      return false
+    }
+    current = parent
+  }
+  true
+}
+
+///|
+async fn find_project_lock(
+  home : @path.Path,
+  cwd : @path.Path,
+) -> @path.Path raise LockDiscoveryError {
+  guard path_is_within(home, cwd) else {
+    raise LockFileNotFound(scope=Project, boundary=home)
+  }
+  let discovered = @target_file_discovery.find_parent_target_file(
+    lock_file_name,
+    home.to_string(),
+    cwd.to_string(),
+  ) catch {
+    _ => raise LockFileNotFound(scope=Project, boundary=home)
+  }
+  let path : @path.Path = discovered
+  path.normalize()
+}
+
+///|
+async fn find_global_lock(
+  home : @path.Path,
+) -> @path.Path raise LockDiscoveryError {
+  let discovered = @target_file_discovery.find_home_target_file(
+    home.to_string(),
+    lock_file_name,
+  ) catch {
+    _ => raise LockFileNotFound(scope=Global, boundary=home)
+  }
+  let path : @path.Path = discovered
+  path.normalize()
+}
+
+///|
+async fn find_recursive_project_locks(
+  home : @path.Path,
+  nearest_lock : @path.Path,
+) -> ReadOnlyArray[@path.Path] raise LockDiscoveryError {
+  let discovered = @target_file_discovery.collect_recursive_target_files(
+    nearest_lock.dirname().to_string(),
+    lock_file_name,
+  ) catch {
+    _ => raise LockFileNotFound(scope=Project, boundary=home)
+  }
+  ReadOnlyArray::from_array(
+    discovered[:].map(path => {
+      let normalized_path : @path.Path = path
+      normalized_path.normalize()
+    }),
+  )
+}
+
+///|
+pub async fn discover_locks(
+  paths : RuntimePaths,
+  options : LockDiscoveryOptions,
+) -> ReadOnlyArray[@path.Path] raise LockDiscoveryError {
+  match options.scope {
+    Global => {
+      guard !options.recursive else { raise GlobalRecursiveUnsupported }
+      ReadOnlyArray::from_array([find_global_lock(paths.home)])
+    }
+    Project => {
+      let nearest_lock = find_project_lock(paths.home, paths.cwd)
+      if options.recursive {
+        find_recursive_project_locks(paths.home, nearest_lock)
+      } else {
+        ReadOnlyArray::from_array([nearest_lock])
+      }
+    }
+  }
+}

--- a/mbt/app/c-plugin-v2/src/lock_discovery_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_discovery_wbtest.mbt
@@ -1,0 +1,268 @@
+///|
+struct LockDiscoveryFixture {
+  root : @path.Path
+  paths : RuntimePaths
+}
+
+///|
+async fn with_lock_discovery_fixture(
+  action : async (LockDiscoveryFixture) -> Unit,
+) -> Unit {
+  let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-lock-discovery-")
+  let home = root.join("home")
+  let cwd = home.join("workspace").join("package").join("source")
+  let cache_root = root.join("cache")
+  @fs.mkdir(cwd.to_string(), recursive=true)
+  @fs.mkdir(cache_root.to_string(), recursive=true)
+  let fixture = {
+    root,
+    paths: RuntimePaths::RuntimePaths(home, cwd, cache_root),
+  }
+  action(fixture) catch {
+    error => {
+      @async.protect_from_cancel(async fn() {
+        @fs.rmdir(root.to_string(), recursive=true)
+      })
+      raise error
+    }
+  }
+  @fs.rmdir(root.to_string(), recursive=true)
+}
+
+///|
+async fn write_lock(path : @path.Path) -> @path.Path {
+  @fs.mkdir(path.dirname().to_string(), recursive=true) catch {
+    _ => ()
+  }
+  @fs.write_file(path.to_string(), "{}", create_mode=CreateOrTruncate)
+  path
+}
+
+///|
+async test "discover_locks - finds the nearest project lock below the synthetic home" {
+  with_lock_discovery_fixture(async fn(fixture) {
+    let outer_lock = write_lock(
+      fixture.paths.home.join("workspace").join("c-plugin-lock.json"),
+    )
+    let nearest_lock = write_lock(
+      fixture.paths.home
+      .join("workspace")
+      .join("package")
+      .join("c-plugin-lock.json"),
+    )
+    let locks = discover_locks(
+      fixture.paths,
+      LockDiscoveryOptions::LockDiscoveryOptions(
+        LockDiscoveryScope::Project,
+        false,
+      ),
+    )
+    inspect(locks[0].to_string(), content=nearest_lock.to_string())
+    assert_false(locks.contains(outer_lock))
+  })
+}
+
+///|
+async test "discover_locks - resolves the global lock exactly below the synthetic home" {
+  with_lock_discovery_fixture(async fn(fixture) {
+    let global_lock = write_lock(fixture.paths.home.join("c-plugin-lock.json"))
+    let _project_lock = write_lock(
+      fixture.paths.home
+      .join("workspace")
+      .join("package")
+      .join("c-plugin-lock.json"),
+    )
+    let locks = discover_locks(
+      fixture.paths,
+      LockDiscoveryOptions::LockDiscoveryOptions(
+        LockDiscoveryScope::Global,
+        false,
+      ),
+    )
+    inspect(locks[0].to_string(), content=global_lock.to_string())
+  })
+}
+
+///|
+async test "discover_locks - includes the nearest project lock and visible descendants recursively" {
+  with_lock_discovery_fixture(async fn(fixture) {
+    let nearest_lock = write_lock(
+      fixture.paths.home
+      .join("workspace")
+      .join("package")
+      .join("c-plugin-lock.json"),
+    )
+    let child_lock = write_lock(
+      fixture.paths.home
+      .join("workspace")
+      .join("package")
+      .join("child")
+      .join("c-plugin-lock.json"),
+    )
+    let nested_lock = write_lock(
+      fixture.paths.home
+      .join("workspace")
+      .join("package")
+      .join("child")
+      .join("nested")
+      .join("c-plugin-lock.json"),
+    )
+    let locks = discover_locks(
+      fixture.paths,
+      LockDiscoveryOptions::LockDiscoveryOptions(
+        LockDiscoveryScope::Project,
+        true,
+      ),
+    )
+    assert_true(locks.contains(nearest_lock))
+    assert_true(locks.contains(child_lock))
+    assert_true(locks.contains(nested_lock))
+  })
+}
+
+///|
+async test "discover_locks - excludes descendants in gitignored directories" {
+  with_lock_discovery_fixture(async fn(fixture) {
+    let project_root = fixture.paths.home.join("workspace").join("package")
+    let nearest_lock = write_lock(project_root.join("c-plugin-lock.json"))
+    @fs.write_file(
+      project_root.join(".gitignore").to_string(),
+      "ignored/\n",
+      create_mode=CreateOrTruncate,
+    )
+    let visible_lock = write_lock(
+      project_root.join("visible").join("c-plugin-lock.json"),
+    )
+    let ignored_lock = write_lock(
+      project_root.join("ignored").join("c-plugin-lock.json"),
+    )
+    let locks = discover_locks(
+      fixture.paths,
+      LockDiscoveryOptions::LockDiscoveryOptions(
+        LockDiscoveryScope::Project,
+        true,
+      ),
+    )
+    assert_true(locks.contains(nearest_lock))
+    assert_true(locks.contains(visible_lock))
+    assert_false(locks.contains(ignored_lock))
+  })
+}
+
+///|
+async test "discover_locks - does not search for project locks above the synthetic home" {
+  with_lock_discovery_fixture(async fn(fixture) {
+    let outside_lock = write_lock(fixture.root.join("c-plugin-lock.json"))
+    let detail = try {
+      discover_locks(
+        fixture.paths,
+        LockDiscoveryOptions::LockDiscoveryOptions(
+          LockDiscoveryScope::Project,
+          false,
+        ),
+      )
+      |> ignore
+      "no error"
+    } catch {
+      LockFileNotFound(scope=Project, boundary~) => boundary.to_string()
+      _ => "wrong error"
+    }
+    inspect(detail, content=fixture.paths.home.to_string())
+    assert_true(@fs.exists(outside_lock.to_string()))
+  })
+}
+
+///|
+async test "discover_locks - rejects global recursive discovery before reading locks" {
+  with_lock_discovery_fixture(async fn(fixture) {
+    let detail = try {
+      discover_locks(
+        fixture.paths,
+        LockDiscoveryOptions::LockDiscoveryOptions(
+          LockDiscoveryScope::Global,
+          true,
+        ),
+      )
+      |> ignore
+      "no error"
+    } catch {
+      GlobalRecursiveUnsupported => "global recursive unsupported"
+      _ => "wrong error"
+    }
+    inspect(detail, content="global recursive unsupported")
+  })
+}
+
+///|
+async test "discover_locks - reports a typed error when no project lock exists" {
+  with_lock_discovery_fixture(async fn(fixture) {
+    let detail = try {
+      discover_locks(
+        fixture.paths,
+        LockDiscoveryOptions::LockDiscoveryOptions(
+          LockDiscoveryScope::Project,
+          false,
+        ),
+      )
+      |> ignore
+      "no error"
+    } catch {
+      LockFileNotFound(scope=Project, boundary~) => boundary.to_string()
+      _ => "wrong error"
+    }
+    inspect(detail, content=fixture.paths.home.to_string())
+  })
+}
+
+///|
+async test "discover_locks - rejects a cwd outside the synthetic home" {
+  with_lock_discovery_fixture(async fn(fixture) {
+    let outside_cwd = fixture.root.join("outside").join("source")
+    let outside_lock = write_lock(
+      fixture.root.join("outside").join("c-plugin-lock.json"),
+    )
+    @fs.mkdir(outside_cwd.to_string(), recursive=true)
+    let paths = RuntimePaths::RuntimePaths(
+      fixture.paths.home,
+      outside_cwd,
+      fixture.paths.cache_root,
+    )
+    let detail = try {
+      discover_locks(
+        paths,
+        LockDiscoveryOptions::LockDiscoveryOptions(
+          LockDiscoveryScope::Project,
+          false,
+        ),
+      )
+      |> ignore
+      "no error"
+    } catch {
+      LockFileNotFound(scope=Project, boundary~) => boundary.to_string()
+      _ => "wrong error"
+    }
+    inspect(detail, content=fixture.paths.home.to_string())
+    assert_true(@fs.exists(outside_lock.to_string()))
+  })
+}
+
+///|
+async test "discover_locks - reports a typed error when no global lock exists" {
+  with_lock_discovery_fixture(async fn(fixture) {
+    let detail = try {
+      discover_locks(
+        fixture.paths,
+        LockDiscoveryOptions::LockDiscoveryOptions(
+          LockDiscoveryScope::Global,
+          false,
+        ),
+      )
+      |> ignore
+      "no error"
+    } catch {
+      LockFileNotFound(scope=Global, boundary~) => boundary.to_string()
+      _ => "wrong error"
+    }
+    inspect(detail, content=fixture.paths.home.to_string())
+  })
+}

--- a/mbt/app/c-plugin-v2/src/moon.pkg
+++ b/mbt/app/c-plugin-v2/src/moon.pkg
@@ -6,6 +6,7 @@ import {
   "shu-kitamura/sha256",
   "totto2727/admiral",
   "totto2727/lens",
+  "totto2727/target-file-discovery" @target_file_discovery,
 }
 
 import {
@@ -14,7 +15,6 @@ import {
   "mizchi/bit_osfs",
   "mizchi/tui",
   "moonbitlang/async/fs",
-  "totto2727/target-file-discovery" @target_file_discovery,
 } for "wbtest"
 
 supported_targets = "native"


### PR DESCRIPTION
## 概要

`totto2727/target-file-discovery` の String API を単一 adapter 境界に閉じ込め、内部では正規化済み `Path` を保持する project/global/recursive lock discovery を実装します。project は synthetic home 境界内の nearest lock、global は home 直下 exact、recursive は nearest lock root と gitignore-aware descendants を返します。project 探索は `cwd` が `home` の外側にある場合、外部lockを読む前にtyped errorで拒否します。

Linear: [TOT-93](https://linear.app/totto2727/issue/TOT-93)

依存PR: #256

## 処理フロー

```mermaid
flowchart TD
  A["LockDiscoveryOptions"] --> B{"scope"}
  B -->|Global| C{"recursive"}
  C -->|true| D["GlobalRecursiveUnsupported"]
  C -->|false| E["home/c-plugin-lock.json exact"]
  B -->|Project| F{"cwd is within home"}
  F -->|false| G["LockFileNotFound"]
  F -->|true| H["home境界までnearestを探索"]
  H --> I{"recursive"}
  I -->|false| J["nearest lock"]
  I -->|true| K["nearest root + gitignore-aware descendants"]
  E --> L["ReadOnlyArray Path"]
  J --> L
  K --> L
```

## テスト条件

```mermaid
flowchart TD
  A["synthetic tmp tree"] --> B["nearest project"]
  A --> C["exact global"]
  A --> D["recursive descendants"]
  A --> E["gitignored descendant除外"]
  A --> F["home boundary"]
  A --> G["cwd outside home拒否"]
  A --> H["global+recursive拒否"]
  A --> I["project/global missing typed errors"]
```

- `moon check mbt/app/c-plugin-v2/src --target native`: 成功
- `moon test mbt/app/c-plugin-v2/src/lock_discovery_wbtest.mbt --target native`: 9/9
- `moon test mbt/app/c-plugin-v2/src --target native`: 64/64
- `moon build mbt/app/c-plugin-v2/src --target native`: 成功
- `git diff --check`: 成功
- F6のnon-merge commit: 1件
- exact-SHA review: goal / QA / code quality / security / context / runtime audit すべてPASS

## CI status

- Latest commit SHA: `f27a02ee446dd1bde44254c96047e3e1b0d16afe`
- Dependency-base head: `de765ee05b54d0b98ca0a1f239c00bd15a6a838b`
- Run: [31187709591](https://github.com/totto2727-org/monorepo/actions/runs/31187709591)
- Attempt 2: success
- Attempt 1: 無関係なcodex-sdk testのprocess spawnがrunner資源枯渇で失敗したため、failed jobのみ再実行
