### PR TITLE
TOT-94: injectable runtime境界を実装

### DIFF
--- a/mbt/app/c-plugin-v2/src/runtime.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime.mbt
@@ -1,0 +1,108 @@
+///|
+/// Injectable composition root for runtime paths, persistence, and discovery.
+pub struct Runtime {
+  paths : RuntimePaths
+  discover_locks_api : async (RuntimePaths, LockDiscoveryOptions) -> ReadOnlyArray[
+    @path.Path,
+  ] raise LockDiscoveryError
+  load_lock : async (@path.Path) -> Lock raise StateStoreError
+  create_lock_exclusive : async (@path.Path, Lock) -> Unit raise StateStoreError
+  write_lock_atomic : async (@path.Path, Lock) -> Unit raise StateStoreError
+  load_ownership_state : async (@path.Path) -> OwnershipState raise StateStoreError
+  write_ownership_state_atomic : async (@path.Path, OwnershipState) -> Unit raise StateStoreError
+}
+
+///|
+/// Create a runtime from explicit path, storage, and discovery callbacks.
+pub fn Runtime::Runtime(
+  paths~ : RuntimePaths,
+  discover_locks_api~ : async (RuntimePaths, LockDiscoveryOptions) -> ReadOnlyArray[
+    @path.Path,
+  ] raise LockDiscoveryError,
+  load_lock~ : async (@path.Path) -> Lock raise StateStoreError,
+  create_lock_exclusive~ : async (@path.Path, Lock) -> Unit raise StateStoreError,
+  write_lock_atomic~ : async (@path.Path, Lock) -> Unit raise StateStoreError,
+  load_ownership_state~ : async (@path.Path) -> OwnershipState raise StateStoreError,
+  write_ownership_state_atomic~ : async (@path.Path, OwnershipState) -> Unit raise StateStoreError,
+) -> Runtime {
+  {
+    paths,
+    discover_locks_api,
+    load_lock,
+    create_lock_exclusive,
+    write_lock_atomic,
+    load_ownership_state,
+    write_ownership_state_atomic,
+  }
+}
+
+///|
+/// Return the lock path for the runtime working directory.
+pub fn Runtime::project_lock_path(
+  self : Runtime,
+) -> @path.Path raise RuntimePathsError {
+  self.paths.project_lock_path(self.paths.cwd)
+}
+
+///|
+/// Return the lock path for the runtime home directory.
+pub fn Runtime::global_lock_path(self : Runtime) -> @path.Path {
+  self.paths.global_lock_path()
+}
+
+///|
+/// Discover lock files with the injected runtime paths.
+pub async fn Runtime::discover_locks(
+  self : Runtime,
+  options : LockDiscoveryOptions,
+) -> ReadOnlyArray[@path.Path] raise LockDiscoveryError {
+  (self.discover_locks_api)(self.paths, options)
+}
+
+///|
+/// Load a lock through the injected state store.
+pub async fn Runtime::load_lock(
+  self : Runtime,
+  path : @path.Path,
+) -> Lock raise StateStoreError {
+  (self.load_lock)(path)
+}
+
+///|
+/// Exclusively create a lock through the injected state store.
+pub async fn Runtime::create_lock_exclusive(
+  self : Runtime,
+  path : @path.Path,
+  lock : Lock,
+) -> Unit raise StateStoreError {
+  (self.create_lock_exclusive)(path, lock)
+}
+
+///|
+/// Atomically write a lock through the injected state store.
+pub async fn Runtime::write_lock_atomic(
+  self : Runtime,
+  path : @path.Path,
+  lock : Lock,
+) -> Unit raise StateStoreError {
+  (self.write_lock_atomic)(path, lock)
+}
+
+///|
+/// Load ownership state through the injected state store.
+pub async fn Runtime::load_ownership_state(
+  self : Runtime,
+  path : @path.Path,
+) -> OwnershipState raise StateStoreError {
+  (self.load_ownership_state)(path)
+}
+
+///|
+/// Atomically write ownership state through the injected state store.
+pub async fn Runtime::write_ownership_state_atomic(
+  self : Runtime,
+  path : @path.Path,
+  state : OwnershipState,
+) -> Unit raise StateStoreError {
+  (self.write_ownership_state_atomic)(path, state)
+}

