### PR TITLE
TOT-91: atomic state storeを実装

### DIFF
--- a/mbt/app/c-plugin-v2/src/moon.pkg
+++ b/mbt/app/c-plugin-v2/src/moon.pkg
@@ -1,5 +1,7 @@
 import {
   "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/async/os_error",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
   "moonbitlang/x/path",
@@ -14,7 +16,6 @@ import {
   "mizchi/bit_lib/native" @bit_native,
   "mizchi/bit_osfs",
   "mizchi/tui",
-  "moonbitlang/async/fs",
 } for "wbtest"
 
 supported_targets = "native"

--- a/mbt/app/c-plugin-v2/src/state_store.mbt
+++ b/mbt/app/c-plugin-v2/src/state_store.mbt
@@ -1,0 +1,117 @@
+///|
+/// Typed failures returned by lock and ownership-state persistence operations.
+pub(all) suberror StateStoreError {
+  AlreadyExists(path~ : @path.Path)
+  Decode(path~ : @path.Path, reason~ : String)
+  IO(path~ : @path.Path, reason~ : String)
+} derive(Debug, Eq)
+
+///|
+async fn read_json(path : @path.Path) -> Json raise StateStoreError {
+  let text = @fs.read_file(path.to_string()).text() catch {
+    error => raise IO(path~, reason=error.to_string())
+  }
+  @json.parse(text) catch {
+    error => raise Decode(path~, reason=error.to_string())
+  }
+}
+
+///|
+/// Load and decode a lock without modifying its bytes on failure.
+pub async fn load_lock(path : @path.Path) -> Lock raise StateStoreError {
+  let json = read_json(path)
+  @json.from_json(json) catch {
+    error => raise Decode(path~, reason=error.to_string())
+  }
+}
+
+///|
+/// Load and decode ownership state without modifying its bytes on failure.
+pub async fn load_ownership_state(
+  path : @path.Path,
+) -> OwnershipState raise StateStoreError {
+  let json = read_json(path)
+  @json.from_json(json) catch {
+    error => raise Decode(path~, reason=error.to_string())
+  }
+}
+
+///|
+async fn ensure_parent(path : @path.Path) -> Unit raise StateStoreError {
+  @fs.mkdir(path.dirname().to_string(), recursive=true) catch {
+    @os_error.OSError(_) as error if error.is_EEXIST() => ()
+    error => raise IO(path~, reason=error.to_string())
+  }
+}
+
+///|
+/// Create a lock only when no file already exists at the target path.
+pub async fn create_lock_exclusive(
+  path : @path.Path,
+  lock : Lock,
+) -> Unit raise StateStoreError {
+  ensure_parent(path)
+  @fs.write_file(
+    path.to_string(),
+    lock.to_pretty_json(),
+    create_mode=CreateNew,
+    sync=Full,
+  ) catch {
+    @os_error.OSError(_) as error if error.is_EEXIST() =>
+      raise AlreadyExists(path~)
+    error => raise IO(path~, reason=error.to_string())
+  }
+}
+
+///|
+async fn replace_atomically(
+  path : @path.Path,
+  content : String,
+) -> Unit raise StateStoreError {
+  ensure_parent(path)
+  let temporary_path = path.dirname().join(path.basename().to_owned() + ".tmp")
+  let temporary_file = @fs.open(
+    temporary_path.to_string(),
+    mode=WriteOnly,
+    create_mode=CreateNew,
+    sync=Full,
+  ) catch {
+    error => raise IO(path=temporary_path, reason=error.to_string())
+  }
+  temporary_file.write(content) catch {
+    error => {
+      temporary_file.close()
+      @fs.remove(temporary_path.to_string()) catch {
+        _ => ()
+      }
+      raise IO(path=temporary_path, reason=error.to_string())
+    }
+  }
+  temporary_file.close()
+  @fs.rename(temporary_path.to_string(), path.to_string(), replace=true) catch {
+    error => {
+      @fs.remove(temporary_path.to_string()) catch {
+        _ => ()
+      }
+      raise IO(path~, reason=error.to_string())
+    }
+  }
+}
+
+///|
+/// Atomically replace a lock through an exclusive temporary sibling.
+pub async fn write_lock_atomic(
+  path : @path.Path,
+  lock : Lock,
+) -> Unit raise StateStoreError {
+  replace_atomically(path, lock.to_pretty_json())
+}
+
+///|
+/// Atomically replace ownership state through an exclusive temporary sibling.
+pub async fn write_ownership_state_atomic(
+  path : @path.Path,
+  state : OwnershipState,
+) -> Unit raise StateStoreError {
+  replace_atomically(path, ToJson::to_json(state).stringify(indent=2) + "\n")
+}

--- a/mbt/app/c-plugin-v2/src/state_store_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/state_store_wbtest.mbt
@@ -1,0 +1,158 @@
+///|
+fn empty_test_lock() -> Lock raise {
+  Lock::Lock([], [])
+}
+
+///|
+fn alternate_test_lock() -> Lock raise {
+  Lock::Lock([Target::Target(".agents/skills")], [])
+}
+
+///|
+async test "StateStore create_lock_exclusive - creates once and preserves existing bytes" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-state-store-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let path = root.join("nested").join("c-plugin-lock.json")
+    create_lock_exclusive(path, empty_test_lock())
+    let original = @fs.read_file(path.to_string()).text()
+    try create_lock_exclusive(path, alternate_test_lock()) catch {
+      StateStoreError::AlreadyExists(path=error_path) =>
+        inspect(error_path == path, content="true")
+      _ => fail("expected AlreadyExists")
+    } noraise {
+      _ => fail("second exclusive create must fail")
+    }
+    inspect(@fs.read_file(path.to_string()).text(), content=original)
+  }
+}
+
+///|
+async test "StateStore write_lock_atomic - replaces the target and removes its temporary sibling" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-state-store-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let path = root.join("c-plugin-lock.json")
+    @fs.write_file(path.to_string(), "old bytes", create_mode=CreateNew)
+    let lock = alternate_test_lock()
+    write_lock_atomic(path, lock)
+    inspect(
+      @fs.read_file(path.to_string()).text(),
+      content=lock.to_pretty_json(),
+    )
+    let temporary_path = path
+      .dirname()
+      .join(path.basename().to_owned() + ".tmp")
+    inspect(@fs.exists(temporary_path.to_string()), content="false")
+    inspect(load_lock(path) == lock, content="true")
+  }
+}
+
+///|
+async test "StateStore write_ownership_state_atomic - replaces the target and removes its temporary sibling" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-state-store-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let path = root.join("nested").join("c-plugin-state.json")
+    let state = OwnershipState::OwnershipState([])
+    write_ownership_state_atomic(path, state)
+    inspect(load_ownership_state(path) == state, content="true")
+    let temporary_path = path
+      .dirname()
+      .join(path.basename().to_owned() + ".tmp")
+    inspect(@fs.exists(temporary_path.to_string()), content="false")
+  }
+}
+
+///|
+async test "StateStore load_lock - corrupt bytes are preserved" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-state-store-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let path = root.join("c-plugin-lock.json")
+    let corrupt = "{not-json\n"
+    @fs.write_file(path.to_string(), corrupt, create_mode=CreateNew)
+    try load_lock(path) catch {
+      StateStoreError::Decode(path=error_path, reason=_) =>
+        inspect(error_path == path, content="true")
+      _ => fail("expected Decode")
+    } noraise {
+      _ => fail("corrupt lock must fail")
+    }
+    inspect(@fs.read_file(path.to_string()).text(), content=corrupt)
+  }
+}
+
+///|
+async test "StateStore load_lock - unsupported version bytes are preserved" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-state-store-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let path = root.join("c-plugin-lock.json")
+    let unsupported = "{\"version\":\"1\",\"targets\":[],\"repositories\":[]}"
+    @fs.write_file(path.to_string(), unsupported, create_mode=CreateNew)
+    try load_lock(path) catch {
+      StateStoreError::Decode(path=error_path, reason=_) =>
+        inspect(error_path == path, content="true")
+      _ => fail("expected Decode")
+    } noraise {
+      _ => fail("unsupported lock must fail")
+    }
+    inspect(@fs.read_file(path.to_string()).text(), content=unsupported)
+  }
+}
+
+///|
+async test "StateStore write_lock_atomic - a stale temporary sibling preserves the existing target" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-state-store-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let path = root.join("c-plugin-lock.json")
+    let temporary_path = path
+      .dirname()
+      .join(path.basename().to_owned() + ".tmp")
+    @fs.write_file(path.to_string(), "old bytes", create_mode=CreateNew)
+    @fs.write_file(
+      temporary_path.to_string(),
+      "stale temp",
+      create_mode=CreateNew,
+    )
+    try write_lock_atomic(path, alternate_test_lock()) catch {
+      StateStoreError::IO(path=error_path, reason=_) =>
+        inspect(error_path == temporary_path, content="true")
+      _ => fail("expected IO")
+    } noraise {
+      _ => fail("stale temp must fail before rename")
+    }
+    inspect(@fs.read_file(path.to_string()).text(), content="old bytes")
+    inspect(
+      @fs.read_file(temporary_path.to_string()).text(),
+      content="stale temp",
+    )
+  }
+}
+
+///|
+async test "StateStore write_lock_atomic - a rename failure removes the new temp and preserves the target directory" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-state-store-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let path = root.join("c-plugin-lock.json")
+    @fs.mkdir(path.to_string())
+    try write_lock_atomic(path, alternate_test_lock()) catch {
+      StateStoreError::IO(path=error_path, reason=_) =>
+        inspect(error_path == path, content="true")
+      _ => fail("expected IO")
+    } noraise {
+      _ => fail("rename over a directory must fail")
+    }
+    inspect(
+      @fs.kind(path.to_string()) == @fs.FileKind::Directory,
+      content="true",
+    )
+    let temporary_path = path
+      .dirname()
+      .join(path.basename().to_owned() + ".tmp")
+    inspect(@fs.exists(temporary_path.to_string()), content="false")
+  }
+}


