### PR TITLE
c-plugin v2: 一意コレクションをimmutable hash collectionで保持する

### DIFF
--- a/c-plugin-v2/README.ja.md
+++ b/c-plugin-v2/README.ja.md
@@ -99,7 +99,7 @@ TUIは選択状態を扱うアダプターであり、コマンドのビジネ�
 - 最も近い親のプロジェクトロック探索、home直下のグローバルロック探索、再帰的な子孫ロック探索。
 - `totto2727/target-file-discovery`による`.gitignore`を考慮した再帰探索。
 - 複数リポジトリ同期の耐障害性。1つのリポジトリが利用できない場合は報告してスキップし、独立した他のリポジトリの同期を妨げない。
-- 現在の動作と同じく、ロック順で最後のリポジトリエントリを採用する決定論的なスキル名重複解決。
+- JSON入力順や内部collectionの反復順に依存せず、同期時にcanonical repository順で最後のリポジトリを採用する決定論的なスキル名重複解決。
 - Claude、Cursor、Codex形式間のマーケットプレイス変換。
 - 正規化された`./plugins/...`パスと`policy.installation = "INSTALLED_BY_DEFAULT"`を持つCodexのローカルsource object。
 - 入力元種別のプラグインに`plugin.json`が存在する場合、対象種別へコピーする。
@@ -278,7 +278,7 @@ JSONの規則は次のとおりです。
 - `MarketplaceKind`のようなscalar closed enumは、厳格な文字列表現を使用してよい。
 - 必須フィールドの欠落、未知のEnum値、不正な型、不正なパス、無効なリポジトリ名、identityの重複、未対応バージョンはエラーとする。
 - 壊れたJSONを空のロックとして扱ったり、不正なリポジトリエントリを暗黙に除外したり、不正な値を寛容な既定値へ置き換えたりしない。
-- 決定論的な出力と重複解決のため、repository、plugin、skill、targetの順序を維持する。
+- 一意なaggregateはimmutable hash set/mapに保持し、JSON入力順を内部状態に残さない。順序が必要な境界だけでsortし、canonical JSONではcode unitの辞書順を用いて、targetを正規化path、repositoryをsource kindとidentity、pluginをname、enabled skillをname、ownership entryを正規化link pathで並べる。
 
 ロックcodecには、canonical encodingをデコードすると同じドメイン値へ戻るという1つのround-trip propertyを持たせます。整形出力は2スペースindentと末尾の改行を使用します。
 

--- a/c-plugin-v2/README.md
+++ b/c-plugin-v2/README.md
@@ -99,7 +99,7 @@ The rewrite is complete only when it preserves these capabilities:
 - Nearest-parent project lock discovery, exact home-level global lock discovery, and recursive descendant lock discovery.
 - `.gitignore`-aware recursive traversal through `totto2727/target-file-discovery`.
 - Tolerant multi-repository synchronization: one unavailable repository is reported and skipped without preventing independent repositories from being synchronized.
-- Deterministic duplicate skill-name resolution using the last repository entry in lock order, matching the current behavior.
+- Deterministic duplicate skill-name resolution using the last repository in canonical repository order at reconciliation time, independent of JSON input order and internal collection iteration order.
 - Marketplace conversion among Claude, Cursor, and Codex formats.
 - Codex local source objects with normalized `./plugins/...` paths and `policy.installation = "INSTALLED_BY_DEFAULT"`.
 - Copying a base-kind plugin's `plugin.json` to target kinds when the base file exists.
@@ -278,7 +278,7 @@ JSON rules:
 - Scalar closed enums such as `MarketplaceKind` may use a strict string representation.
 - Missing required fields, unknown enum values, wrong types, malformed paths, invalid repository names, duplicate identities, and unsupported versions are errors.
 - Never treat corrupt JSON as an empty lock, silently filter invalid repository entries, or replace invalid values with permissive defaults.
-- Preserve repository, plugin, skill, and target ordering for deterministic output and duplicate resolution.
+- Store unique aggregates in immutable hash sets and maps without retaining JSON input order. Sort only at the boundary that needs ordering: canonical JSON sorts targets by normalized path, repositories by source kind and identity, plugins by name, enabled skills by name, and ownership entries by normalized link path, using lexicographical code-unit order.
 
 The lock codec has one round-trip property: decoding the canonical encoded form returns the same domain value. Pretty output uses two-space indentation and a trailing newline.
 

