### PR TITLE
TOT-96: init commandを実装

### DIFF
--- a/mbt/app/c-plugin-v2/src/command_init.mbt
+++ b/mbt/app/c-plugin-v2/src/command_init.mbt
@@ -1,0 +1,61 @@
+///|
+let init_global_option : @admiral.OptionDef[Bool] = @admiral.bool(
+  "global",
+  short='g',
+  description="Create the user-level lock file",
+)
+
+///|
+struct InitOptions {
+  global : Bool
+}
+
+///|
+fn init_options(
+  context : @admiral.Context,
+) -> InitOptions raise @json.JsonDecodeError {
+  { global: context.get_bool(init_global_option) }
+}
+
+///|
+fn runtime_for_init(paths : RuntimePaths) -> Runtime {
+  Runtime::Runtime(
+    paths~,
+    discover_locks_api=discover_locks,
+    load_lock~,
+    create_lock_exclusive~,
+    write_lock_atomic~,
+    load_ownership_state~,
+    write_ownership_state_atomic~,
+  )
+}
+
+///|
+/// Create an empty project or global v2 lock without replacing existing bytes.
+async fn init_lock(runtime : Runtime, options : InitOptions) -> @path.Path {
+  let lock_path = if options.global {
+    runtime.global_lock_path()
+  } else {
+    runtime.project_lock_path()
+  }
+  runtime.create_lock_exclusive(lock_path, Lock::Lock([], []))
+  lock_path
+}
+
+///|
+async fn run_init(runtime : Runtime, context : @admiral.Context) -> Unit {
+  let lock_path = init_lock(runtime, init_options(context))
+  println("Created " + lock_path.to_string())
+}
+
+///|
+fn init_command_def(
+  run : async (@admiral.Context) -> Unit,
+) -> @admiral.CommandDef {
+  @admiral.CommandDef::CommandDef(
+    name="init",
+    description="Create an empty c-plugin lock file",
+    options=[init_global_option],
+    run=Some(run),
+  )
+}

