### PR TITLE
TOT-100 c-plugin v2: marketplace manifest parserを追加

### DIFF
--- a/mbt/app/c-plugin-v2/src/marketplace.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace.mbt
@@ -1,0 +1,202 @@
+///|
+pub struct MarketplacePlugin {
+  name : PluginName
+  path : RelativePluginPath
+} derive(Eq)
+
+///|
+pub fn MarketplacePlugin::MarketplacePlugin(
+  name : PluginName,
+  path : RelativePluginPath,
+) -> MarketplacePlugin {
+  { name, path }
+}
+
+///|
+pub struct Marketplace {
+  name : String
+  plugins : ReadOnlyArray[MarketplacePlugin]
+} derive(Eq)
+
+///|
+pub fn Marketplace::Marketplace(
+  name : String,
+  plugins : Array[MarketplacePlugin],
+) -> Marketplace raise {
+  let plugin_names = @immut_hashset.HashSet(plugins.map(plugin => plugin.name))
+  guard plugin_names.length() == plugins.length() else {
+    fail("marketplace plugin names must be unique")
+  }
+  { name, plugins: ReadOnlyArray::from_array(plugins) }
+}
+
+///|
+let marketplace_name_lens : @lens.Lens[Json] = @lens.root().json("name")
+
+///|
+let marketplace_plugins_lens : @lens.Lens[Json] = @lens.root().json("plugins")
+
+///|
+let marketplace_plugin_name_lens : @lens.Lens[Json] = @lens.root().json("name")
+
+///|
+let marketplace_plugin_source_lens : @lens.Lens[Json] = @lens.root().json(
+  "source",
+)
+
+///|
+let codex_source_kind_lens : @lens.Lens[Json] = @lens.root().json("source")
+
+///|
+let codex_source_path_lens : @lens.Lens[Json] = @lens.root().json("path")
+
+///|
+struct StringSourceMarketplaceWire {
+  name : String
+  plugins : Array[StringSourcePluginWire]
+  plugins_path : @json.JsonPath
+}
+
+///|
+impl @json.FromJson for StringSourceMarketplaceWire with fn from_json(
+  json,
+  path,
+) {
+  let name : String = @json.from_json(
+    marketplace_name_lens.get_or_json_decode_error(json, path),
+    path=marketplace_name_lens.add_to_json_path(path),
+  )
+  let plugins_path = marketplace_plugins_lens.add_to_json_path(path)
+  let plugins : Array[StringSourcePluginWire] = @json.from_json(
+    marketplace_plugins_lens.get_or_json_decode_error(json, path),
+    path=plugins_path,
+  )
+  { name, plugins, plugins_path }
+}
+
+///|
+struct StringSourcePluginWire {
+  name : PluginName
+  source : RelativePluginPath
+}
+
+///|
+impl @json.FromJson for StringSourcePluginWire with fn from_json(json, path) {
+  let name : PluginName = @json.from_json(
+    marketplace_plugin_name_lens.get_or_json_decode_error(json, path),
+    path=marketplace_plugin_name_lens.add_to_json_path(path),
+  )
+  let source : RelativePluginPath = @json.from_json(
+    marketplace_plugin_source_lens.get_or_json_decode_error(json, path),
+    path=marketplace_plugin_source_lens.add_to_json_path(path),
+  )
+  { name, source }
+}
+
+///|
+struct CodexMarketplaceWire {
+  name : String
+  plugins : Array[CodexPluginWire]
+  plugins_path : @json.JsonPath
+}
+
+///|
+impl @json.FromJson for CodexMarketplaceWire with fn from_json(json, path) {
+  let name : String = @json.from_json(
+    marketplace_name_lens.get_or_json_decode_error(json, path),
+    path=marketplace_name_lens.add_to_json_path(path),
+  )
+  let plugins_path = marketplace_plugins_lens.add_to_json_path(path)
+  let plugins : Array[CodexPluginWire] = @json.from_json(
+    marketplace_plugins_lens.get_or_json_decode_error(json, path),
+    path=plugins_path,
+  )
+  { name, plugins, plugins_path }
+}
+
+///|
+struct CodexPluginWire {
+  name : PluginName
+  source : CodexSourceWire
+}
+
+///|
+impl @json.FromJson for CodexPluginWire with fn from_json(json, path) {
+  let name : PluginName = @json.from_json(
+    marketplace_plugin_name_lens.get_or_json_decode_error(json, path),
+    path=marketplace_plugin_name_lens.add_to_json_path(path),
+  )
+  let source : CodexSourceWire = @json.from_json(
+    marketplace_plugin_source_lens.get_or_json_decode_error(json, path),
+    path=marketplace_plugin_source_lens.add_to_json_path(path),
+  )
+  { name, source }
+}
+
+///|
+struct CodexSourceWire {
+  path : RelativePluginPath
+}
+
+///|
+enum CodexSourceKind {
+  Local
+}
+
+///|
+impl @json.FromJson for CodexSourceKind with fn from_json(json, path) {
+  let value : String = @json.from_json(json, path~)
+  match value {
+    "local" => Local
+    unsupported =>
+      raise @json.JsonDecodeError(
+        (path, "unsupported Codex plugin source: \{unsupported}"),
+      )
+  }
+}
+
+///|
+impl @json.FromJson for CodexSourceWire with fn from_json(json, path) {
+  let _source : CodexSourceKind = @json.from_json(
+    codex_source_kind_lens.get_or_json_decode_error(json, path),
+    path=codex_source_kind_lens.add_to_json_path(path),
+  )
+  let plugin_path : RelativePluginPath = @json.from_json(
+    codex_source_path_lens.get_or_json_decode_error(json, path),
+    path=codex_source_path_lens.add_to_json_path(path),
+  )
+  { path: plugin_path }
+}
+
+///|
+pub fn Marketplace::from_json(
+  kind : MarketplaceKind,
+  json : Json,
+) -> Marketplace raise @json.JsonDecodeError {
+  match kind {
+    Claude | Cursor => {
+      let wire : StringSourceMarketplaceWire = @json.from_json(json)
+      let plugins = wire.plugins.map(plugin => {
+        MarketplacePlugin(plugin.name, plugin.source)
+      })
+      Marketplace(wire.name, plugins) catch {
+        _ =>
+          raise @json.JsonDecodeError(
+            (wire.plugins_path, "marketplace plugin names must be unique"),
+          )
+      }
+    }
+    Codex => {
+      let wire : CodexMarketplaceWire = @json.from_json(json)
+      let plugins = wire.plugins.map(plugin => {
+        MarketplacePlugin(plugin.name, plugin.source.path)
+      })
+      Marketplace(wire.name, plugins) catch {
+        _ =>
+          raise @json.JsonDecodeError(
+            (wire.plugins_path, "marketplace plugin names must be unique"),
+          )
+      }
+    }
+  }
+}

