### PR TITLE
c-plugin v2: initのDocker E2Eを追加

### DIFF
--- a/mbt/app/c-plugin-v2/src/e2e/Dockerfile
+++ b/mbt/app/c-plugin-v2/src/e2e/Dockerfile
@@ -1,0 +1,47 @@
+ARG SANDBOX_IMAGE=ghcr.io/totto2727-org/monorepo/sandbox-base@sha256:df12730051f9c1c920c250be35e04a56332dd9d31f2a2dc839042f74c90fe1c0
+
+FROM ${SANDBOX_IMAGE} AS builder
+
+ARG TARGETARCH
+USER sandbox
+WORKDIR /sandbox
+
+RUN case "$TARGETARCH" in \
+      amd64) moon_arch=x86_64 ;; \
+      arm64) moon_arch=aarch64 ;; \
+      *) printf 'Unsupported architecture: %s\n' "$TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    cd /tmp && \
+    moon_archive="moonbit-linux-$moon_arch.tar.gz" && \
+    curl -fsSLO "https://cli.moonbitlang.com/binaries/latest/$moon_archive" && \
+    curl -fsSLO "https://cli.moonbitlang.com/binaries/latest/$moon_archive.sha256" && \
+    sha256sum -c "$moon_archive.sha256" && \
+    tar -xzf "$moon_archive" -C /sandbox/.moon && \
+    chmod +x /sandbox/.moon/bin/* /sandbox/.moon/bin/internal/tcc && \
+    moon -C /sandbox/.moon/lib/core bundle --warn-list -a --all && \
+    rm "$moon_archive" "$moon_archive.sha256"
+
+COPY --chown=sandbox:sandbox . /tmp/monorepo
+
+RUN cd /tmp/monorepo && \
+    moon update && \
+    moon install /tmp/monorepo/mbt/app/c-plugin-v2/src \
+      --bin /sandbox/.local/bin \
+      --target-dir /sandbox/.cache/c-plugin-v2-build && \
+    test -x /sandbox/.local/bin/c-plugin-v2 && \
+    rm -rf /tmp/monorepo /sandbox/.cache/c-plugin-v2-build
+
+FROM ${SANDBOX_IMAGE}
+
+LABEL org.opencontainers.image.source="https://github.com/totto2727-org/monorepo"
+
+USER sandbox
+WORKDIR /sandbox
+
+COPY --from=builder --chown=sandbox:sandbox /sandbox/.local/bin/c-plugin-v2 /sandbox/.local/bin/c-plugin-v2
+COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/init.sh /sandbox/e2e/init.sh
+
+RUN chmod +x /sandbox/.local/bin/c-plugin-v2 /sandbox/e2e/init.sh && \
+    ln -s /sandbox/.local/bin/c-plugin-v2 /sandbox/.local/bin/c-plugin
+
+ENTRYPOINT ["/sandbox/e2e/init.sh"]

--- a/mbt/app/c-plugin-v2/src/e2e/init.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/init.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+scenario=${1:-}
+case "$scenario" in
+  project | global) ;;
+  *)
+    printf 'Usage: %s project|global\n' "$0" >&2
+    exit 2
+    ;;
+esac
+
+test_root=/tmp/c-plugin-v2-e2e
+test_home=$test_root/home
+project_root=$test_root/totto2727-org/monorepo
+expected_lock=$test_root/expected-lock.json
+expected_stdout=$test_root/expected-stdout.txt
+initial_stdout=$test_root/initial.stdout
+initial_stderr=$test_root/initial.stderr
+repeat_stdout=$test_root/repeat.stdout
+repeat_stderr=$test_root/repeat.stderr
+original_lock=$test_root/original-lock.json
+
+mkdir -p "$test_home" "$project_root"
+cd "$project_root"
+
+printf '%s\n' \
+  '{' \
+  '  "version": "2",' \
+  '  "targets": [],' \
+  '  "repositories": []' \
+  '}' >"$expected_lock"
+
+if [[ $scenario == project ]]; then
+  lock_path=$project_root/c-plugin-lock.json
+  opposite_lock=$test_home/c-plugin-lock.json
+  initial_command=(env HOME="$test_home" c-plugin init)
+  repeat_command=(env HOME="$test_home" c-plugin init)
+else
+  lock_path=$test_home/c-plugin-lock.json
+  opposite_lock=$project_root/c-plugin-lock.json
+  initial_command=(env HOME="$test_home" c-plugin init -g)
+  repeat_command=(env HOME="$test_home" c-plugin init --global)
+fi
+
+set +e
+"${initial_command[@]}" >"$initial_stdout" 2>"$initial_stderr"
+initial_status=$?
+set -e
+
+printf '%s initial status=%s\n' "$scenario" "$initial_status"
+[[ $initial_status -eq 0 ]]
+printf 'Created %s\n' "$lock_path" >"$expected_stdout"
+cmp -s "$expected_stdout" "$initial_stdout"
+[[ ! -s $initial_stderr ]]
+cmp -s "$expected_lock" "$lock_path"
+[[ ! -e $opposite_lock ]]
+
+cp "$lock_path" "$original_lock"
+set +e
+"${repeat_command[@]}" >"$repeat_stdout" 2>"$repeat_stderr"
+repeat_status=$?
+set -e
+
+printf '%s repeat status=%s\n' "$scenario" "$repeat_status"
+[[ $repeat_status -ne 0 ]]
+grep -Fx 'totto2727/c-plugin-v2.StateStoreError.AlreadyExists' "$repeat_stdout" >/dev/null
+[[ ! -s $repeat_stderr ]]
+cmp -s "$original_lock" "$lock_path"
+[[ ! -e $opposite_lock ]]
+[[ ! -e $project_root/.agents ]]
+[[ ! -e $test_home/.agents ]]
+[[ ! -e $test_home/.cache/c-plugin ]]
+
+printf 'PASS: init %s\n' "$scenario"

--- a/mbt/app/c-plugin-v2/src/e2e/run.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+e2e_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+repository_root=$(CDPATH= cd -- "$e2e_dir/../../../../.." && pwd -P)
+
+if [[ $(pwd -P) != "$repository_root" ]]; then
+  printf 'Run %s from the repository root.\n' "$0" >&2
+  exit 2
+fi
+
+image='c-plugin-v2-e0-init:local'
+platform_args=()
+if [[ -n ${C_PLUGIN_E2E_PLATFORM:-} ]]; then
+  platform_args=(--platform "$C_PLUGIN_E2E_PLATFORM")
+fi
+build_context=$(mktemp -d "${TMPDIR:-/tmp}/c-plugin-v2-e0-context.XXXXXX")
+before_state=$(mktemp "${TMPDIR:-/tmp}/c-plugin-v2-e0-before.XXXXXX")
+after_state=$(mktemp "${TMPDIR:-/tmp}/c-plugin-v2-e0-after.XXXXXX")
+
+cleanup() {
+  rm -rf -- "$build_context"
+  rm -f -- "$before_state" "$after_state"
+}
+trap cleanup EXIT INT TERM
+
+git ls-files -z -- moon.work mbt | \
+  tar --null -T - -cf - | \
+  tar -xf - -C "$build_context"
+
+snapshot_path() {
+  local path=$1
+  if [[ -L $path ]]; then
+    printf 'link %s %s\n' "$path" "$(readlink "$path")"
+  elif [[ -f $path ]]; then
+    printf 'file %s ' "$path"
+    cksum "$path"
+  elif [[ -d $path ]]; then
+    printf 'directory %s ' "$path"
+    tar -cf - -C "$(dirname -- "$path")" "$(basename -- "$path")" | cksum
+  else
+    printf 'absent %s\n' "$path"
+  fi
+}
+
+snapshot_host_state() {
+  snapshot_path "$repository_root/c-plugin-lock.json"
+  snapshot_path "$repository_root/.agents"
+  snapshot_path "$HOME/c-plugin-lock.json"
+  snapshot_path "$HOME/.agents"
+  snapshot_path "$HOME/.cache/c-plugin"
+}
+
+snapshot_host_state >"$before_state"
+
+docker build \
+  "${platform_args[@]}" \
+  --file "$e2e_dir/Dockerfile" \
+  --tag "$image" \
+  "$build_context"
+
+docker run --rm "${platform_args[@]}" "$image" project
+docker run --rm "${platform_args[@]}" "$image" global
+
+snapshot_host_state >"$after_state"
+if ! cmp -s "$before_state" "$after_state"; then
+  diff -u "$before_state" "$after_state" >&2 || true
+  printf 'Host state changed during c-plugin-v2 E2E.\n' >&2
+  exit 1
+fi
+
+printf 'PASS: c-plugin-v2 init Docker E2E\n'


### PR DESCRIPTION
## 概要

Linear TOT-95のE0として、`init` のproject/global正常系と再実行安全性を、毎回破棄するDockerコンテナで検証します。

- 固定digestのmonorepo sandbox imageからE2E imageを1回だけbuildします
- build contextはGit管理下の `moon.work` / `mbt` だけを一時領域へ抽出します
- 公式MoonBit archiveを公式 `.sha256` で検証し、現在のmonorepo workspaceから `moon install` を1回だけ実行します
- multi-stage buildでfinal imageには実行バイナリとleaf scriptだけを含めます
- project/globalを別々の `docker run --rm` で実行します
- `src/e2e/` はMoonBit package外のため `moon test` / `vp test` の収集対象になりません
- E2E前後でhost側のlock、`.agents`、cache状態が変わらないことを確認します

## 処理フロー

```mermaid
flowchart TD
  A[tracked MoonBit filesだけをcontext化] --> B[固定digestのbuilder image]
  B --> C[公式SHA-256でMoonBit archiveを検証]
  C --> D[workspaceでmoon update]
  D --> E[moon installを1回実行]
  E --> F[final imageへbinaryだけをCOPY]
  F --> G[project用コンテナを起動]
  F --> H[global用コンテナを起動]
  G --> I[initと再実行を検証]
  H --> J[-gと--globalの再実行を検証]
  I --> K[コンテナを破棄]
  J --> L[コンテナを破棄]
  K --> M[host状態を比較]
  L --> M
```

## テストケース

```mermaid
flowchart LR
  A[scenario] --> B{scope}
  B -->|project| C[c-plugin init]
  B -->|global| D[c-plugin init -g]
  C --> E[status 0 / stdout完全一致 / stderr空]
  D --> E
  E --> F[canonical lock JSON完全一致]
  F --> G[同じscopeで再実行]
  G --> H[非0 / AlreadyExists / lock bytes不変]
  H --> I[反対scope・.agents・cacheが未生成]
```

## 検証

- `mbt/app/c-plugin-v2/src/e2e/run.sh`
  - verified MoonBit archive: PASS
  - project initial/repeat: PASS
  - global initial/repeat: PASS
  - host state invariant: PASS
- `moon test mbt/app/c-plugin-v2/src/command_init_wbtest.mbt --target native --no-parallelize`: 5/5
- `moon test mbt/app/c-plugin-v2/src/main_wbtest.mbt --target native --no-parallelize`: 1/1
- `moon test mbt/app/c-plugin-v2/src --target native --no-parallelize`: 78/78
- native check/build/release build: PASS
- `moon test --outline`: 既存78件のみで `src/e2e/` は非収集

## Stack

- GitHub native stack: #267
- Base: #261 C-init
- Linear: TOT-95