--- a/mbt/app/c-plugin-v2/src/e2e/Dockerfile
+++ b/mbt/app/c-plugin-v2/src/e2e/Dockerfile
@@ -1,0 +1,47 @@
+ARG SANDBOX_IMAGE=ghcr.io/totto2727-org/monorepo/sandbox-base@sha256:df12730051f9c1c920c250be35e04a56332dd9d31f2a2dc839042f74c90fe1c0
+
+FROM ${SANDBOX_IMAGE} AS builder
+
+ARG TARGETARCH
+USER sandbox
+WORKDIR /sandbox
+
+RUN case "$TARGETARCH" in \
+      amd64) moon_arch=x86_64 ;; \
+      arm64) moon_arch=aarch64 ;; \
+      *) printf 'Unsupported architecture: %s\n' "$TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    cd /tmp && \
+    moon_archive="moonbit-linux-$moon_arch.tar.gz" && \
+    curl -fsSLO "https://cli.moonbitlang.com/binaries/latest/$moon_archive" && \
+    curl -fsSLO "https://cli.moonbitlang.com/binaries/latest/$moon_archive.sha256" && \
+    sha256sum -c "$moon_archive.sha256" && \
+    tar -xzf "$moon_archive" -C /sandbox/.moon && \
+    chmod +x /sandbox/.moon/bin/* /sandbox/.moon/bin/internal/tcc && \
+    moon -C /sandbox/.moon/lib/core bundle --warn-list -a --all && \
+    rm "$moon_archive" "$moon_archive.sha256"
+
+COPY --chown=sandbox:sandbox . /tmp/monorepo
+
+RUN cd /tmp/monorepo && \
+    moon update && \
+    moon install /tmp/monorepo/mbt/app/c-plugin-v2/src \
+      --bin /sandbox/.local/bin \
+      --target-dir /sandbox/.cache/c-plugin-v2-build && \
+    test -x /sandbox/.local/bin/c-plugin-v2 && \
+    rm -rf /tmp/monorepo /sandbox/.cache/c-plugin-v2-build
+
+FROM ${SANDBOX_IMAGE}
+
+LABEL org.opencontainers.image.source="https://github.com/totto2727-org/monorepo"
+
+USER sandbox
+WORKDIR /sandbox
+
+COPY --from=builder --chown=sandbox:sandbox /sandbox/.local/bin/c-plugin-v2 /sandbox/.local/bin/c-plugin-v2
+COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/init.sh /sandbox/e2e/init.sh
+
+RUN chmod +x /sandbox/.local/bin/c-plugin-v2 /sandbox/e2e/init.sh && \
+    ln -s /sandbox/.local/bin/c-plugin-v2 /sandbox/.local/bin/c-plugin
+
+ENTRYPOINT ["/sandbox/e2e/init.sh"]

--- a/mbt/app/c-plugin-v2/src/e2e/init.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/init.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+scenario=${1:-}
+case "$scenario" in
+  project | global) ;;
+  *)
+    printf 'Usage: %s project|global\n' "$0" >&2
+    exit 2
+    ;;
+esac
+
+test_root=/tmp/c-plugin-v2-e2e
+test_home=$test_root/home
+project_root=$test_root/totto2727-org/monorepo
+expected_lock=$test_root/expected-lock.json
+expected_stdout=$test_root/expected-stdout.txt
+initial_stdout=$test_root/initial.stdout
+initial_stderr=$test_root/initial.stderr
+repeat_stdout=$test_root/repeat.stdout
+repeat_stderr=$test_root/repeat.stderr
+original_lock=$test_root/original-lock.json
+
+mkdir -p "$test_home" "$project_root"
+cd "$project_root"
+
+printf '%s\n' \
+  '{' \
+  '  "version": "2",' \
+  '  "targets": [],' \
+  '  "repositories": []' \
+  '}' >"$expected_lock"
+
+if [[ $scenario == project ]]; then
+  lock_path=$project_root/c-plugin-lock.json
+  opposite_lock=$test_home/c-plugin-lock.json
+  initial_command=(env HOME="$test_home" c-plugin init)
+  repeat_command=(env HOME="$test_home" c-plugin init)
+else
+  lock_path=$test_home/c-plugin-lock.json
+  opposite_lock=$project_root/c-plugin-lock.json
+  initial_command=(env HOME="$test_home" c-plugin init -g)
+  repeat_command=(env HOME="$test_home" c-plugin init --global)
+fi
+
+set +e
+"${initial_command[@]}" >"$initial_stdout" 2>"$initial_stderr"
+initial_status=$?
+set -e
+
+printf '%s initial status=%s\n' "$scenario" "$initial_status"
+[[ $initial_status -eq 0 ]]
+printf 'Created %s\n' "$lock_path" >"$expected_stdout"
+cmp -s "$expected_stdout" "$initial_stdout"
+[[ ! -s $initial_stderr ]]
+cmp -s "$expected_lock" "$lock_path"
+[[ ! -e $opposite_lock ]]
+
+cp "$lock_path" "$original_lock"
+set +e
+"${repeat_command[@]}" >"$repeat_stdout" 2>"$repeat_stderr"
+repeat_status=$?
+set -e
+
+printf '%s repeat status=%s\n' "$scenario" "$repeat_status"
+[[ $repeat_status -ne 0 ]]
+grep -Fx 'totto2727/c-plugin-v2.StateStoreError.AlreadyExists' "$repeat_stdout" >/dev/null
+[[ ! -s $repeat_stderr ]]
+cmp -s "$original_lock" "$lock_path"
+[[ ! -e $opposite_lock ]]
+[[ ! -e $project_root/.agents ]]
+[[ ! -e $test_home/.agents ]]
+[[ ! -e $test_home/.cache/c-plugin ]]
+
+printf 'PASS: init %s\n' "$scenario"

--- a/mbt/app/c-plugin-v2/src/e2e/run.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+e2e_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+repository_root=$(CDPATH= cd -- "$e2e_dir/../../../../.." && pwd -P)
+
+if [[ $(pwd -P) != "$repository_root" ]]; then
+  printf 'Run %s from the repository root.\n' "$0" >&2
+  exit 2
+fi
+
+image='c-plugin-v2-e0-init:local'
+platform_args=()
+if [[ -n ${C_PLUGIN_E2E_PLATFORM:-} ]]; then
+  platform_args=(--platform "$C_PLUGIN_E2E_PLATFORM")
+fi
+build_context=$(mktemp -d "${TMPDIR:-/tmp}/c-plugin-v2-e0-context.XXXXXX")
+before_state=$(mktemp "${TMPDIR:-/tmp}/c-plugin-v2-e0-before.XXXXXX")
+after_state=$(mktemp "${TMPDIR:-/tmp}/c-plugin-v2-e0-after.XXXXXX")
+
+cleanup() {
+  rm -rf -- "$build_context"
+  rm -f -- "$before_state" "$after_state"
+}
+trap cleanup EXIT INT TERM
+
+git ls-files -z -- moon.work mbt | \
+  tar --null -T - -cf - | \
+  tar -xf - -C "$build_context"
+
+snapshot_path() {
+  local path=$1
+  if [[ -L $path ]]; then
+    printf 'link %s %s\n' "$path" "$(readlink "$path")"
+  elif [[ -f $path ]]; then
+    printf 'file %s ' "$path"
+    cksum "$path"
+  elif [[ -d $path ]]; then
+    printf 'directory %s ' "$path"
+    tar -cf - -C "$(dirname -- "$path")" "$(basename -- "$path")" | cksum
+  else
+    printf 'absent %s\n' "$path"
+  fi
+}
+
+snapshot_host_state() {
+  snapshot_path "$repository_root/c-plugin-lock.json"
+  snapshot_path "$repository_root/.agents"
+  snapshot_path "$HOME/c-plugin-lock.json"
+  snapshot_path "$HOME/.agents"
+  snapshot_path "$HOME/.cache/c-plugin"
+}
+
+snapshot_host_state >"$before_state"
+
+docker build \
+  "${platform_args[@]}" \
+  --file "$e2e_dir/Dockerfile" \
+  --tag "$image" \
+  "$build_context"
+
+docker run --rm "${platform_args[@]}" "$image" project
+docker run --rm "${platform_args[@]}" "$image" global
+
+snapshot_host_state >"$after_state"
+if ! cmp -s "$before_state" "$after_state"; then
+  diff -u "$before_state" "$after_state" >&2 || true
+  printf 'Host state changed during c-plugin-v2 E2E.\n' >&2
+  exit 1
+fi
+
+printf 'PASS: c-plugin-v2 init Docker E2E\n'

--- a/mbt/app/c-plugin-v2/src/lock_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_codec.mbt
@@ -211,9 +211,7 @@ pub impl @json.FromJson for Plugin with fn from_json(json, path) {
 pub impl ToJson for Plugin with fn to_json(self) -> Json {
   let builder = @lens.JsonBuilder::JsonBuilder()
   let enabled_skills = self.enabled_skills.iter().to_array()
-  enabled_skills.sort_by((left, right) => {
-    left.value.lexical_compare(right.value)
-  })
+  enabled_skills.sort()
   plugin_name_lens.set_or_abort(builder, self.name.to_json())
   plugin_path_lens.set_or_abort(builder, self.path.to_json())
   plugin_enabled_skills_lens.set_or_abort(builder, enabled_skills.to_json())
@@ -224,11 +222,9 @@ pub impl ToJson for Plugin with fn to_json(self) -> Json {
 fn sorted_plugins_for_json(
   plugins : @immut_hashmap.HashMap[PluginName, Plugin],
 ) -> Array[Plugin] {
-  let result = plugins.values().to_array()
-  result.sort_by((left, right) => {
-    left.name.value.lexical_compare(right.name.value)
-  })
-  result
+  let entries = plugins.to_array()
+  entries.sort_by((left, right) => left.0.compare(right.0))
+  entries.map(entry => entry.1)
 }
 
 ///|
@@ -359,21 +355,6 @@ pub impl ToJson for LockRepository with fn to_json(self) -> Json {
 }
 
 ///|
-fn compare_repositories_for_json(
-  left : LockRepository,
-  right : LockRepository,
-) -> Int {
-  match (left, right) {
-    (GitHub(left), GitHub(right)) =>
-      left.repository.route().lexical_compare(right.repository.route())
-    (GitHub(_), Local(_)) => -1
-    (Local(_), GitHub(_)) => 1
-    (Local(left), Local(right)) =>
-      left.path.path.to_string().lexical_compare(right.path.path.to_string())
-  }
-}
-
-///|
 pub impl @json.FromJson for Lock with fn from_json(json, path) {
   let version : String = @json.from_json(
     lock_version_lens.get_or_json_decode_error(json, path),
@@ -402,11 +383,10 @@ pub impl @json.FromJson for Lock with fn from_json(json, path) {
 pub impl ToJson for Lock with fn to_json(self) -> Json {
   let builder = @lens.JsonBuilder::JsonBuilder()
   let targets = self.targets.iter().to_array()
-  targets.sort_by((left, right) => {
-    left.path.to_string().lexical_compare(right.path.to_string())
-  })
-  let repositories = self.repositories.values().to_array()
-  repositories.sort_by(compare_repositories_for_json)
+  targets.sort()
+  let repository_entries = self.repositories.to_array()
+  repository_entries.sort_by((left, right) => left.0.compare(right.0))
+  let repositories = repository_entries.map(entry => entry.1)
   lock_version_lens.set_or_abort(builder, self.version.to_string().to_json())
   lock_targets_lens.set_or_abort(builder, targets.to_json())
   lock_repositories_lens.set_or_abort(builder, repositories.to_json())

--- a/mbt/app/c-plugin-v2/src/lock_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_codec.mbt
@@ -210,13 +210,25 @@ pub impl @json.FromJson for Plugin with fn from_json(json, path) {
 ///|
 pub impl ToJson for Plugin with fn to_json(self) -> Json {
   let builder = @lens.JsonBuilder::JsonBuilder()
+  let enabled_skills = self.enabled_skills.iter().to_array()
+  enabled_skills.sort_by((left, right) => {
+    left.value.lexical_compare(right.value)
+  })
   plugin_name_lens.set_or_abort(builder, self.name.to_json())
   plugin_path_lens.set_or_abort(builder, self.path.to_json())
-  plugin_enabled_skills_lens.set_or_abort(
-    builder,
-    self.enabled_skills.to_array().to_json(),
-  )
+  plugin_enabled_skills_lens.set_or_abort(builder, enabled_skills.to_json())
   builder.to_json()
+}
+
+///|
+fn sorted_plugins_for_json(
+  plugins : @immut_hashmap.HashMap[PluginName, Plugin],
+) -> Array[Plugin] {
+  let result = plugins.values().to_array()
+  result.sort_by((left, right) => {
+    left.name.value.lexical_compare(right.name.value)
+  })
+  result
 }
 
 ///|
@@ -268,7 +280,7 @@ pub impl ToJson for GitHubLockRepository with fn to_json(self) -> Json {
   github_commit_lens.set_or_abort(builder, self.commit.to_json())
   github_plugins_lens.set_or_abort(
     builder,
-    self.plugins.values().collect().to_json(),
+    sorted_plugins_for_json(self.plugins).to_json(),
   )
   builder.to_json()
 }
@@ -317,7 +329,7 @@ pub impl ToJson for LocalLockRepository with fn to_json(self) -> Json {
   )
   local_plugins_lens.set_or_abort(
     builder,
-    self.plugins.values().collect().to_json(),
+    sorted_plugins_for_json(self.plugins).to_json(),
   )
   builder.to_json()
 }
@@ -343,6 +355,21 @@ pub impl ToJson for LockRepository with fn to_json(self) -> Json {
   match self {
     GitHub(repository) => repository.to_json()
     Local(repository) => repository.to_json()
+  }
+}
+
+///|
+fn compare_repositories_for_json(
+  left : LockRepository,
+  right : LockRepository,
+) -> Int {
+  match (left, right) {
+    (GitHub(left), GitHub(right)) =>
+      left.repository.route().lexical_compare(right.repository.route())
+    (GitHub(_), Local(_)) => -1
+    (Local(_), GitHub(_)) => 1
+    (Local(left), Local(right)) =>
+      left.path.path.to_string().lexical_compare(right.path.path.to_string())
   }
 }
 
@@ -374,12 +401,15 @@ pub impl @json.FromJson for Lock with fn from_json(json, path) {
 ///|
 pub impl ToJson for Lock with fn to_json(self) -> Json {
   let builder = @lens.JsonBuilder::JsonBuilder()
+  let targets = self.targets.iter().to_array()
+  targets.sort_by((left, right) => {
+    left.path.to_string().lexical_compare(right.path.to_string())
+  })
+  let repositories = self.repositories.values().to_array()
+  repositories.sort_by(compare_repositories_for_json)
   lock_version_lens.set_or_abort(builder, self.version.to_string().to_json())
-  lock_targets_lens.set_or_abort(builder, self.targets.to_array().to_json())
-  lock_repositories_lens.set_or_abort(
-    builder,
-    self.repositories.values().collect().to_json(),
-  )
+  lock_targets_lens.set_or_abort(builder, targets.to_json())
+  lock_repositories_lens.set_or_abort(builder, repositories.to_json())
   builder.to_json()
 }
 

--- a/mbt/app/c-plugin-v2/src/lock_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_codec.mbt
@@ -214,7 +214,7 @@ pub impl ToJson for Plugin with fn to_json(self) -> Json {
   plugin_path_lens.set_or_abort(builder, self.path.to_json())
   plugin_enabled_skills_lens.set_or_abort(
     builder,
-    self.enabled_skills.to_json(),
+    self.enabled_skills.to_array().to_json(),
   )
   builder.to_json()
 }
@@ -266,7 +266,10 @@ pub impl ToJson for GitHubLockRepository with fn to_json(self) -> Json {
     self.marketplace_kind.to_json(),
   )
   github_commit_lens.set_or_abort(builder, self.commit.to_json())
-  github_plugins_lens.set_or_abort(builder, self.plugins.to_json())
+  github_plugins_lens.set_or_abort(
+    builder,
+    self.plugins.values().collect().to_json(),
+  )
   builder.to_json()
 }
 
@@ -312,7 +315,10 @@ pub impl ToJson for LocalLockRepository with fn to_json(self) -> Json {
     builder,
     self.marketplace_kind.to_json(),
   )
-  local_plugins_lens.set_or_abort(builder, self.plugins.to_json())
+  local_plugins_lens.set_or_abort(
+    builder,
+    self.plugins.values().collect().to_json(),
+  )
   builder.to_json()
 }
 
@@ -369,8 +375,11 @@ pub impl @json.FromJson for Lock with fn from_json(json, path) {
 pub impl ToJson for Lock with fn to_json(self) -> Json {
   let builder = @lens.JsonBuilder::JsonBuilder()
   lock_version_lens.set_or_abort(builder, self.version.to_string().to_json())
-  lock_targets_lens.set_or_abort(builder, self.targets.to_json())
-  lock_repositories_lens.set_or_abort(builder, self.repositories.to_json())
+  lock_targets_lens.set_or_abort(builder, self.targets.to_array().to_json())
+  lock_repositories_lens.set_or_abort(
+    builder,
+    self.repositories.values().collect().to_json(),
+  )
   builder.to_json()
 }
 

--- a/mbt/app/c-plugin-v2/src/lock_codec_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_codec_wbtest.mbt
@@ -113,6 +113,23 @@ test "Lock FromJson and ToJson - canonical round trip preserves order" {
 }
 
 ///|
+test "Lock FromJson and ToJson - preserves non-sorted collection order" {
+  let text =
+    #|{"version":"2","targets":[".cursor/skills",".agents/skills"],"repositories":[{"type":"local","path":"vendor/z-last","marketplaceKind":"claude","plugins":[{"name":"z-plugin","path":"plugins/z","enabledSkills":["sync","install"]},{"name":"a-plugin","path":"plugins/a","enabledSkills":[]}]},{"type":"github","repository":"a-owner/a-repo","marketplaceKind":"codex","commit":"0123456789abcdef0123456789abcdef01234567","plugins":[]}]}
+  let lock : Lock = @json.from_json(@json.parse(text))
+  inspect(lock.targets()[0].path.to_string(), content=".cursor/skills")
+  match lock.repositories()[0] {
+    Local(repository) => {
+      inspect(repository.path.path.to_string(), content="vendor/z-last")
+      inspect(repository.plugins()[0].name.value, content="z-plugin")
+      inspect(repository.plugins()[0].enabled_skills()[0].value, content="sync")
+    }
+    GitHub(_) => fail("first repository must preserve local insertion order")
+  }
+  inspect(lock.to_json().stringify(), content=text)
+}
+
+///|
 test "Lock FromJson - nested failure preserves JSON path" {
   let invalid_text = "{\"version\":\"2\",\"targets\":[],\"repositories\":[{\"type\":\"github\",\"repository\":\"openai/codex\",\"marketplaceKind\":\"codex\",\"commit\":\"0123456789abcdef0123456789abcdef01234567\",\"plugins\":[{\"name\":\"c-plugin\",\"path\":\"plugins/c-plugin\",\"enabledSkills\":[1]}]}]}"
   let invalid = @json.parse(invalid_text)
@@ -166,6 +183,30 @@ test "LockRepository FromJson - dispatches each top-level type" {
 
 ///|
 test "lock FromJson - rejects strict schema failures" {
+  expect_json_rejection(
+    fn() -> Unit raise {
+      let text =
+        #|{"version":"2","targets":[".agents/skills",".agents/./skills"],"repositories":[]}
+      (@json.from_json(@json.parse(text)) : Lock) |> ignore
+    },
+    "duplicate normalized target identity",
+  )
+  expect_json_rejection(
+    fn() -> Unit raise {
+      let text =
+        #|{"version":"2","targets":[],"repositories":[{"type":"local","path":"vendor/plugin","marketplaceKind":"claude","plugins":[{"name":"plugin","path":"plugins/first","enabledSkills":["sync","sync"]}]}]}
+      (@json.from_json(@json.parse(text)) : Lock) |> ignore
+    },
+    "duplicate enabled skill identity",
+  )
+  expect_json_rejection(
+    fn() -> Unit raise {
+      let text =
+        #|{"version":"2","targets":[],"repositories":[{"type":"local","path":"vendor/plugin","marketplaceKind":"claude","plugins":[{"name":"plugin","path":"plugins/first","enabledSkills":[]},{"name":"plugin","path":"plugins/second","enabledSkills":[]}]}]}
+      (@json.from_json(@json.parse(text)) : Lock) |> ignore
+    },
+    "duplicate plugin name identity",
+  )
   expect_json_rejection(
     fn() -> Unit raise {
       let text = "{\"version\":\"2\",\"targets\":[],\"repositories\":[{\"type\":\"gitlab\"}]}"

--- a/mbt/app/c-plugin-v2/src/lock_codec_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_codec_wbtest.mbt
@@ -96,37 +96,25 @@ let canonical_lock_json =
   #|}
 
 ///|
-test "Lock FromJson and ToJson - canonical round trip preserves order" {
+test "Lock FromJson and ToJson - canonical round trip is sorted" {
   let lock : Lock = @json.parse(canonical_lock_json) |> @json.from_json
   inspect(lock.to_pretty_json(), content=canonical_lock_json + "\n")
   let decoded : Lock = @json.from_json(lock.to_json())
   inspect(decoded == lock, content="true")
-  inspect(decoded.targets()[0].path.to_string(), content=".agents/skills")
-  match decoded.repositories()[0] {
-    GitHub(repository) =>
-      inspect(
-        repository.plugins()[0].enabled_skills()[0].value,
-        content="install",
-      )
-    Local(_) => fail("first repository must remain GitHub")
-  }
+  inspect(
+    decoded.targets.contains(Target::Target(".agents/skills")),
+    content="true",
+  )
 }
 
 ///|
-test "Lock FromJson and ToJson - preserves non-sorted collection order" {
+test "Lock FromJson and ToJson - sorts collections at the JSON boundary" {
   let text =
     #|{"version":"2","targets":[".cursor/skills",".agents/skills"],"repositories":[{"type":"local","path":"vendor/z-last","marketplaceKind":"claude","plugins":[{"name":"z-plugin","path":"plugins/z","enabledSkills":["sync","install"]},{"name":"a-plugin","path":"plugins/a","enabledSkills":[]}]},{"type":"github","repository":"a-owner/a-repo","marketplaceKind":"codex","commit":"0123456789abcdef0123456789abcdef01234567","plugins":[]}]}
   let lock : Lock = @json.from_json(@json.parse(text))
-  inspect(lock.targets()[0].path.to_string(), content=".cursor/skills")
-  match lock.repositories()[0] {
-    Local(repository) => {
-      inspect(repository.path.path.to_string(), content="vendor/z-last")
-      inspect(repository.plugins()[0].name.value, content="z-plugin")
-      inspect(repository.plugins()[0].enabled_skills()[0].value, content="sync")
-    }
-    GitHub(_) => fail("first repository must preserve local insertion order")
-  }
-  inspect(lock.to_json().stringify(), content=text)
+  let expected =
+    #|{"version":"2","targets":[".agents/skills",".cursor/skills"],"repositories":[{"type":"github","repository":"a-owner/a-repo","marketplaceKind":"codex","commit":"0123456789abcdef0123456789abcdef01234567","plugins":[]},{"type":"local","path":"vendor/z-last","marketplaceKind":"claude","plugins":[{"name":"a-plugin","path":"plugins/a","enabledSkills":[]},{"name":"z-plugin","path":"plugins/z","enabledSkills":["install","sync"]}]}]}
+  inspect(lock.to_json().stringify(), content=expected)
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/lock_domain.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_domain.mbt
@@ -50,6 +50,11 @@ pub struct GitHubRepository {
 } derive(Eq, Hash)
 
 ///|
+pub impl Compare for GitHubRepository with fn compare(self, other) {
+  self.route().lexical_compare(other.route())
+}
+
+///|
 pub fn GitHubRepository::GitHubRepository(
   owner : GitHubOwner,
   name : GitHubRepositoryName,
@@ -83,6 +88,11 @@ pub struct Target {
 } derive(Eq)
 
 ///|
+pub impl Compare for Target with fn compare(self, other) {
+  self.path.to_string().lexical_compare(other.path.to_string())
+}
+
+///|
 pub impl Hash for Target with fn hash_combine(self, hasher) {
   self.path.to_string().hash_combine(hasher)
 }
@@ -97,6 +107,11 @@ pub fn Target::Target(path : @path.Path) -> Target raise {
 pub struct RelativeSourcePath {
   path : @path.Path
 } derive(Eq)
+
+///|
+pub impl Compare for RelativeSourcePath with fn compare(self, other) {
+  self.path.to_string().lexical_compare(other.path.to_string())
+}
 
 ///|
 pub impl Hash for RelativeSourcePath with fn hash_combine(self, hasher) {
@@ -150,6 +165,11 @@ pub struct PluginName {
 } derive(Eq, Hash)
 
 ///|
+pub impl Compare for PluginName with fn compare(self, other) {
+  self.value.lexical_compare(other.value)
+}
+
+///|
 pub fn PluginName::PluginName(value : String) -> PluginName raise {
   validate_item_name(value, "plugin name")
   { value, }
@@ -159,6 +179,11 @@ pub fn PluginName::PluginName(value : String) -> PluginName raise {
 pub struct SkillName {
   value : String
 } derive(Eq, Hash)
+
+///|
+pub impl Compare for SkillName with fn compare(self, other) {
+  self.value.lexical_compare(other.value)
+}
 
 ///|
 pub fn SkillName::SkillName(value : String) -> SkillName raise {
@@ -335,6 +360,16 @@ pub enum RepositoryIdentity {
   GitHubIdentity(GitHubRepository)
   LocalIdentity(RelativeSourcePath)
 } derive(Eq, Hash)
+
+///|
+pub impl Compare for RepositoryIdentity with fn compare(self, other) {
+  match (self, other) {
+    (GitHubIdentity(left), GitHubIdentity(right)) => left.compare(right)
+    (GitHubIdentity(_), LocalIdentity(_)) => -1
+    (LocalIdentity(_), GitHubIdentity(_)) => 1
+    (LocalIdentity(left), LocalIdentity(right)) => left.compare(right)
+  }
+}
 
 ///|
 pub fn LockRepository::identity(self : LockRepository) -> RepositoryIdentity {

--- a/mbt/app/c-plugin-v2/src/lock_domain.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_domain.mbt
@@ -331,13 +331,13 @@ pub fn Lock::Lock(
 }
 
 ///|
-enum RepositoryIdentity {
+pub enum RepositoryIdentity {
   GitHubIdentity(GitHubRepository)
   LocalIdentity(RelativeSourcePath)
 } derive(Eq, Hash)
 
 ///|
-fn LockRepository::identity(self : LockRepository) -> RepositoryIdentity {
+pub fn LockRepository::identity(self : LockRepository) -> RepositoryIdentity {
   match self {
     GitHub(repository) => GitHubIdentity(repository.repository)
     Local(repository) => LocalIdentity(repository.path)

--- a/mbt/app/c-plugin-v2/src/lock_domain.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_domain.mbt
@@ -1,7 +1,7 @@
 ///|
 pub struct GitHubOwner {
   value : String
-} derive(Eq)
+} derive(Eq, Hash)
 
 ///|
 pub fn GitHubOwner::GitHubOwner(value : String) -> GitHubOwner raise {
@@ -21,7 +21,7 @@ pub fn GitHubOwner::GitHubOwner(value : String) -> GitHubOwner raise {
 ///|
 pub struct GitHubRepositoryName {
   value : String
-} derive(Eq)
+} derive(Eq, Hash)
 
 ///|
 pub fn GitHubRepositoryName::GitHubRepositoryName(
@@ -47,7 +47,7 @@ pub fn GitHubRepositoryName::GitHubRepositoryName(
 pub struct GitHubRepository {
   owner : GitHubOwner
   name : GitHubRepositoryName
-} derive(Eq)
+} derive(Eq, Hash)
 
 ///|
 pub fn GitHubRepository::GitHubRepository(
@@ -83,6 +83,11 @@ pub struct Target {
 } derive(Eq)
 
 ///|
+pub impl Hash for Target with fn hash_combine(self, hasher) {
+  self.path.to_string().hash_combine(hasher)
+}
+
+///|
 pub fn Target::Target(path : @path.Path) -> Target raise {
   guard path.to_string() != "" else { fail("target path must not be empty") }
   { path: path.normalize() }
@@ -92,6 +97,11 @@ pub fn Target::Target(path : @path.Path) -> Target raise {
 pub struct RelativeSourcePath {
   path : @path.Path
 } derive(Eq)
+
+///|
+pub impl Hash for RelativeSourcePath with fn hash_combine(self, hasher) {
+  self.path.to_string().hash_combine(hasher)
+}
 
 ///|
 pub fn RelativeSourcePath::RelativeSourcePath(
@@ -105,6 +115,11 @@ pub fn RelativeSourcePath::RelativeSourcePath(
 pub struct RelativePluginPath {
   path : @path.Path
 } derive(Eq)
+
+///|
+pub impl Hash for RelativePluginPath with fn hash_combine(self, hasher) {
+  self.path.to_string().hash_combine(hasher)
+}
 
 ///|
 pub fn RelativePluginPath::RelativePluginPath(
@@ -132,7 +147,7 @@ fn validate_relative_path(path : @path.Path, kind : String) -> Unit raise {
 ///|
 pub struct PluginName {
   value : String
-} derive(Eq)
+} derive(Eq, Hash)
 
 ///|
 pub fn PluginName::PluginName(value : String) -> PluginName raise {
@@ -143,7 +158,7 @@ pub fn PluginName::PluginName(value : String) -> PluginName raise {
 ///|
 pub struct SkillName {
   value : String
-} derive(Eq)
+} derive(Eq, Hash)
 
 ///|
 pub fn SkillName::SkillName(value : String) -> SkillName raise {
@@ -208,8 +223,20 @@ pub fn MarketplaceKind::codex() -> MarketplaceKind {
 pub struct Plugin {
   name : PluginName
   path : RelativePluginPath
-  priv enabled_skills : Array[SkillName]
-} derive(Eq)
+  priv enabled_skills : Set[SkillName]
+}
+
+///|
+pub impl Eq for Plugin with fn equal(self, other) {
+  self.name == other.name &&
+  self.path == other.path &&
+  ordered_iter_equal(
+    self.enabled_skills.iter(),
+    other.enabled_skills.iter(),
+    self.enabled_skills.length(),
+    other.enabled_skills.length(),
+  )
+}
 
 ///|
 pub fn Plugin::Plugin(
@@ -217,15 +244,18 @@ pub fn Plugin::Plugin(
   path : RelativePluginPath,
   enabled_skills : Array[SkillName],
 ) -> Plugin raise {
-  guard unique_skill_count(enabled_skills) == enabled_skills.length() else {
-    fail("plugin enabled skills must be unique")
+  let stored_skills : Set[SkillName] = Set::default()
+  for skill in enabled_skills {
+    guard stored_skills.add_and_check(skill) else {
+      fail("plugin enabled skills must be unique")
+    }
   }
-  { name, path, enabled_skills: [..enabled_skills] }
+  { name, path, enabled_skills: stored_skills }
 }
 
 ///|
 pub fn Plugin::enabled_skills(self : Plugin) -> ReadOnlyArray[SkillName] {
-  ReadOnlyArray::from_array(self.enabled_skills)
+  ReadOnlyArray::from_array(self.enabled_skills.to_array())
 }
 
 ///|
@@ -233,8 +263,21 @@ pub struct GitHubLockRepository {
   repository : GitHubRepository
   marketplace_kind : MarketplaceKind
   commit : CommitId
-  priv plugins : Array[Plugin]
-} derive(Eq)
+  priv plugins : Map[PluginName, Plugin]
+}
+
+///|
+pub impl Eq for GitHubLockRepository with fn equal(self, other) {
+  self.repository == other.repository &&
+  self.marketplace_kind == other.marketplace_kind &&
+  self.commit == other.commit &&
+  ordered_iter_equal(
+    self.plugins.values(),
+    other.plugins.values(),
+    self.plugins.length(),
+    other.plugins.length(),
+  )
+}
 
 ///|
 pub fn GitHubLockRepository::GitHubLockRepository(
@@ -243,25 +286,41 @@ pub fn GitHubLockRepository::GitHubLockRepository(
   commit : CommitId,
   plugins : Array[Plugin],
 ) -> GitHubLockRepository raise {
-  guard unique_plugin_count(plugins) == plugins.length() else {
-    fail("repository plugin names must be unique")
+  let stored_plugins : Map[PluginName, Plugin] = Map([])
+  for plugin in plugins {
+    guard !stored_plugins.contains(plugin.name) else {
+      fail("repository plugin names must be unique")
+    }
+    stored_plugins[plugin.name] = plugin
   }
-  { repository, marketplace_kind, commit, plugins: [..plugins] }
+  { repository, marketplace_kind, commit, plugins: stored_plugins }
 }
 
 ///|
 pub fn GitHubLockRepository::plugins(
   self : GitHubLockRepository,
 ) -> ReadOnlyArray[Plugin] {
-  ReadOnlyArray::from_array(self.plugins)
+  ReadOnlyArray::from_array(self.plugins.values().collect())
 }
 
 ///|
 pub struct LocalLockRepository {
   path : RelativeSourcePath
   marketplace_kind : MarketplaceKind
-  priv plugins : Array[Plugin]
-} derive(Eq)
+  priv plugins : Map[PluginName, Plugin]
+}
+
+///|
+pub impl Eq for LocalLockRepository with fn equal(self, other) {
+  self.path == other.path &&
+  self.marketplace_kind == other.marketplace_kind &&
+  ordered_iter_equal(
+    self.plugins.values(),
+    other.plugins.values(),
+    self.plugins.length(),
+    other.plugins.length(),
+  )
+}
 
 ///|
 pub fn LocalLockRepository::LocalLockRepository(
@@ -269,17 +328,21 @@ pub fn LocalLockRepository::LocalLockRepository(
   marketplace_kind : MarketplaceKind,
   plugins : Array[Plugin],
 ) -> LocalLockRepository raise {
-  guard unique_plugin_count(plugins) == plugins.length() else {
-    fail("repository plugin names must be unique")
+  let stored_plugins : Map[PluginName, Plugin] = Map([])
+  for plugin in plugins {
+    guard !stored_plugins.contains(plugin.name) else {
+      fail("repository plugin names must be unique")
+    }
+    stored_plugins[plugin.name] = plugin
   }
-  { path, marketplace_kind, plugins: [..plugins] }
+  { path, marketplace_kind, plugins: stored_plugins }
 }
 
 ///|
 pub fn LocalLockRepository::plugins(
   self : LocalLockRepository,
 ) -> ReadOnlyArray[Plugin] {
-  ReadOnlyArray::from_array(self.plugins)
+  ReadOnlyArray::from_array(self.plugins.values().collect())
 }
 
 ///|
@@ -305,96 +368,80 @@ pub fn LockRepository::from_local(
 ///|
 pub struct Lock {
   version : Int
-  priv targets : Array[Target]
-  priv repositories : Array[LockRepository]
-} derive(Eq)
+  priv targets : Set[Target]
+  priv repositories : Map[RepositoryIdentity, LockRepository]
+}
+
+///|
+pub impl Eq for Lock with fn equal(self, other) {
+  self.version == other.version &&
+  ordered_iter_equal(
+    self.targets.iter(),
+    other.targets.iter(),
+    self.targets.length(),
+    other.targets.length(),
+  ) &&
+  ordered_iter_equal(
+    self.repositories.values(),
+    other.repositories.values(),
+    self.repositories.length(),
+    other.repositories.length(),
+  )
+}
 
 ///|
 pub fn Lock::Lock(
   targets : Array[Target],
   repositories : Array[LockRepository],
 ) -> Lock raise {
-  guard unique_target_count(targets) == targets.length() else {
-    fail("lock targets must be unique")
+  let stored_targets : Set[Target] = Set::default()
+  for target in targets {
+    guard stored_targets.add_and_check(target) else {
+      fail("lock targets must be unique")
+    }
   }
-  guard unique_repository_count(repositories) == repositories.length() else {
-    fail("lock repositories must be unique")
+  let stored_repositories : Map[RepositoryIdentity, LockRepository] = Map([])
+  for repository in repositories {
+    let identity = repository.identity()
+    guard !stored_repositories.contains(identity) else {
+      fail("lock repositories must be unique")
+    }
+    stored_repositories[identity] = repository
   }
-  { version: 2, targets: [..targets], repositories: [..repositories] }
+  { version: 2, targets: stored_targets, repositories: stored_repositories }
 }
 
 ///|
 pub fn Lock::targets(self : Lock) -> ReadOnlyArray[Target] {
-  ReadOnlyArray::from_array(self.targets)
+  ReadOnlyArray::from_array(self.targets.to_array())
 }
 
 ///|
 pub fn Lock::repositories(self : Lock) -> ReadOnlyArray[LockRepository] {
-  ReadOnlyArray::from_array(self.repositories)
-}
-
-///|
-fn unique_skill_count(skills : Array[SkillName]) -> Int {
-  skills
-  .iter()
-  .fold(init=[], fn(unique, skill) {
-    if unique.contains(skill) {
-      unique
-    } else {
-      [..unique, skill]
-    }
-  })
-  .length()
-}
-
-///|
-fn unique_plugin_count(plugins : Array[Plugin]) -> Int {
-  plugins
-  .iter()
-  .fold(init=[], fn(unique, plugin) {
-    if unique.contains(plugin.name) {
-      unique
-    } else {
-      [..unique, plugin.name]
-    }
-  })
-  .length()
-}
-
-///|
-fn unique_target_count(targets : Array[Target]) -> Int {
-  targets
-  .iter()
-  .fold(init=[], fn(unique, target) {
-    if unique.contains(target) {
-      unique
-    } else {
-      [..unique, target]
-    }
-  })
-  .length()
+  ReadOnlyArray::from_array(self.repositories.values().collect())
 }
 
 ///|
 enum RepositoryIdentity {
   GitHubIdentity(GitHubRepository)
   LocalIdentity(RelativeSourcePath)
-} derive(Eq)
+} derive(Eq, Hash)
 
 ///|
-fn unique_repository_count(repositories : Array[LockRepository]) -> Int {
-  repositories
-  .iter()
-  .fold(init=[], fn(unique, repository) {
-    let identity = match repository {
-      GitHub(repository) => GitHubIdentity(repository.repository)
-      Local(repository) => LocalIdentity(repository.path)
-    }
-    if unique.contains(identity) {
-      unique
-    } else {
-      [..unique, identity]
-    }
-  })
-  .length()
+fn LockRepository::identity(self : LockRepository) -> RepositoryIdentity {
+  match self {
+    GitHub(repository) => GitHubIdentity(repository.repository)
+    Local(repository) => LocalIdentity(repository.path)
+  }
+}
+
+///|
+fn[X : Eq] ordered_iter_equal(
+  left : Iter[X],
+  right : Iter[X],
+  left_length : Int,
+  right_length : Int,
+) -> Bool {
+  left_length == right_length &&
+  left.zip(right).all(fn(pair) { pair.0 == pair.1 })
 }

--- a/mbt/app/c-plugin-v2/src/lock_domain.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_domain.mbt
@@ -223,20 +223,8 @@ pub fn MarketplaceKind::codex() -> MarketplaceKind {
 pub struct Plugin {
   name : PluginName
   path : RelativePluginPath
-  priv enabled_skills : Set[SkillName]
-}
-
-///|
-pub impl Eq for Plugin with fn equal(self, other) {
-  self.name == other.name &&
-  self.path == other.path &&
-  ordered_iter_equal(
-    self.enabled_skills.iter(),
-    other.enabled_skills.iter(),
-    self.enabled_skills.length(),
-    other.enabled_skills.length(),
-  )
-}
+  enabled_skills : @immut_hashset.HashSet[SkillName]
+} derive(Eq)
 
 ///|
 pub fn Plugin::Plugin(
@@ -244,18 +232,11 @@ pub fn Plugin::Plugin(
   path : RelativePluginPath,
   enabled_skills : Array[SkillName],
 ) -> Plugin raise {
-  let stored_skills : Set[SkillName] = Set::default()
-  for skill in enabled_skills {
-    guard stored_skills.add_and_check(skill) else {
-      fail("plugin enabled skills must be unique")
-    }
+  let stored_skills = @immut_hashset.HashSet(enabled_skills)
+  guard stored_skills.length() == enabled_skills.length() else {
+    fail("plugin enabled skills must be unique")
   }
   { name, path, enabled_skills: stored_skills }
-}
-
-///|
-pub fn Plugin::enabled_skills(self : Plugin) -> ReadOnlyArray[SkillName] {
-  ReadOnlyArray::from_array(self.enabled_skills.to_array())
 }
 
 ///|
@@ -263,21 +244,8 @@ pub struct GitHubLockRepository {
   repository : GitHubRepository
   marketplace_kind : MarketplaceKind
   commit : CommitId
-  priv plugins : Map[PluginName, Plugin]
-}
-
-///|
-pub impl Eq for GitHubLockRepository with fn equal(self, other) {
-  self.repository == other.repository &&
-  self.marketplace_kind == other.marketplace_kind &&
-  self.commit == other.commit &&
-  ordered_iter_equal(
-    self.plugins.values(),
-    other.plugins.values(),
-    self.plugins.length(),
-    other.plugins.length(),
-  )
-}
+  plugins : @immut_hashmap.HashMap[PluginName, Plugin]
+} derive(Eq)
 
 ///|
 pub fn GitHubLockRepository::GitHubLockRepository(
@@ -286,41 +254,21 @@ pub fn GitHubLockRepository::GitHubLockRepository(
   commit : CommitId,
   plugins : Array[Plugin],
 ) -> GitHubLockRepository raise {
-  let stored_plugins : Map[PluginName, Plugin] = Map([])
-  for plugin in plugins {
-    guard !stored_plugins.contains(plugin.name) else {
-      fail("repository plugin names must be unique")
-    }
-    stored_plugins[plugin.name] = plugin
+  let stored_plugins = @immut_hashmap.HashMap(
+    plugins.map(plugin => (plugin.name, plugin)),
+  )
+  guard stored_plugins.length() == plugins.length() else {
+    fail("repository plugin names must be unique")
   }
   { repository, marketplace_kind, commit, plugins: stored_plugins }
-}
-
-///|
-pub fn GitHubLockRepository::plugins(
-  self : GitHubLockRepository,
-) -> ReadOnlyArray[Plugin] {
-  ReadOnlyArray::from_array(self.plugins.values().collect())
 }
 
 ///|
 pub struct LocalLockRepository {
   path : RelativeSourcePath
   marketplace_kind : MarketplaceKind
-  priv plugins : Map[PluginName, Plugin]
-}
-
-///|
-pub impl Eq for LocalLockRepository with fn equal(self, other) {
-  self.path == other.path &&
-  self.marketplace_kind == other.marketplace_kind &&
-  ordered_iter_equal(
-    self.plugins.values(),
-    other.plugins.values(),
-    self.plugins.length(),
-    other.plugins.length(),
-  )
-}
+  plugins : @immut_hashmap.HashMap[PluginName, Plugin]
+} derive(Eq)
 
 ///|
 pub fn LocalLockRepository::LocalLockRepository(
@@ -328,21 +276,13 @@ pub fn LocalLockRepository::LocalLockRepository(
   marketplace_kind : MarketplaceKind,
   plugins : Array[Plugin],
 ) -> LocalLockRepository raise {
-  let stored_plugins : Map[PluginName, Plugin] = Map([])
-  for plugin in plugins {
-    guard !stored_plugins.contains(plugin.name) else {
-      fail("repository plugin names must be unique")
-    }
-    stored_plugins[plugin.name] = plugin
+  let stored_plugins = @immut_hashmap.HashMap(
+    plugins.map(plugin => (plugin.name, plugin)),
+  )
+  guard stored_plugins.length() == plugins.length() else {
+    fail("repository plugin names must be unique")
   }
   { path, marketplace_kind, plugins: stored_plugins }
-}
-
-///|
-pub fn LocalLockRepository::plugins(
-  self : LocalLockRepository,
-) -> ReadOnlyArray[Plugin] {
-  ReadOnlyArray::from_array(self.plugins.values().collect())
 }
 
 ///|
@@ -368,57 +308,26 @@ pub fn LockRepository::from_local(
 ///|
 pub struct Lock {
   version : Int
-  priv targets : Set[Target]
-  priv repositories : Map[RepositoryIdentity, LockRepository]
-}
-
-///|
-pub impl Eq for Lock with fn equal(self, other) {
-  self.version == other.version &&
-  ordered_iter_equal(
-    self.targets.iter(),
-    other.targets.iter(),
-    self.targets.length(),
-    other.targets.length(),
-  ) &&
-  ordered_iter_equal(
-    self.repositories.values(),
-    other.repositories.values(),
-    self.repositories.length(),
-    other.repositories.length(),
-  )
-}
+  targets : @immut_hashset.HashSet[Target]
+  repositories : @immut_hashmap.HashMap[RepositoryIdentity, LockRepository]
+} derive(Eq)
 
 ///|
 pub fn Lock::Lock(
   targets : Array[Target],
   repositories : Array[LockRepository],
 ) -> Lock raise {
-  let stored_targets : Set[Target] = Set::default()
-  for target in targets {
-    guard stored_targets.add_and_check(target) else {
-      fail("lock targets must be unique")
-    }
+  let stored_targets = @immut_hashset.HashSet(targets)
+  guard stored_targets.length() == targets.length() else {
+    fail("lock targets must be unique")
   }
-  let stored_repositories : Map[RepositoryIdentity, LockRepository] = Map([])
-  for repository in repositories {
-    let identity = repository.identity()
-    guard !stored_repositories.contains(identity) else {
-      fail("lock repositories must be unique")
-    }
-    stored_repositories[identity] = repository
+  let stored_repositories = @immut_hashmap.HashMap(
+    repositories.map(repository => (repository.identity(), repository)),
+  )
+  guard stored_repositories.length() == repositories.length() else {
+    fail("lock repositories must be unique")
   }
   { version: 2, targets: stored_targets, repositories: stored_repositories }
-}
-
-///|
-pub fn Lock::targets(self : Lock) -> ReadOnlyArray[Target] {
-  ReadOnlyArray::from_array(self.targets.to_array())
-}
-
-///|
-pub fn Lock::repositories(self : Lock) -> ReadOnlyArray[LockRepository] {
-  ReadOnlyArray::from_array(self.repositories.values().collect())
 }
 
 ///|
@@ -433,15 +342,4 @@ fn LockRepository::identity(self : LockRepository) -> RepositoryIdentity {
     GitHub(repository) => GitHubIdentity(repository.repository)
     Local(repository) => LocalIdentity(repository.path)
   }
-}
-
-///|
-fn[X : Eq] ordered_iter_equal(
-  left : Iter[X],
-  right : Iter[X],
-  left_length : Int,
-  right_length : Int,
-) -> Bool {
-  left_length == right_length &&
-  left.zip(right).all(fn(pair) { pair.0 == pair.1 })
 }

--- a/mbt/app/c-plugin-v2/src/lock_domain_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_domain_wbtest.mbt
@@ -170,7 +170,7 @@ test "path identity Hash::hash - matches normalized equality" {
 }
 
 ///|
-test "lock domain preserves version two order and equality" {
+test "lock domain equality ignores collection input order" {
   let plugin = Plugin::Plugin(
     PluginName::PluginName("c-plugin"),
     RelativePluginPath::RelativePluginPath("plugins/c-plugin"),
@@ -206,7 +206,7 @@ test "lock domain preserves version two order and equality" {
     RelativePluginPath::RelativePluginPath("plugins/c-plugin"),
     [SkillName::SkillName("sync"), SkillName::SkillName("install")],
   )
-  inspect(plugin == reordered_plugin, content="false")
+  inspect(plugin == reordered_plugin, content="true")
   let second_plugin = Plugin::Plugin(
     PluginName::PluginName("second"),
     RelativePluginPath::RelativePluginPath("plugins/second"),
@@ -224,7 +224,7 @@ test "lock domain preserves version two order and equality" {
     CommitId::CommitId("0123456789abcdef0123456789abcdef01234567"),
     [second_plugin, plugin],
   )
-  inspect(ordered_github == reordered_github, content="false")
+  inspect(ordered_github == reordered_github, content="true")
   let ordered_local = LocalLockRepository::LocalLockRepository(
     RelativeSourcePath::RelativeSourcePath("vendor/plugin"),
     MarketplaceKind::claude(),
@@ -235,21 +235,23 @@ test "lock domain preserves version two order and equality" {
     MarketplaceKind::claude(),
     [second_plugin, plugin],
   )
-  inspect(ordered_local == reordered_local, content="false")
+  inspect(ordered_local == reordered_local, content="true")
   let target_reordered_lock = Lock::Lock(
     [Target::Target(".cursor/skills"), Target::Target(".agents/skills")],
     [github, local_repository],
   )
-  inspect(lock == target_reordered_lock, content="false")
+  inspect(lock == target_reordered_lock, content="true")
   let repository_reordered_lock = Lock::Lock(
     [Target::Target(".agents/skills"), Target::Target(".cursor/skills")],
     [local_repository, github],
   )
-  inspect(lock == repository_reordered_lock, content="false")
+  inspect(lock == repository_reordered_lock, content="true")
   inspect(lock.version, content="2")
-  inspect(lock.targets()[0].path.to_string(), content=".agents/skills")
-  inspect(lock.repositories()[0] == github, content="true")
-  match lock.repositories()[0] {
+  inspect(
+    lock.targets.contains(Target::Target(".agents/skills")),
+    content="true",
+  )
+  match lock.repositories[github.identity()] {
     LockRepository::GitHub(repository) => {
       inspect(repository.repository.owner.value, content="openai")
       inspect(repository.repository.name.value, content="codex")
@@ -259,67 +261,72 @@ test "lock domain preserves version two order and equality" {
         content="0123456789abcdef0123456789abcdef01234567",
       )
       inspect(
-        repository.plugins()[0].enabled_skills()[0].value,
-        content="install",
+        repository.plugins[plugin.name].enabled_skills.contains(
+          SkillName::SkillName("install"),
+        ),
+        content="true",
       )
     }
-    LockRepository::Local(_) =>
-      fail("first repository must preserve GitHub order")
+    LockRepository::Local(_) => fail("expected GitHub repository")
   }
 }
 
 ///|
-test "mutable aggregate fields expose detached readonly snapshots" {
+test "aggregate collections are immutable values" {
   let plugin = Plugin::Plugin(
     PluginName::PluginName("plugin"),
     RelativePluginPath::RelativePluginPath("plugin"),
     [SkillName::SkillName("install")],
   )
-  let enabled_skills = plugin.enabled_skills()
-  plugin.enabled_skills.add(SkillName::SkillName("sync"))
-  inspect(enabled_skills.length(), content="1")
-  inspect(plugin.enabled_skills().length(), content="2")
+  let expanded_skills = plugin.enabled_skills.add(SkillName::SkillName("sync"))
+  inspect(plugin.enabled_skills.length(), content="1")
+  inspect(expanded_skills.length(), content="2")
   let github = GitHubLockRepository::GitHubLockRepository(
     GitHubRepository::from_route("openai/codex"),
     MarketplaceKind::codex(),
     CommitId::CommitId("0123456789abcdef0123456789abcdef01234567"),
     [plugin],
   )
-  let github_plugins = github.plugins()
   let github_extra = Plugin::Plugin(
     PluginName::PluginName("github-extra"),
     RelativePluginPath::RelativePluginPath("github-extra"),
     [],
   )
-  github.plugins[github_extra.name] = github_extra
-  inspect(github_plugins.length(), content="1")
-  inspect(github.plugins().length(), content="2")
+  let expanded_github_plugins = github.plugins.add(
+    github_extra.name,
+    github_extra,
+  )
+  inspect(github.plugins.length(), content="1")
+  inspect(expanded_github_plugins.length(), content="2")
   let local_repository = LocalLockRepository::LocalLockRepository(
     RelativeSourcePath::RelativeSourcePath("vendor/plugin"),
     MarketplaceKind::claude(),
     [plugin],
   )
-  let local_plugins = local_repository.plugins()
   let local_extra = Plugin::Plugin(
     PluginName::PluginName("local-extra"),
     RelativePluginPath::RelativePluginPath("local-extra"),
     [],
   )
-  local_repository.plugins[local_extra.name] = local_extra
-  inspect(local_plugins.length(), content="1")
-  inspect(local_repository.plugins().length(), content="2")
+  let expanded_local_plugins = local_repository.plugins.add(
+    local_extra.name,
+    local_extra,
+  )
+  inspect(local_repository.plugins.length(), content="1")
+  inspect(expanded_local_plugins.length(), content="2")
   let lock = Lock::Lock([Target::Target(".agents/skills")], [
     LockRepository::github(github),
   ])
-  let targets = lock.targets()
-  let repositories = lock.repositories()
-  lock.targets.add(Target::Target(".cursor/skills"))
+  let expanded_targets = lock.targets.add(Target::Target(".cursor/skills"))
   let added_repository = LockRepository::from_local(local_repository)
-  lock.repositories[added_repository.identity()] = added_repository
-  inspect(targets.length(), content="1")
-  inspect(repositories.length(), content="1")
-  inspect(lock.targets().length(), content="2")
-  inspect(lock.repositories().length(), content="2")
+  let expanded_repositories = lock.repositories.add(
+    added_repository.identity(),
+    added_repository,
+  )
+  inspect(lock.targets.length(), content="1")
+  inspect(lock.repositories.length(), content="1")
+  inspect(expanded_targets.length(), content="2")
+  inspect(expanded_repositories.length(), content="2")
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/lock_domain_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_domain_wbtest.mbt
@@ -150,6 +150,26 @@ test "SkillName preserves the c-plugin skill namespace" {
 }
 
 ///|
+test "path identity Hash::hash - matches normalized equality" {
+  let target = Target::Target(".agents/skills")
+  let equivalent_target = Target::Target(".agents/./skills")
+  inspect(target == equivalent_target, content="true")
+  inspect(target.hash() == equivalent_target.hash(), content="true")
+  let source = RelativeSourcePath::RelativeSourcePath("vendor/plugin")
+  let equivalent_source = RelativeSourcePath::RelativeSourcePath(
+    "vendor/./plugin",
+  )
+  inspect(source == equivalent_source, content="true")
+  inspect(source.hash() == equivalent_source.hash(), content="true")
+  let plugin_path = RelativePluginPath::RelativePluginPath("plugins/example")
+  let equivalent_plugin_path = RelativePluginPath::RelativePluginPath(
+    "plugins/./example",
+  )
+  inspect(plugin_path == equivalent_plugin_path, content="true")
+  inspect(plugin_path.hash() == equivalent_plugin_path.hash(), content="true")
+}
+
+///|
 test "lock domain preserves version two order and equality" {
   let plugin = Plugin::Plugin(
     PluginName::PluginName("c-plugin"),
@@ -181,6 +201,51 @@ test "lock domain preserves version two order and equality" {
     [Target::Target(".agents/skills"), Target::Target(".cursor/skills")],
     [github, local_repository],
   )
+  let reordered_plugin = Plugin::Plugin(
+    PluginName::PluginName("c-plugin"),
+    RelativePluginPath::RelativePluginPath("plugins/c-plugin"),
+    [SkillName::SkillName("sync"), SkillName::SkillName("install")],
+  )
+  inspect(plugin == reordered_plugin, content="false")
+  let second_plugin = Plugin::Plugin(
+    PluginName::PluginName("second"),
+    RelativePluginPath::RelativePluginPath("plugins/second"),
+    [],
+  )
+  let ordered_github = GitHubLockRepository::GitHubLockRepository(
+    GitHubRepository::from_route("openai/codex"),
+    MarketplaceKind::codex(),
+    CommitId::CommitId("0123456789abcdef0123456789abcdef01234567"),
+    [plugin, second_plugin],
+  )
+  let reordered_github = GitHubLockRepository::GitHubLockRepository(
+    GitHubRepository::from_route("openai/codex"),
+    MarketplaceKind::codex(),
+    CommitId::CommitId("0123456789abcdef0123456789abcdef01234567"),
+    [second_plugin, plugin],
+  )
+  inspect(ordered_github == reordered_github, content="false")
+  let ordered_local = LocalLockRepository::LocalLockRepository(
+    RelativeSourcePath::RelativeSourcePath("vendor/plugin"),
+    MarketplaceKind::claude(),
+    [plugin, second_plugin],
+  )
+  let reordered_local = LocalLockRepository::LocalLockRepository(
+    RelativeSourcePath::RelativeSourcePath("vendor/plugin"),
+    MarketplaceKind::claude(),
+    [second_plugin, plugin],
+  )
+  inspect(ordered_local == reordered_local, content="false")
+  let target_reordered_lock = Lock::Lock(
+    [Target::Target(".cursor/skills"), Target::Target(".agents/skills")],
+    [github, local_repository],
+  )
+  inspect(lock == target_reordered_lock, content="false")
+  let repository_reordered_lock = Lock::Lock(
+    [Target::Target(".agents/skills"), Target::Target(".cursor/skills")],
+    [local_repository, github],
+  )
+  inspect(lock == repository_reordered_lock, content="false")
   inspect(lock.version, content="2")
   inspect(lock.targets()[0].path.to_string(), content=".agents/skills")
   inspect(lock.repositories()[0] == github, content="true")
@@ -211,7 +276,7 @@ test "mutable aggregate fields expose detached readonly snapshots" {
     [SkillName::SkillName("install")],
   )
   let enabled_skills = plugin.enabled_skills()
-  plugin.enabled_skills.push(SkillName::SkillName("sync"))
+  plugin.enabled_skills.add(SkillName::SkillName("sync"))
   inspect(enabled_skills.length(), content="1")
   inspect(plugin.enabled_skills().length(), content="2")
   let github = GitHubLockRepository::GitHubLockRepository(
@@ -221,13 +286,12 @@ test "mutable aggregate fields expose detached readonly snapshots" {
     [plugin],
   )
   let github_plugins = github.plugins()
-  github.plugins.push(
-    Plugin::Plugin(
-      PluginName::PluginName("github-extra"),
-      RelativePluginPath::RelativePluginPath("github-extra"),
-      [],
-    ),
+  let github_extra = Plugin::Plugin(
+    PluginName::PluginName("github-extra"),
+    RelativePluginPath::RelativePluginPath("github-extra"),
+    [],
   )
+  github.plugins[github_extra.name] = github_extra
   inspect(github_plugins.length(), content="1")
   inspect(github.plugins().length(), content="2")
   let local_repository = LocalLockRepository::LocalLockRepository(
@@ -236,13 +300,12 @@ test "mutable aggregate fields expose detached readonly snapshots" {
     [plugin],
   )
   let local_plugins = local_repository.plugins()
-  local_repository.plugins.push(
-    Plugin::Plugin(
-      PluginName::PluginName("local-extra"),
-      RelativePluginPath::RelativePluginPath("local-extra"),
-      [],
-    ),
+  let local_extra = Plugin::Plugin(
+    PluginName::PluginName("local-extra"),
+    RelativePluginPath::RelativePluginPath("local-extra"),
+    [],
   )
+  local_repository.plugins[local_extra.name] = local_extra
   inspect(local_plugins.length(), content="1")
   inspect(local_repository.plugins().length(), content="2")
   let lock = Lock::Lock([Target::Target(".agents/skills")], [
@@ -250,8 +313,9 @@ test "mutable aggregate fields expose detached readonly snapshots" {
   ])
   let targets = lock.targets()
   let repositories = lock.repositories()
-  lock.targets.push(Target::Target(".cursor/skills"))
-  lock.repositories.push(LockRepository::from_local(local_repository))
+  lock.targets.add(Target::Target(".cursor/skills"))
+  let added_repository = LockRepository::from_local(local_repository)
+  lock.repositories[added_repository.identity()] = added_repository
   inspect(targets.length(), content="1")
   inspect(repositories.length(), content="1")
   inspect(lock.targets().length(), content="2")

--- a/mbt/app/c-plugin-v2/src/lock_domain_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_domain_wbtest.mbt
@@ -123,6 +123,42 @@ test "domain names reject empty and slash values" {
 }
 
 ///|
+test "PluginName Compare::compare - uses lexical order" {
+  let alpha = PluginName::PluginName("alpha")
+  let z = PluginName::PluginName("z")
+  inspect(alpha.compare(z), content="-1")
+}
+
+///|
+test "SkillName Compare::compare - uses lexical order" {
+  let install = SkillName::SkillName("install")
+  let sync = SkillName::SkillName("sync")
+  inspect(install.compare(sync), content="-1")
+}
+
+///|
+test "Target Compare::compare - uses normalized lexical path order" {
+  let agents = Target::Target("project/other/../.agents")
+  let cursor = Target::Target("project/.cursor")
+  inspect(agents.compare(cursor), content="-1")
+}
+
+///|
+test "RepositoryIdentity Compare::compare - orders type then identity" {
+  let github = RepositoryIdentity::GitHubIdentity(
+    GitHubRepository::from_route("alpha/z"),
+  )
+  let later_github = RepositoryIdentity::GitHubIdentity(
+    GitHubRepository::from_route("z/a"),
+  )
+  let local_repository = RepositoryIdentity::LocalIdentity(
+    RelativeSourcePath::RelativeSourcePath("alpha"),
+  )
+  inspect(github.compare(later_github), content="-1")
+  inspect(later_github.compare(local_repository), content="-1")
+}
+
+///|
 test "CommitId rejects bad length and hexadecimal boundaries" {
   expect_rejection(
     fn() -> Unit raise {

--- a/mbt/app/c-plugin-v2/src/moon.pkg
+++ b/mbt/app/c-plugin-v2/src/moon.pkg
@@ -4,6 +4,8 @@ import {
   "moonbitlang/async/os_error",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
+  "moonbitlang/core/immut/hashmap" @immut_hashmap,
+  "moonbitlang/core/immut/hashset" @immut_hashset,
   "moonbitlang/core/json",
   "moonbitlang/x/path",
   "shu-kitamura/sha256",

--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -92,31 +92,55 @@ pub fn OwnershipEntry::OwnershipEntry(
 ///|
 pub struct OwnershipState {
   version : Int
-  priv entries : Array[OwnershipEntry]
+  priv entries : Map[OwnershipLinkIdentity, OwnershipEntry]
+}
+
+///|
+pub impl Eq for OwnershipState with fn equal(self, other) {
+  self.version == other.version &&
+  ordered_iter_equal(
+    self.entries.values(),
+    other.entries.values(),
+    self.entries.length(),
+    other.entries.length(),
+  )
+}
+
+///|
+struct OwnershipLinkIdentity {
+  path : @path.Path
 } derive(Eq)
+
+///|
+fn OwnershipLinkIdentity::OwnershipLinkIdentity(
+  path : @path.Path,
+) -> OwnershipLinkIdentity {
+  { path: path.normalize() }
+}
+
+///|
+impl Hash for OwnershipLinkIdentity with fn hash_combine(self, hasher) {
+  self.path.to_string().hash_combine(hasher)
+}
 
 ///|
 pub fn OwnershipState::OwnershipState(
   entries : Array[OwnershipEntry],
 ) -> OwnershipState raise {
-  let unique_links = entries
-    .iter()
-    .fold(init=[], fn(unique, entry) {
-      if unique.contains(entry.link) {
-        unique
-      } else {
-        [..unique, entry.link]
-      }
-    })
-  guard unique_links.length() == entries.length() else {
-    fail("ownership links must be unique")
+  let stored_entries : Map[OwnershipLinkIdentity, OwnershipEntry] = Map([])
+  for entry in entries {
+    let identity = OwnershipLinkIdentity(entry.link)
+    guard !stored_entries.contains(identity) else {
+      fail("ownership links must be unique")
+    }
+    stored_entries[identity] = entry
   }
-  { version: 1, entries: [..entries] }
+  { version: 1, entries: stored_entries }
 }
 
 ///|
 pub fn OwnershipState::entries(
   self : OwnershipState,
 ) -> ReadOnlyArray[OwnershipEntry] {
-  ReadOnlyArray::from_array(self.entries)
+  ReadOnlyArray::from_array(self.entries.values().collect())
 }

--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -108,7 +108,7 @@ pub fn OwnershipLinkIdentity::OwnershipLinkIdentity(
 }
 
 ///|
-impl Hash for OwnershipLinkIdentity with fn hash_combine(self, hasher) {
+pub impl Hash for OwnershipLinkIdentity with fn hash_combine(self, hasher) {
   self.path.to_string().hash_combine(hasher)
 }
 

--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -101,6 +101,11 @@ pub struct OwnershipLinkIdentity {
 } derive(Eq)
 
 ///|
+pub impl Compare for OwnershipLinkIdentity with fn compare(self, other) {
+  self.path.to_string().lexical_compare(other.path.to_string())
+}
+
+///|
 pub fn OwnershipLinkIdentity::OwnershipLinkIdentity(
   path : @path.Path,
 ) -> OwnershipLinkIdentity {

--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -92,19 +92,8 @@ pub fn OwnershipEntry::OwnershipEntry(
 ///|
 pub struct OwnershipState {
   version : Int
-  priv entries : Map[OwnershipLinkIdentity, OwnershipEntry]
-}
-
-///|
-pub impl Eq for OwnershipState with fn equal(self, other) {
-  self.version == other.version &&
-  ordered_iter_equal(
-    self.entries.values(),
-    other.entries.values(),
-    self.entries.length(),
-    other.entries.length(),
-  )
-}
+  entries : @immut_hashmap.HashMap[OwnershipLinkIdentity, OwnershipEntry]
+} derive(Eq)
 
 ///|
 struct OwnershipLinkIdentity {
@@ -127,20 +116,11 @@ impl Hash for OwnershipLinkIdentity with fn hash_combine(self, hasher) {
 pub fn OwnershipState::OwnershipState(
   entries : Array[OwnershipEntry],
 ) -> OwnershipState raise {
-  let stored_entries : Map[OwnershipLinkIdentity, OwnershipEntry] = Map([])
-  for entry in entries {
-    let identity = OwnershipLinkIdentity(entry.link)
-    guard !stored_entries.contains(identity) else {
-      fail("ownership links must be unique")
-    }
-    stored_entries[identity] = entry
+  let stored_entries = @immut_hashmap.HashMap(
+    entries.map(entry => (OwnershipLinkIdentity(entry.link), entry)),
+  )
+  guard stored_entries.length() == entries.length() else {
+    fail("ownership links must be unique")
   }
   { version: 1, entries: stored_entries }
-}
-
-///|
-pub fn OwnershipState::entries(
-  self : OwnershipState,
-) -> ReadOnlyArray[OwnershipEntry] {
-  ReadOnlyArray::from_array(self.entries.values().collect())
 }

--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -96,12 +96,12 @@ pub struct OwnershipState {
 } derive(Eq)
 
 ///|
-struct OwnershipLinkIdentity {
+pub struct OwnershipLinkIdentity {
   path : @path.Path
 } derive(Eq)
 
 ///|
-fn OwnershipLinkIdentity::OwnershipLinkIdentity(
+pub fn OwnershipLinkIdentity::OwnershipLinkIdentity(
   path : @path.Path,
 ) -> OwnershipLinkIdentity {
   { path: path.normalize() }

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
@@ -252,13 +252,14 @@ pub impl FromJson for OwnershipState with fn from_json(json, path) {
 ///|
 pub impl ToJson for OwnershipState with fn to_json(self) -> Json {
   let builder = @lens.JsonBuilder::JsonBuilder()
+  let entries = self.entries.values().to_array()
+  entries.sort_by((left, right) => {
+    left.link.to_string().lexical_compare(right.link.to_string())
+  })
   ownership_state_version_lens.set_or_abort(
     builder,
     self.version.to_string().to_json(),
   )
-  ownership_state_entries_lens.set_or_abort(
-    builder,
-    self.entries.values().collect().to_json(),
-  )
+  ownership_state_entries_lens.set_or_abort(builder, entries.to_json())
   builder.to_json()
 }

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
@@ -256,6 +256,9 @@ pub impl ToJson for OwnershipState with fn to_json(self) -> Json {
     builder,
     self.version.to_string().to_json(),
   )
-  ownership_state_entries_lens.set_or_abort(builder, self.entries.to_json())
+  ownership_state_entries_lens.set_or_abort(
+    builder,
+    self.entries.values().collect().to_json(),
+  )
   builder.to_json()
 }

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
@@ -252,10 +252,9 @@ pub impl FromJson for OwnershipState with fn from_json(json, path) {
 ///|
 pub impl ToJson for OwnershipState with fn to_json(self) -> Json {
   let builder = @lens.JsonBuilder::JsonBuilder()
-  let entries = self.entries.values().to_array()
-  entries.sort_by((left, right) => {
-    left.link.to_string().lexical_compare(right.link.to_string())
-  })
+  let stored_entries = self.entries.to_array()
+  stored_entries.sort_by((left, right) => left.0.compare(right.0))
+  let entries = stored_entries.map(entry => entry.1)
   ownership_state_version_lens.set_or_abort(
     builder,
     self.version.to_string().to_json(),

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
@@ -68,6 +68,18 @@ test "OwnershipState ToJson::to_json - round trips local ownership metadata" {
 }
 
 ///|
+test "OwnershipState ToJson::to_json - preserves non-sorted entry order" {
+  let text =
+    #|{"version":"1","entries":[{"link":"/home/alice/project/.agents/skills/z-last","symlinkTarget":"../../../cache/skills/z-last","resolvedTarget":"/home/alice/.cache/c-plugin/skills/z-last","managedRoot":"/home/alice/project/.agents/skills","source":{"type":"github","repository":"openai/codex","plugin":"c-plugin","skill":"z-last"}},{"link":"/home/alice/project/.agents/skills/a-first","symlinkTarget":"../../../cache/skills/a-first","resolvedTarget":"/home/alice/.cache/c-plugin/skills/a-first","managedRoot":"/home/alice/project/.agents/skills","source":{"type":"github","repository":"openai/codex","plugin":"c-plugin","skill":"a-first"}}]}
+  let state : OwnershipState = @json.from_json(@json.parse(text))
+  inspect(
+    state.entries()[0].link.to_string(),
+    content="/home/alice/project/.agents/skills/z-last",
+  )
+  inspect(ToJson::to_json(state).stringify(), content=text)
+}
+
+///|
 test "OwnershipSource FromJson::from_json - rejects an invalid discriminator" {
   expect_ownership_rejection(
     fn() -> Unit raise {
@@ -175,6 +187,18 @@ test "OwnershipState FromJson::from_json - rejects unsupported version shapes" {
       (@json.from_json(json) : OwnershipState) |> ignore
     },
     "precision-sensitive version",
+  )
+}
+
+///|
+test "OwnershipState FromJson::from_json - rejects duplicate normalized links" {
+  let text =
+    #|{"version":"1","entries":[{"link":"/home/alice/project/.agents/skills/sync","symlinkTarget":"../../../cache/skills/sync","resolvedTarget":"/home/alice/.cache/c-plugin/skills/sync","managedRoot":"/home/alice/project/.agents/skills","source":{"type":"github","repository":"openai/codex","plugin":"c-plugin","skill":"sync"}},{"link":"/home/alice/project/.agents/skills/./sync","symlinkTarget":"../../../cache/skills/sync","resolvedTarget":"/home/alice/.cache/c-plugin/skills/sync","managedRoot":"/home/alice/project/.agents/skills","source":{"type":"github","repository":"openai/codex","plugin":"c-plugin","skill":"sync"}}]}
+  expect_ownership_rejection(
+    fn() -> Unit raise {
+      (@json.from_json(@json.parse(text)) : OwnershipState) |> ignore
+    },
+    "duplicate normalized ownership link",
   )
 }
 

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
@@ -68,15 +68,13 @@ test "OwnershipState ToJson::to_json - round trips local ownership metadata" {
 }
 
 ///|
-test "OwnershipState ToJson::to_json - preserves non-sorted entry order" {
+test "OwnershipState ToJson::to_json - sorts entries by link" {
   let text =
     #|{"version":"1","entries":[{"link":"/home/alice/project/.agents/skills/z-last","symlinkTarget":"../../../cache/skills/z-last","resolvedTarget":"/home/alice/.cache/c-plugin/skills/z-last","managedRoot":"/home/alice/project/.agents/skills","source":{"type":"github","repository":"openai/codex","plugin":"c-plugin","skill":"z-last"}},{"link":"/home/alice/project/.agents/skills/a-first","symlinkTarget":"../../../cache/skills/a-first","resolvedTarget":"/home/alice/.cache/c-plugin/skills/a-first","managedRoot":"/home/alice/project/.agents/skills","source":{"type":"github","repository":"openai/codex","plugin":"c-plugin","skill":"a-first"}}]}
   let state : OwnershipState = @json.from_json(@json.parse(text))
-  inspect(
-    state.entries()[0].link.to_string(),
-    content="/home/alice/project/.agents/skills/z-last",
-  )
-  inspect(ToJson::to_json(state).stringify(), content=text)
+  let expected =
+    #|{"version":"1","entries":[{"link":"/home/alice/project/.agents/skills/a-first","symlinkTarget":"../../../cache/skills/a-first","resolvedTarget":"/home/alice/.cache/c-plugin/skills/a-first","managedRoot":"/home/alice/project/.agents/skills","source":{"type":"github","repository":"openai/codex","plugin":"c-plugin","skill":"a-first"}},{"link":"/home/alice/project/.agents/skills/z-last","symlinkTarget":"../../../cache/skills/z-last","resolvedTarget":"/home/alice/.cache/c-plugin/skills/z-last","managedRoot":"/home/alice/project/.agents/skills","source":{"type":"github","repository":"openai/codex","plugin":"c-plugin","skill":"z-last"}}]}
+  inspect(ToJson::to_json(state).stringify(), content=expected)
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
@@ -49,11 +49,21 @@ test "OwnershipState entries - returns a detached readonly snapshot" {
     ownership_entry("/home/alice/project/.agents/skills/sync"),
   ])
   let entries = state.entries()
-  state.entries.push(
-    ownership_entry("/home/alice/project/.agents/skills/install"),
+  let added_entry = ownership_entry(
+    "/home/alice/project/.agents/skills/install",
   )
+  state.entries[OwnershipLinkIdentity(added_entry.link)] = added_entry
   inspect(entries.length(), content="1")
   inspect(state.entries().length(), content="2")
+}
+
+///|
+test "OwnershipState equality - preserves entry order" {
+  let sync = ownership_entry("/home/alice/project/.agents/skills/sync")
+  let install = ownership_entry("/home/alice/project/.agents/skills/install")
+  let state = OwnershipState::OwnershipState([sync, install])
+  let reordered = OwnershipState::OwnershipState([install, sync])
+  inspect(state == reordered, content="false")
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
@@ -44,26 +44,29 @@ test "OwnershipEntry OwnershipEntry - normalizes absolute paths but preserves sy
 }
 
 ///|
-test "OwnershipState entries - returns a detached readonly snapshot" {
+test "OwnershipState entries - stores an immutable hash map" {
   let state = OwnershipState::OwnershipState([
     ownership_entry("/home/alice/project/.agents/skills/sync"),
   ])
-  let entries = state.entries()
+  let entries = state.entries
   let added_entry = ownership_entry(
     "/home/alice/project/.agents/skills/install",
   )
-  state.entries[OwnershipLinkIdentity(added_entry.link)] = added_entry
+  let expanded_entries = state.entries.add(
+    OwnershipLinkIdentity(added_entry.link),
+    added_entry,
+  )
   inspect(entries.length(), content="1")
-  inspect(state.entries().length(), content="2")
+  inspect(expanded_entries.length(), content="2")
 }
 
 ///|
-test "OwnershipState equality - preserves entry order" {
+test "OwnershipState equality - ignores entry order" {
   let sync = ownership_entry("/home/alice/project/.agents/skills/sync")
   let install = ownership_entry("/home/alice/project/.agents/skills/install")
   let state = OwnershipState::OwnershipState([sync, install])
   let reordered = OwnershipState::OwnershipState([install, sync])
-  inspect(state == reordered, content="false")
+  inspect(state == reordered, content="true")
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
@@ -70,6 +70,15 @@ test "OwnershipState equality - ignores entry order" {
 }
 
 ///|
+test "OwnershipLinkIdentity Compare::compare - uses normalized lexical path order" {
+  let first = OwnershipLinkIdentity(
+    "/home/alice/project/.agents/skills/other/../alpha",
+  )
+  let last = OwnershipLinkIdentity("/home/alice/project/.agents/skills/z")
+  inspect(first.compare(last), content="-1")
+}
+
+///|
 test "OwnershipEntry OwnershipEntry - rejects a relative link" {
   expect_ownership_rejection(
     fn() -> Unit raise { ownership_entry(".agents/skills/sync") |> ignore },


### PR DESCRIPTION
## 概要

[TOT-98](https://linear.app/totto2727/issue/TOT-98/c-plugin-v2-unique-collectionをsetmapで保持する) として、c-plugin-v2の一意性を持つaggregateをimmutable hash collectionへ変更し、順序をJSON出力境界の責務に限定します。

- `immut/hashset`: enabled skills、lock targets
- `immut/hashmap`: repository plugins、lock repositories、ownership entries
- constructorの外部境界は`Array`のまま維持し、collection構築後の件数比較で重複を厳格拒否
- aggregate `Eq`は集合・写像の意味で入力順を無視
- mutable collectionを隠す`priv`と単純なsnapshot accessorを削除
- 公開immutable mapのkey identity型、正規化constructor、必要な`Hash` / `Compare`実装をdomain APIとして公開
- canonical JSON出力時だけtarget、repository、plugin、skill、ownership entryを辞書順にsort
- 正規化済み`Path` wrapperへ`Eq`と整合する`Hash`を追加

## 型選定

内部状態には順序契約がないため、永続的な`immut/hashset` / `immut/hashmap`を採用します。JSONはcollectionの反復順を利用せず、`ToJson`内で一時Arrayを生成してsortします。順序規約はaggregateではなくcanonical identity型の`Compare`へ集約し、既存仕様どおり`String::lexical_compare`によるUTF-16コード単位の辞書順を維持します。

`Plugin`全体には`Compare`を実装しません。同名でpathやenabled skillsが異なる値を名前だけで比較すると、`Eq`では異なるのに`compare == 0`となるためです。

参考:

- [immut/hashset](https://mooncakes.io/docs/moonbitlang/core/immut/hashset)
- [immut/hashmap](https://mooncakes.io/docs/moonbitlang/core/immut/hashmap)
- [MoonBit methods and traits](https://docs.moonbitlang.com/en/stable/language/methods.html)
- [String lexical_compare](https://mooncakes.io/assets/moonbitlang/core/builtin/string.mbt.html)
- [Array sort](https://mooncakes.io/assets/moonbitlang/core/builtin/array_sort.mbt.html)

## 処理フロー

```mermaid
flowchart TD
  A["JSON array / constructor Array"] --> B["型付き値へdecode・Path正規化"]
  B --> C["immutable HashSet / HashMapを構築"]
  C --> D{"入力件数とcollection件数が一致するか"}
  D -->|No| E["strict duplicate error"]
  D -->|Yes| F["順序を持たないdomain aggregate"]
  F --> G["集合・写像としてEq"]
  F --> H["ToJsonでkey/valueを一時Arrayへ変換"]
  H --> I["identityのCompareで辞書順sort"]
  I --> J["canonical JSON"]
```

## テスト条件

```mermaid
flowchart LR
  A["typed constructor"] --> A1["一意入力: accept"]
  A --> A2["同一/正規化重複: reject"]
  B["collection contract"] --> B1["逆順aggregate: equal"]
  B --> B2["immutable add: 元値不変"]
  C["ordering contract"] --> C1["短いzと長いalpha: lexical順"]
  C --> C2["Path正規化後: lexical順"]
  C --> C3["GitHub identityをLocalより先に出力"]
  D["JSON boundary"] --> D1["逆辞書順入力: canonical sort"]
  D --> D2["decode/encode/decode: domain equal"]
  E["integration"] --> E1["native check/build"]
  E --> E2["88 unit tests"]
  E --> E3["Docker moon install"]
  E3 --> E4["project/global init + host invariant"]
```

## 検証

- Exact SHA: `0924d9bcad468986b4fe99b14e4255de350193d4`
- `moon fmt`
- `moon check`
- `moon test mbt/app/c-plugin-v2/src --no-parallelize` (`88/88`)
- `moon build --release`
- `moon info`（7つの公開`Compare`実装を確認）
- `bash mbt/app/c-plugin-v2/src/e2e/run.sh`
  - clean Docker buildから`moon install`
  - project/globalを別containerで実行
  - 初回成功、再実行時の既存lock保持、host state不変を確認
- 5 lane review: goal / QA / code quality / security / context 全てPASS

## CI status

- Latest commit SHA: `0924d9bc`
- Latest `check` job: success (run id: `31237514060`, attempt: 1)
- Retry history: none

## Stack

- Base: `codex/cpv2-m2-e0-init-e2e`
- このPRはE0 init Docker E2Eの上へ積み上げる独立したTOT-98レイヤーです。