--- a/mbt/app/c-plugin-v2/src/marketplace_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace_wbtest.mbt
@@ -1,0 +1,141 @@
+///|
+test "Marketplace FromJson - normalizes Claude Cursor and Codex plugin sources in declaration order" {
+  let claude_text =
+    #|{"name":"totto2727","description":"totto2727's plugins","owner":{"name":"totto2727","url":"https://github.com/totto2727","email":"owner@example.com"},"plugins":[{"name":"totto2727","source":"./plugins/totto2727"},{"name":"totto2727-coding","source":"./plugins/totto2727-coding"},{"name":"external-search","source":"./plugins/external-search"}]}
+  let cursor_text =
+    #|{"name":"totto2727","plugins":[{"name":"totto2727","source":"./plugins/totto2727"},{"name":"totto2727-coding","source":"./plugins/totto2727-coding"},{"name":"external-search","source":"./plugins/external-search"}]}
+  let codex_text =
+    #|{"name":"totto2727","plugins":[{"category":"Productivity","name":"totto2727","policy":{"authentication":"ON_INSTALL","installation":"INSTALLED_BY_DEFAULT"},"source":{"path":"./plugins/totto2727","source":"local"}},{"category":"Productivity","name":"totto2727-coding","policy":{"authentication":"ON_INSTALL","installation":"INSTALLED_BY_DEFAULT"},"source":{"path":"./plugins/totto2727-coding","source":"local"}},{"category":"Productivity","name":"external-search","policy":{"authentication":"ON_INSTALL","installation":"INSTALLED_BY_DEFAULT"},"source":{"path":"./plugins/external-search","source":"local"}}]}
+  let marketplaces = [
+    Marketplace::from_json(MarketplaceKind::claude(), @json.parse(claude_text)),
+    Marketplace::from_json(MarketplaceKind::cursor(), @json.parse(cursor_text)),
+    Marketplace::from_json(MarketplaceKind::codex(), @json.parse(codex_text)),
+  ]
+  debug_inspect(
+    marketplaces.map(marketplace => {
+      marketplace.plugins
+      .map(plugin => "\{plugin.name.value}:\{plugin.path.path.to_string()}")
+      .iter()
+      .to_array()
+    }),
+    content=(
+      #|[
+      #|  [
+      #|    "totto2727:plugins/totto2727",
+      #|    "totto2727-coding:plugins/totto2727-coding",
+      #|    "external-search:plugins/external-search",
+      #|  ],
+      #|  [
+      #|    "totto2727:plugins/totto2727",
+      #|    "totto2727-coding:plugins/totto2727-coding",
+      #|    "external-search:plugins/external-search",
+      #|  ],
+      #|  [
+      #|    "totto2727:plugins/totto2727",
+      #|    "totto2727-coding:plugins/totto2727-coding",
+      #|    "external-search:plugins/external-search",
+      #|  ],
+      #|]
+    ),
+  )
+}
+
+///|
+test "Marketplace FromJson - malformed required field preserves JSON path" {
+  let text =
+    #|{"name":"test","plugins":[{"source":"./plugins/first"}]}
+  try
+    Marketplace::from_json(MarketplaceKind::claude(), @json.parse(text))
+    |> ignore
+  catch {
+    @json.JsonDecodeError::JsonDecodeError((path, _)) =>
+      inspect(path.to_string(), content="/plugins/0/name")
+    _ => fail("expected JsonDecodeError")
+  }
+}
+
+///|
+test "Marketplace FromJson - relative plugin path rejects parent traversal" {
+  let text =
+    #|{"name":"test","plugins":[{"name":"first","source":"../outside"}]}
+  try
+    Marketplace::from_json(MarketplaceKind::cursor(), @json.parse(text))
+    |> ignore
+  catch {
+    @json.JsonDecodeError::JsonDecodeError((path, _)) =>
+      inspect(path.to_string(), content="/plugins/0/source")
+    _ => fail("expected JsonDecodeError")
+  }
+}
+
+///|
+test "Marketplace FromJson - duplicate normalized plugin identity is rejected" {
+  let text =
+    #|{"name":"test","plugins":[{"name":"same","source":"plugins/first"},{"name":"same","source":"plugins/second"}]}
+  try
+    Marketplace::from_json(MarketplaceKind::claude(), @json.parse(text))
+    |> ignore
+  catch {
+    @json.JsonDecodeError::JsonDecodeError((path, message)) => {
+      inspect(path.to_string(), content="/plugins")
+      inspect(message, content="marketplace plugin names must be unique")
+    }
+    _ => fail("expected JsonDecodeError")
+  }
+}
+
+///|
+test "Marketplace FromJson - Claude rejects Codex object source at source path" {
+  let text =
+    #|{"name":"test","plugins":[{"name":"first","source":{"source":"local","path":"plugins/first"}}]}
+  try
+    Marketplace::from_json(MarketplaceKind::claude(), @json.parse(text))
+    |> ignore
+  catch {
+    @json.JsonDecodeError::JsonDecodeError((path, _)) =>
+      inspect(path.to_string(), content="/plugins/0/source")
+    _ => fail("expected JsonDecodeError")
+  }
+}
+
+///|
+test "Marketplace FromJson - Codex rejects string source at source path" {
+  let text =
+    #|{"name":"test","plugins":[{"name":"first","source":"plugins/first"}]}
+  try
+    Marketplace::from_json(MarketplaceKind::codex(), @json.parse(text))
+    |> ignore
+  catch {
+    @json.JsonDecodeError::JsonDecodeError((path, _)) =>
+      inspect(path.to_string(), content="/plugins/0/source")
+    _ => fail("expected JsonDecodeError")
+  }
+}
+
+///|
+test "Marketplace FromJson - Codex rejects missing source discriminator" {
+  let text =
+    #|{"name":"test","plugins":[{"name":"first","source":{"path":"plugins/first"}}]}
+  try
+    Marketplace::from_json(MarketplaceKind::codex(), @json.parse(text))
+    |> ignore
+  catch {
+    @json.JsonDecodeError::JsonDecodeError((path, _)) =>
+      inspect(path.to_string(), content="/plugins/0/source/source")
+    _ => fail("expected JsonDecodeError")
+  }
+}
+
+///|
+test "Marketplace FromJson - Codex rejects unsupported source discriminator" {
+  let text =
+    #|{"name":"test","plugins":[{"name":"first","source":{"source":"remote","path":"plugins/first"}}]}
+  try
+    Marketplace::from_json(MarketplaceKind::codex(), @json.parse(text))
+    |> ignore
+  catch {
+    @json.JsonDecodeError::JsonDecodeError((path, _)) =>
+      inspect(path.to_string(), content="/plugins/0/source/source")
+    _ => fail("expected JsonDecodeError")
+  }
+}