--- a/mbt/app/c-plugin-v2/src/runtime_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime_wbtest.mbt
@@ -1,0 +1,106 @@
+///|
+async test "Runtime discover_locks - injects synthetic runtime paths" {
+  let paths = RuntimePaths::RuntimePaths(
+    "/synthetic/home", "/synthetic/work/project", "/synthetic/cache",
+  )
+  let lock = Lock::Lock([], [])
+  let ownership_state = OwnershipState::OwnershipState([])
+  let mut received = []
+  let runtime = Runtime::Runtime(
+    paths~,
+    discover_locks_api=fn(runtime_paths, _options) {
+      received = [
+        runtime_paths.home,
+        runtime_paths.cwd,
+        runtime_paths.cache_root,
+      ]
+      ReadOnlyArray::from_array([runtime_paths.cwd.join("c-plugin-lock.json")])
+    },
+    load_lock=fn(_path) { lock },
+    create_lock_exclusive=fn(_path, _lock) { () },
+    write_lock_atomic=fn(_path, _lock) { () },
+    load_ownership_state=fn(_path) { ownership_state },
+    write_ownership_state_atomic=fn(_path, _state) { () },
+  )
+
+  let discovered = runtime.discover_locks(
+    LockDiscoveryOptions::LockDiscoveryOptions(
+      LockDiscoveryScope::Project,
+      false,
+    ),
+  )
+
+  inspect(received[0].to_string(), content="/synthetic/home")
+  inspect(received[1].to_string(), content="/synthetic/work/project")
+  inspect(received[2].to_string(), content="/synthetic/cache")
+  inspect(
+    discovered[0].to_string(),
+    content="/synthetic/work/project/c-plugin-lock.json",
+  )
+  inspect(
+    runtime.project_lock_path().to_string(),
+    content="/synthetic/work/project/c-plugin-lock.json",
+  )
+  inspect(
+    runtime.global_lock_path().to_string(),
+    content="/synthetic/home/c-plugin-lock.json",
+  )
+}
+
+///|
+async test "Runtime storage callbacks - forward synthetic paths and typed values" {
+  let paths = RuntimePaths::RuntimePaths(
+    "/synthetic/home", "/synthetic/work/project", "/synthetic/cache",
+  )
+  let lock = Lock::Lock([], [])
+  let ownership_state = OwnershipState::OwnershipState([])
+  let lock_path : @path.Path = "/synthetic/work/project/c-plugin-lock.json"
+  let ownership_path : @path.Path = "/synthetic/work/project/.agents/c-plugin-state.json"
+  let mut received_paths = []
+  let mut received_lock = None
+  let mut received_ownership_state = None
+  let runtime = Runtime::Runtime(
+    paths~,
+    discover_locks_api=fn(_paths, _options) { ReadOnlyArray::from_array([]) },
+    load_lock=fn(path) {
+      received_paths = [..received_paths, path]
+      lock
+    },
+    create_lock_exclusive=fn(path, received) {
+      received_paths = [..received_paths, path]
+      received_lock = Some(received)
+    },
+    write_lock_atomic=fn(path, received) {
+      received_paths = [..received_paths, path]
+      received_lock = Some(received)
+    },
+    load_ownership_state=fn(path) {
+      received_paths = [..received_paths, path]
+      ownership_state
+    },
+    write_ownership_state_atomic=fn(path, received) {
+      received_paths = [..received_paths, path]
+      received_ownership_state = Some(received)
+    },
+  )
+
+  let loaded_lock = runtime.load_lock(lock_path)
+  runtime.create_lock_exclusive(lock_path, lock)
+  runtime.write_lock_atomic(lock_path, lock)
+  let loaded_ownership_state = runtime.load_ownership_state(ownership_path)
+  runtime.write_ownership_state_atomic(ownership_path, ownership_state)
+
+  assert_true(loaded_lock == lock)
+  assert_true(loaded_ownership_state == ownership_state)
+  assert_true(received_lock == Some(lock))
+  assert_true(received_ownership_state == Some(ownership_state))
+  inspect(received_paths.length(), content="5")
+  inspect(
+    received_paths[0].to_string(),
+    content="/synthetic/work/project/c-plugin-lock.json",
+  )
+  inspect(
+    received_paths[3].to_string(),
+    content="/synthetic/work/project/.agents/c-plugin-state.json",
+  )
+}


### PR DESCRIPTION
## 概要

- TOT-94: runtime path、lock discovery、state storeを注入可能な`Runtime`へ集約
- discoveryとstate storeの具体的なtyped errorを境界の外まで維持
- 未実装のsync境界は先行して抽象化せず、現行のproduction APIだけを合成
- home、cwd、cache rootおよび保存先を末端まで`Path`型で転送

## 処理フロー

```mermaid
flowchart TD
  A["RuntimePaths"] --> B["Runtime"]
  C["discover_locks callback"] --> B
  D["5 state-store callbacks"] --> B
  B --> E["project/global lock Path"]
  B --> F["lock discovery"]
  B --> G["lock/ownership state store"]
```

## テスト条件

```mermaid
flowchart LR
  A["synthetic home/cwd/cache"] --> B["3 Pathをdiscoveryへ転送"]
  B --> C["project/global lock pathを検証"]
  D["synthetic lock/state paths"] --> E["load/create/atomic write callbacks"]
  E --> F["型付き値と呼出回数を検証"]
  C --> G["実HOME・cwd・cacheへ非接触"]
  F --> G
```

## 検証

- `moon test mbt/app/c-plugin-v2/src/runtime_wbtest.mbt --target native --no-parallelize` (2 passed)
- `moon check mbt/app/c-plugin-v2/src --target native`
- `LD_LIBRARY_PATH="$MOONBIT_OPENSSL_LIBRARY_PATH" moon test mbt/app/c-plugin-v2/src --target native --no-parallelize` (73 passed)
- `moon build mbt/app/c-plugin-v2/src --target native`
- `moon fmt mbt/app/c-plugin-v2/src`
- `git diff --check`
- `vp run mbt:fix`は当該worktreeにJS依存が未導入のためtask graph読込で失敗。上記の直接MoonBit検証で代替

## CI status

- Latest commit SHA: `fcfeeb7b0bf59cd83bbeee94a6986d3a76611a1c`
- Latest `check` job: success (run id: `31195121348`, watch `EXIT=0`, API conclusion `success`)
- Dependency base: PR #258 head `b0511f40199811c745992ae5784b0c36b7217147`
- Retry history:
  - `cb2ce5cc`: CI success後、main package blackbox warningをレビューで検出
  - `fcfeeb7b`: warningを避ける`_wbtest.mbt`へ最小修正し、focused 2/2・package 73/73・CI success
- Review gate: goal / QA / code / security / context / runtime audit の6レーンすべてPASS

Linear: TOT-94