--- a/mbt/app/c-plugin-v2/src/command_init_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/command_init_wbtest.mbt
@@ -1,0 +1,139 @@
+///|
+async fn with_init_test_runtime(
+  body : async (Runtime, @path.Path) -> Unit,
+) -> Unit {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-init-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let home = root.join("home")
+    let cwd = root.join("project")
+    let cache_root = root.join("cache")
+    @fs.mkdir(home.to_string(), recursive=true)
+    @fs.mkdir(cwd.to_string(), recursive=true)
+    @fs.mkdir(cache_root.to_string(), recursive=true)
+    let runtime = runtime_for_init(
+      RuntimePaths::RuntimePaths(home, cwd, cache_root),
+    )
+    body(runtime, root)
+  }
+}
+
+///|
+fn init_command_test_runtime(
+  paths : RuntimePaths,
+  create_lock_exclusive : async (@path.Path, Lock) -> Unit raise StateStoreError,
+) -> Runtime {
+  Runtime::Runtime(
+    paths~,
+    discover_locks_api=discover_locks,
+    load_lock~,
+    create_lock_exclusive~,
+    write_lock_atomic~,
+    load_ownership_state~,
+    write_ownership_state_atomic~,
+  )
+}
+
+///|
+async test "Init init_lock - creates the project lock in cwd" {
+  with_init_test_runtime(async fn(runtime, root) {
+    let lock_path = init_lock(runtime, { global: false })
+    inspect(
+      lock_path == root.join("project").join("c-plugin-lock.json"),
+      content="true",
+    )
+    inspect(load_lock(lock_path) == Lock::Lock([], []), content="true")
+    let original = @fs.read_file(lock_path.to_string()).text()
+    inspect(original, content=Lock::Lock([], []).to_pretty_json())
+    try init_lock(runtime, { global: false }) catch {
+      StateStoreError::AlreadyExists(path=error_path) =>
+        inspect(error_path == lock_path, content="true")
+      _ => fail("expected AlreadyExists")
+    } noraise {
+      _ => fail("repeated init must fail")
+    }
+    inspect(@fs.read_file(lock_path.to_string()).text(), content=original)
+  })
+}
+
+///|
+async test "Init init_lock - creates the global lock in home" {
+  with_init_test_runtime(async fn(runtime, root) {
+    let lock_path = init_lock(runtime, { global: true })
+    inspect(
+      lock_path == root.join("home").join("c-plugin-lock.json"),
+      content="true",
+    )
+    inspect(load_lock(lock_path) == Lock::Lock([], []), content="true")
+  })
+}
+
+///|
+async test "Init init_lock - rejects an invalid existing lock without changing bytes" {
+  with_init_test_runtime(async fn(runtime, root) {
+    let lock_path = root.join("project").join("c-plugin-lock.json")
+    let original = "existing bytes\n"
+    @fs.write_file(lock_path.to_string(), original, create_mode=CreateNew)
+    try init_lock(runtime, { global: false }) catch {
+      StateStoreError::AlreadyExists(path=error_path) =>
+        inspect(error_path == lock_path, content="true")
+      _ => fail("expected AlreadyExists")
+    } noraise {
+      _ => fail("existing lock must fail")
+    }
+    inspect(@fs.read_file(lock_path.to_string()).text(), content=original)
+  })
+}
+
+///|
+async test "Init command - routes the short global option to the home lock" {
+  let paths = RuntimePaths::RuntimePaths(
+    "/synthetic/home", "/synthetic/project", "/synthetic/cache",
+  )
+  let mut created_path = None
+  let runtime = init_command_test_runtime(paths, fn(path, _lock) {
+    created_path = Some(path)
+  })
+  let cli = @admiral.CliApp::CliApp(
+    name="c-plugin",
+    version="test",
+    description="test",
+    commands=[
+      init_command_def(async fn(context) { run_init(runtime, context) }),
+    ],
+  )
+
+  cli.run(argv=Some(["init", "-g"]), env=Map([]))
+
+  debug_inspect(
+    created_path,
+    content="Some(Path(\"/synthetic/home/c-plugin-lock.json\"))",
+  )
+}
+
+///|
+async test "Init command - rejects an unknown option before lock creation" {
+  let paths = RuntimePaths::RuntimePaths(
+    "/synthetic/home", "/synthetic/project", "/synthetic/cache",
+  )
+  let mut created_path = None
+  let runtime = init_command_test_runtime(paths, fn(path, _lock) {
+    created_path = Some(path)
+  })
+  let cli = @admiral.CliApp::CliApp(
+    name="c-plugin",
+    version="test",
+    description="test",
+    commands=[
+      init_command_def(async fn(context) { run_init(runtime, context) }),
+    ],
+  )
+
+  try cli.run(argv=Some(["init", "--unknown"]), env=Map([])) catch {
+    _ => ()
+  } noraise {
+    _ => fail("unknown option must fail")
+  }
+
+  debug_inspect(created_path, content="None")
+}

--- a/mbt/app/c-plugin-v2/src/main.mbt
+++ b/mbt/app/c-plugin-v2/src/main.mbt
@@ -1,13 +1,25 @@
 ///|