### PR DESCRIPTION
## 概要

Milestone 3の最初のatomic unitとして、Claude、Cursor、Codexのmarketplace manifestを型付きの共通read modelへ正規化するM0 parserを追加します。

- `MarketplaceKind`を最上位で一度だけ分岐します。
- Claude/Cursorはstring source、Codexは`source: "local"`を必須とするlocal source objectとして個別のwire `FromJson`でdecodeします。
- plugin nameは`PluginName`、source pathは`RelativePluginPath`として検証します。
- 宣言順は`ReadOnlyArray`で保持し、重複identityはdomain constructor内のimmutable `HashSet`で一度だけ検出します。
- malformed field、path escape、kind/source不一致はJSON path付きで拒否します。

## 処理フロー

```mermaid
flowchart TD
  A[Manifest JSON + MarketplaceKind] --> B{MarketplaceKind}
  B -->|Claude / Cursor| C[String source wire FromJson]
  B -->|Codex| D[Local object source wire FromJson]
  D --> D1{source == local}
  D1 -->|No| H[JsonDecodeError at source path]
  D1 -->|Yes| E[PluginName + RelativePluginPath]
  C --> E
  E --> F{PluginName is unique}
  F -->|Yes| G[Ordered Marketplace ReadOnlyArray]
  F -->|No| I[JsonDecodeError at /plugins]
```

