### PR TITLE
coding plugin: unique collectionルールを追加する

### DIFF
--- a/plugins/totto2727-coding/skills/share-coding/SKILL.md
+++ b/plugins/totto2727-coding/skills/share-coding/SKILL.md
@@ -15,6 +15,16 @@ description: >-
 
 Express invariants in the type system whenever possible. Preserve paths, identifiers, commands, and domain payloads as specific structural values while they cross application layers. Keep generic JSON at serialization boundaries, and convert structural values to text only when an external protocol or display requires it.
 
+## Collection invariants
+
+Do not construct a unique array with manual `contains`, `filter`, `fold`, or a local deduplication helper. When uniqueness is a domain invariant, store the values in a collection whose type guarantees uniqueness. Prefer the language's `Set` or a library set such as Effect `HashSet` for TypeScript and `@immut/hashset` or `@immut/sorted_set` for MoonBit. Convert the set to an array only at a consumer or API boundary that requires a sequence, such as serialization, presentation, interoperability, or a detached public snapshot.
+
+Choose the collection by its observable semantics as well as uniqueness: insertion order versus comparison order, `Eq` and `Hash` identity, and mutable versus persistent updates. Do not replace an order-preserving representation with a sorted collection unless the domain contract explicitly requires sorted order.
+
+When duplicate input is invalid, reject it at the boundary before collection construction can collapse it. Silently deduplicate only when deduplication is the explicit domain behavior.
+
+If a private array exists only to stop callers from mutating it, prefer a readonly or persistent immutable collection. Keep a mutable private collection only when controlled mutation is part of the implementation's behavior.
+
 ## Strict boundary conversion
 
 Keep untrusted or weakly typed values at the boundary where they enter or leave the program. Convert an external response into a wire model, convert the wire model into a validated domain model, convert the domain model into an outbound request model, and serialize only that request model. Apply the same rule to library values whose types are too broad to preserve domain invariants. Do not pass `any`, generic JSON, stringly typed identifiers, or parser contexts through internal application layers.


### PR DESCRIPTION
## 概要

[TOT-99](https://linear.app/totto2727/issue/TOT-99/coding-plugin-unique-collectionルールをshare-codingへ追加する) として、`share-coding`へ言語横断のcollection invariantを追加します。

- unique arrayを`contains` / `filter` / `fold` / 独自dedup helperで構築しない
- 一意性がdomain invariantなら、一意性を型で保証するSet系collectionで保持する
- TypeScriptはEffect `HashSet`、MoonBitは`@immut/hashset` / `@immut/sorted_set`を具体例にする
- insertion order / comparison order、Eq / Hash、mutable / persistentの意味を確認して型を選ぶ
- invalid duplicateはcollectionがcollapseする前にboundaryで拒否する
- private Arrayが外部mutation防止のためだけならreadonly / persistent immutable collectionを優先する
- Array化はsequenceを要求するconsumer/API boundaryに限定し、detached public snapshotを含める

## 適用フロー

```mermaid
flowchart TD
  A{"一意性はdomain invariantか"}
  A -->|No| B["通常のsequenceを選ぶ"]
  A -->|Yes| C{"duplicate inputはinvalidか"}
  C -->|Yes| D["collection構築前にreject"]
  C -->|No| E["明示的dedupを許可"]
  D --> F["Set / HashSet / SortedSetを選択"]
  E --> F
  F --> G{"order・Eq/Hash・mutabilityは適合するか"}
  G -->|No| H["別のunique collectionを選ぶ"]
  G -->|Yes| I["domain storageとして保持"]
  I --> J["必要なconsumer/API boundaryだけsequence化"]
```

## テスト条件

```mermaid
flowchart LR
  A["skill metadata"] --> A1["quick_validate PASS"]
  B["MoonBit manual dedup"] --> B1["Set系へ誘導"]
  C["TypeScript dedup"] --> C1["Set / Effect HashSetを意味で選択"]
  D["invalid duplicate"] --> D1["collapse前にreject"]
  E["private Array"] --> E1["readonly / immutableを優先"]
  F["public snapshot"] --> F1["detached sequence boundaryを許可"]
```

## 検証

- Exact SHA: `ab2e94bcf0c8b88cccf42adf941073f3b59d50ec`
- `quick_validate.py plugins/totto2727-coding/skills/share-coding`: PASS
- `git diff --check`: PASS
- forward cases: MoonBit / TypeScript / duplicate rejection / detached snapshot: PASS
- 5 lane review: goal / QA / code quality / security / context 全てPASS

## 公式資料

- [Effect HashSet](https://effect.website/docs/data-types/hash-set/)
- [MoonBit immut/hashset](https://mooncakes.io/docs/moonbitlang/core/immut/hashset)
- [MoonBit immut/sorted_set](https://mooncakes.io/docs/moonbitlang/core/immut/sorted_set)

## CI status

- Latest commit SHA: `ab2e94bc`
- Latest `check` job: success (run id: `31233213804`, attempt: 1)
- Retry history: none

## Scope

- Base: `main`
- 変更は`plugins/totto2727-coding/skills/share-coding/SKILL.md`のみ
- c-plugin-v2 stackとは独立した1 issue = 1 PR