### PR DESCRIPTION
## 概要

- TOT-91: lock と ownership state の読み込み・永続化を型付きエラー境界で実装
- init 向けの排他的作成と、更新向けの同一ディレクトリ一時ファイル・Full sync・atomic rename を追加
- stale temp、書き込み・rename 失敗、壊れた JSON、未対応 version でも既存データを保持
- 更新済み plugin 規約に従い、Path を内部で維持し、不要な `priv` や単純アクセサを追加せず、公開 API とテストを整備
- main package では black-box test が将来非対応になる Moon warning を避けるため、既存パッケージと同じ `_wbtest.mbt` に配置

## 処理フロー

```mermaid
flowchart TD
  A["検証済み Lock / OwnershipState"] --> B["canonical JSON を生成"]
  B --> C{"作成か更新か"}
  C -->|init| D["CreateNew で排他的作成"]
  C -->|update| E["同一ディレクトリの .tmp を CreateNew"]
  E --> F["write + Full sync"]
  F --> G["atomic rename (replace)"]
  E -->|既存 .tmp| H["対象と既存 .tmp を保持して失敗"]
  F -->|write 失敗| I["自分が作成した .tmp のみ削除"]
  G -->|rename 失敗| I
```

## テスト条件

```mermaid
flowchart LR
  A["排他的作成"] --> A1["初回成功"]
  A --> A2["2回目は AlreadyExists・既存 bytes 保持"]
  B["atomic 更新"] --> B1["lock を置換・tmp 削除"]
  B --> B2["ownership state を置換・tmp 削除"]
  C["読み込み失敗"] --> C1["壊れた JSON の bytes 保持"]
  C --> C2["未対応 version の bytes 保持"]
  D["更新失敗"] --> D1["stale temp と対象を保持"]
  D --> D2["rename 失敗で owned temp のみ削除"]
```

## 検証

- `moon test mbt/app/c-plugin-v2/src/state_store_wbtest.mbt --target native`：7 / 7
- `moon check`：成功
- `LD_LIBRARY_PATH="$MOONBIT_OPENSSL_LIBRARY_PATH" moon test --no-parallelize`：wasm-gc 579 / 579、native 359 / 359
- `moon build`：成功
- `git diff --check`：成功
- Vite+ wrapper は、この worktree で JS 依存 `@totto2727/fp/vite` が未セットアップのため task graph 読み込み前に停止。上記の基盤 Moon コマンドを repository root から直接実行して確認

## Stack

- Base: PR #257 / `f27a02ee446dd1bde44254c96047e3e1b0d16afe`
- Head: `b0511f40199811c745992ae5784b0c36b7217147`
- Linear: TOT-91
- Exact-SHA CI: run `31191981950`、watch `EXIT=0`、API `conclusion=success`
- Exact-SHA review: goal / QA / code quality / security / context / runtime の 6 lane すべて PASS
- GitHub feedback: unresolved thread 0、inline review comment 0