## 対象外

- filesystem上のskill探索
- symlink reconciliationとownership更新
- command registration
- Git/TUI処理
- Docker command E2E

M0はleaf commandではないため、clean-container E2Eはこのparserを最初に利用する後続の`skill add --local` unitで追加します。

## テストケース

```mermaid
flowchart TD
  T[Marketplace parser] --> H[正常系]
  T --> E[異常系]
  H --> H1[実リポジトリのClaude/Cursor/Codex full shapeを同じ型へ正規化]
  H --> H2[manifest宣言順を維持]
  E --> E1[必須name欠落を正確なJSON pathで拒否]
  E --> E2[parent traversalをsource pathで拒否]
  E --> E3[重複plugin identityを/pluginsで拒否]
  E --> E4[ClaudeがCodex object sourceを拒否]
  E --> E5[Codexがstring sourceを拒否]
  E --> E6[Codex discriminator欠落・未知値を拒否]
```

- `moon fmt --check mbt/app/c-plugin-v2/src`: PASS
- `moon check mbt/app/c-plugin-v2/src --target native`: PASS
- `moon test mbt/app/c-plugin-v2/src --target native --no-parallelize`: 96/96 PASS
- `moon build mbt/app/c-plugin-v2/src --target native --release`: PASS
- committed fixture: 実際の`.claude-plugin`、`.cursor-plugin`、`.agents/plugins` manifest shapeを縮約せず主要extra fields込みで保持し、3形式のname/path/orderを検証します。

## Stacked PR

- Linear: TOT-100
- base: PR #268 / `codex/cpv2-m2-f8-unique-collections`
- head: `codex/cpv2-m3-m0-marketplace-parsing`
- dependency: TOT-98 / PR #268
- native GitHub stack: #267（bottom PR #253 -> top PR #270）
- atomic history: baseから1 commit

既存stackはmerge queueで`AWAITING_CHECKS`中です。現行CI workflowにGitHub公式仕様上必要な`merge_group` triggerが無いため、queueを変更せず本PRはDraftで保持します。既存stackがmergeされ最新mainを取り込めるまでReadyにはしません。

## Review status

- 初回SHA `a67b5b98`: goal/QA/code/security PASS、context FAIL
- 指摘対応: Codex local discriminator検証と永続fixture testを追加
- 最終SHA 2571b955c3ec58c0bfa15fba3ae32bb804f7447d: goal、QA、code-quality、security、contextの5/5 PASS

## CI status

- Latest commit SHA: `2571b955c3ec58c0bfa15fba3ae32bb804f7447d`
- Latest `check` job: success (run 31239964232、watch EXIT=0 + API conclusion=success)
- Previous commit `a67b5b98`: success (run 31239368716, watch EXIT=0 + API conclusion=success)
- Retry history: review fix push; CI failure retryなし