### PR TITLE
MoonBitのstruct可視性とaccessorルールを定義

### DIFF
--- a/plugins/totto2727-coding/skills/mbt-coding/SKILL.md
+++ b/plugins/totto2727-coding/skills/mbt-coding/SKILL.md
@@ -19,7 +19,7 @@ All references below are concrete MoonBit implementation guidance. Conceptual gu
 ## Language conventions
 
 - [`style.md`](references/style.md) — documentation, project README layout, identifiers, callbacks, and ignored results.
-- [`visibility.md`](references/visibility.md) — public type construction, open extension boundaries, and test visibility.
+- [`visibility.md`](references/visibility.md) — public type construction, direct readonly field access, `priv` exceptions, open extension boundaries, and test visibility.
 - [`constructors.md`](references/constructors.md) — canonical constructors and factories.
 - [`updates.md`](references/updates.md) — immutable value updates and mutable builder updates.
 - [`sequences.md`](references/sequences.md) — Array and Iter return shapes.

--- a/plugins/totto2727-coding/skills/mbt-coding/references/visibility.md
+++ b/plugins/totto2727-coding/skills/mbt-coding/references/visibility.md
@@ -10,6 +10,12 @@ Keep package-level functions minimal. Prefer type-associated functions whenever 
 
 Declare structs as `pub` by default and expose one canonical `TypeName::TypeName` constructor. Use `pub(all)` only when direct external struct literals are an intentional API requirement, and document that requirement next to the declaration.
 
+A `pub struct` already exposes its non-`priv` fields for readonly access outside the defining package. Read immutable state directly through those fields. Do not add a method that only returns one field unchanged; a getter such as `Repository::owner() -> Owner { self.owner }` duplicates the field surface without adding validation, conversion, ownership isolation, or behavior.
+
+Do not declare a type or struct field with `priv` by default. Use `priv` only when the hidden representation enforces a concrete boundary, such as preventing aliases from mutating an internal `Array` or `Map`, or supporting a trait-based abstraction whose representation must not become part of the public contract. State the reason next to the declaration or in the owning reference. Validation alone is not a reason to hide immutable fields: keep the canonical constructor as the construction boundary and expose the resulting readonly fields directly.
+
+Add a field-specific update method when direct property replacement would be cumbersome or would bypass validation. Use `with_<field>` for an immutable value that returns a reconstructed value, and route the replacement through the canonical constructor. Use `set_<field>` only when the type contract intentionally includes in-place mutation. Add update methods for real callers, not speculatively.
+
 ## Enums and suberrors
 
 An enum or suberror may use `pub(all)` when its variants only wrap primitive values or structs and every representable value is valid without validation, normalization, or cross-value rules. Construct these values directly with `TypeName::VariantName`.


### PR DESCRIPTION
## 概要

MoonBitのreadonly `pub struct`はnon-`priv` fieldをpackage外から直接参照できるため、値をそのまま返すgetterを禁止し、field accessを正規のsurfaceとするルールを`mbt-coding` skillへ追加します。

`priv`はmutable `Array` / `Map`のaliasing防止やtrait abstractionなど、具体的なrepresentation boundaryがある場合だけ許可します。validationだけを理由にimmutable fieldを隠さず、canonical constructorをconstruction boundaryとして維持します。

Linear: [TOT-97](https://linear.app/totto2727/issue/TOT-97)

参考: [MoonBit公式 Access Control](https://docs.moonbitlang.com/en/latest/language/packages.html#access-control)

## 適用フロー

```mermaid
flowchart TD
  A["struct fieldを設計"] --> B{"immutable state?"}
  B -->|Yes| C["readonly pub structのfieldを直接公開"]
  C --> D["単純getterは追加しない"]
  B -->|No| E{"mutable Array/Map aliasまたはtrait representationを隠す必要?"}
  E -->|Yes| F["理由を明記してprivを使用"]
  E -->|No| C
  C --> G{"field単体更新の実需要?"}
  G -->|immutable| H["with_fieldをconstructor経由で追加"]
  G -->|in-place mutation contract| I["set_fieldを追加"]
  G -->|No| J["update methodを追加しない"]
```

## 変更

- `mbt-coding` indexのvisibility説明へdirect readonly field accessと`priv` exceptionを追加
- `visibility.md`へ単純getter禁止を追加
- `priv`を許可する具体的条件を追加
- immutable `with_<field>`とmutable `set_<field>`の使い分けを追加

## テスト条件

```mermaid
flowchart LR
  A["skill index"] --> A1["visibility ruleを発見可能"]
  B["visibility reference"] --> B1["direct field access"]
  B --> B2["trivial getter禁止"]
  B --> B3["priv exceptions"]
  B --> B4["update method policy"]
  A1 --> C["git diff --check PASS"]
  B1 --> C
  B2 --> C
  B3 --> C
  B4 --> C
```

## 検証

- `git diff --check`: PASS
- GitHub CI: [run 31177261565](https://github.com/totto2727-org/monorepo/actions/runs/31177261565) attempt 1 success（watch `EXIT=0`、独立確認 `conclusion=success`）

merge前のためLinear IssueはDoneへ変更しません。