-fn app() -> @admiral.CliApp {
+fn app(runtime : Runtime) -> @admiral.CliApp {
   @admiral.CliApp::CliApp(
     name="c-plugin",
     version="0.1.0",
     description="Native MoonBit CLI for c-plugin v2",
+    commands=[
+      init_command_def(async fn(context) { run_init(runtime, context) }),
+    ],
   )
 }
 
 ///|
 async fn main {
-  app().run()
+  let home : @path.Path = @env.get_env_var("HOME").unwrap_or_else(() => {
+    fail("HOME is not set")
+  })
+  let cwd : @path.Path = @env.current_dir().unwrap_or_else(() => {
+    fail("failed to resolve current directory")
+  })
+  let cache_root = home.join(".cache").join("c-plugin").join("repositories")
+  let paths = RuntimePaths::RuntimePaths(home, cwd, cache_root)
+  let runtime = runtime_for_init(paths)
+  app(runtime).run()
 }

--- a/mbt/app/c-plugin-v2/src/main_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/main_wbtest.mbt
@@ -1,7 +1,12 @@
 ///|
-test "app identity uses c-plugin version 0.1.0 without commands" {
-  let cli = app()
+test "CliApp app - exposes the init command" {
+  let paths = RuntimePaths::RuntimePaths(
+    "/tmp/c-plugin-v2-main-home", "/tmp/c-plugin-v2-main-cwd", "/tmp/c-plugin-v2-main-cache",
+  )
+  let runtime = runtime_for_init(paths)
+  let cli = app(runtime)
   inspect(cli.name, content="c-plugin")
   inspect(cli.version, content="0.1.0")
-  inspect(cli.commands.length(), content="0")
+  inspect(cli.commands.length(), content="1")
+  inspect(cli.commands[0].name, content="init")
 }

--- a/mbt/app/c-plugin-v2/src/moon.pkg
+++ b/mbt/app/c-plugin-v2/src/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbitlang/async/fs",
   "moonbitlang/async/os_error",
   "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/env",
   "moonbitlang/core/json",
   "moonbitlang/x/path",
   "shu-kitamura/sha256",


### PR DESCRIPTION
## 概要

- `c-plugin init`でcwd直下にcanonicalな空v2 lockを排他的作成
- `c-plugin init -g` / `--global`で`HOME/c-plugin-lock.json`を排他的作成
- 既存fileと繰り返し実行は非zeroで拒否し、既存bytesを変更しない
- 不正なAdmiral入力はlock作成前に拒否
- `Context`をcommand-localな`InitOptions`へ変換してからlock operationへ渡す
- initは新規empty lockを作るため、persist後syncルールの明示的な例外
- pathはenv/FS/output境界以外では`moonbitlang/x`の`Path`で保持

Linear: [TOT-96](https://linear.app/totto2727/issue/TOT-96)

依存PR: #259

## 処理フロー

```mermaid
flowchart TD
  A["c-plugin init"] --> B{"-g / --global?"}
  B -->|no| C["cwd/c-plugin-lock.json"]
  B -->|yes| D["HOME/c-plugin-lock.json"]
  C --> E["CreateNewでcanonical empty v2 lock"]
  D --> E
  E --> F{"既存path?"}
  F -->|no| G["Created <Path>を出力してexit 0"]
  F -->|yes| H["bytesを保持して非zero"]
  G --> I["syncは実行しない"]
```

## テストケース

```mermaid
flowchart LR
  A["focused 5+1"] --> B["project/global成功"]
  A --> C["-gのAdmiral配線"]
  A --> D["canonical JSON bytes"]
  A --> E["既存・繰り返し拒否"]
  A --> F["不正argvを事前拒否"]
  B --> G["synthetic cwd/HOME"]
  C --> H["package 78/78"]
  D --> H
  E --> H
  F --> H
  G --> H
  H --> I["release CLI QA"]
```

## 検証

- `moon test mbt/app/c-plugin-v2/src/command_init_wbtest.mbt --target native --no-parallelize` (5/5)
- `moon test mbt/app/c-plugin-v2/src/main_wbtest.mbt --target native --no-parallelize` (1/1)
- `moon check mbt/app/c-plugin-v2/src --target native`
- `moon test mbt/app/c-plugin-v2/src --target native --no-parallelize` (78/78)
- `moon build mbt/app/c-plugin-v2/src --target native --release`
- release CLI: project=0、repeat=1、`-g`=0、`--global`=0、invalid=1
- project lockのSHA-256はrepeat前後で一致
- project/HOME直下のlockだけを作成し、`.agents`、cache、invalid cwdのlockは未作成
- exact SHAに対するgoal / QA / code quality / security / context / runtime auditは全PASS

## CI status

- Latest commit SHA: `2bb8a885739021ce7af9bbba1789827963572cd0`
- GitHub Actions: [run 31197987351](https://github.com/totto2727-org/monorepo/actions/runs/31197987351) `success`
- Dependency base: PR #259 head `fcfeeb7b0bf59cd83bbeee94a6986d3a76611a1c`
- C-initはbase直上の1 atomic commit
- Prior SHAのCI・レビューは履歴統合により無効
