### PR TITLE
TOT-101 c-plugin v2: local skill resolverを追加

### DIFF
--- a/mbt/app/c-plugin-v2/src/marketplace_resolution.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace_resolution.mbt
@@ -1,0 +1,72 @@
+///|
+pub struct ResolvedSkill {
+  plugin_name : PluginName
+  plugin_path : RelativePluginPath
+  skill_name : SkillName
+  skill_path : @path.Path
+} derive(Eq)
+
+///|
+pub(all) suberror SkillResolutionError {
+  RelativeRepositoryRoot(path~ : @path.Path)
+  IO(path~ : @path.Path, reason~ : String)
+  InvalidSkillName(path~ : @path.Path, reason~ : String)
+} derive(Debug, Eq)
+
+///|
+pub async fn resolve_marketplace_skills(
+  repository_root : @path.Path,
+  marketplace : Marketplace,
+) -> ReadOnlyArray[ResolvedSkill] raise SkillResolutionError {
+  guard repository_root.is_absolute() else {
+    raise RelativeRepositoryRoot(path=repository_root)
+  }
+  let normalized_root = repository_root.normalize()
+  let resolved = []
+  for plugin in marketplace.plugins {
+    let plugin_skills = resolve_plugin_skills(normalized_root, plugin)
+    resolved.push_iter(plugin_skills.iter())
+  }
+  ReadOnlyArray::from_array(resolved)
+}
+
+///|
+async fn resolve_plugin_skills(
+  repository_root : @path.Path,
+  plugin : MarketplacePlugin,
+) -> Array[ResolvedSkill] raise SkillResolutionError {
+  let skills_directory = repository_root.join(plugin.path.path).join("skills")
+  let entries = @fs.readdir(
+    skills_directory.to_string(),
+    include_hidden=false,
+    include_special=false,
+    sort=false,
+  ) catch {
+    @os_error.OSError(_) as error if error.is_ENOENT() => return []
+    error => raise IO(path=skills_directory, reason=error.to_string())
+  }
+  let candidates : Array[(SkillName, @path.Path)] = []
+  for entry in entries {
+    let candidate_path = skills_directory.join(entry)
+    let marker_path = candidate_path.join("SKILL.md")
+    let has_marker = @fs.exists(marker_path.to_string()) catch {
+      @os_error.OSError(_) as error if error.is_ENOENT() || error.is_ENOTDIR() =>
+        false
+      error => raise IO(path=marker_path, reason=error.to_string())
+    }
+    if has_marker {
+      let skill_name = SkillName::SkillName(entry) catch {
+        error =>
+          raise InvalidSkillName(path=candidate_path, reason=error.to_string())
+      }
+      candidates.push((skill_name, candidate_path))
+    }
+  }
+  candidates.sort_by((left, right) => left.0.compare(right.0))
+  candidates.map(candidate => {
+    plugin_name: plugin.name,
+    plugin_path: plugin.path,
+    skill_name: candidate.0,
+    skill_path: candidate.1,
+  })
+}

--- a/mbt/app/c-plugin-v2/src/marketplace_resolution_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace_resolution_wbtest.mbt
@@ -1,0 +1,258 @@
+///|
+async fn create_test_skill(
+  root : @path.Path,
+  plugin_path : String,
+  skill_name : String,
+) -> Unit {
+  let directory = root.join(plugin_path).join("skills").join(skill_name)
+  @fs.mkdir(directory.to_string(), recursive=true)
+  @fs.write_file(
+    directory.join("SKILL.md").to_string(),
+    "# Test\n",
+    create_mode=CreateNew,
+  )
+}
+
+///|
+fn test_marketplace(plugins : Array[(String, String)]) -> Marketplace raise {
+  Marketplace::Marketplace(
+    "test",
+    plugins.map(plugin => {
+      MarketplacePlugin::MarketplacePlugin(
+        PluginName::PluginName(plugin.0),
+        RelativePluginPath::RelativePluginPath(@path.Path(plugin.1)),
+      )
+    }),
+  )
+}
+
+///|
+async test "MarketplaceResolution resolve_marketplace_skills - preserves plugin and sorted skill order" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-resolution-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    create_test_skill(root, "plugins/b", "zeta")
+    create_test_skill(root, "plugins/b", "alpha")
+    create_test_skill(root, "plugins/a", "shared")
+    let marketplace = test_marketplace([
+      ("plugin-b", "plugins/b"),
+      ("plugin-a", "plugins/a"),
+    ])
+    let resolved = resolve_marketplace_skills(root, marketplace)
+    debug_inspect(
+      resolved.map(skill => {
+        "\{skill.plugin_name.value}|\{skill.plugin_path.path.to_string()}|\{skill.skill_name.value}|\{skill.skill_path.to_string()}"
+      }),
+      content=(
+        #|<ReadOnlyArray:
+        #|  [
+        #|    "plugin-b|plugins/b|alpha|ROOT/plugins/b/skills/alpha",
+        #|    "plugin-b|plugins/b|zeta|ROOT/plugins/b/skills/zeta",
+        #|    "plugin-a|plugins/a|shared|ROOT/plugins/a/skills/shared",
+        #|  ]>
+      ).replace_all(old="ROOT", new=root.to_string()),
+    )
+  }
+}
+
+///|
+async test "MarketplaceResolution resolve_marketplace_skills - consumes every M0 kind identically" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-resolution-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    create_test_skill(root, "plugins/p", "install")
+    let strings =
+      #|{"name":"test","plugins":[{"name":"plugin","source":"plugins/p"}]}
+    let codex =
+      #|{"name":"test","plugins":[{"name":"plugin","source":{"source":"local","path":"plugins/p"}}]}
+    let claude = resolve_marketplace_skills(
+      root,
+      Marketplace::from_json(MarketplaceKind::claude(), @json.parse(strings)),
+    )
+    let cursor = resolve_marketplace_skills(
+      root,
+      Marketplace::from_json(MarketplaceKind::cursor(), @json.parse(strings)),
+    )
+    let codex_result = resolve_marketplace_skills(
+      root,
+      Marketplace::from_json(MarketplaceKind::codex(), @json.parse(codex)),
+    )
+    inspect(claude == cursor && cursor == codex_result, content="true")
+  }
+}
+
+///|
+async test "MarketplaceResolution resolve_marketplace_skills - missing skills directory is empty" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-resolution-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    create_test_skill(root, "plugins/later", "valid")
+    let resolved = resolve_marketplace_skills(
+      root,
+      test_marketplace([
+        ("missing", "plugins/missing"),
+        ("later", "plugins/later"),
+      ]),
+    )
+    inspect(resolved.length(), content="1")
+    inspect(resolved[0].plugin_name.value, content="later")
+  }
+}
+
+///|
+async test "MarketplaceResolution resolve_marketplace_skills - filters non-skills and hidden entries" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-resolution-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    create_test_skill(root, "plugins/p", "valid")
+    create_test_skill(root, "plugins/p", ".hidden")
+    let skills = root.join("plugins/p/skills")
+    @fs.mkdir(skills.join("no-marker").to_string())
+    @fs.write_file(
+      skills.join("regular-file").to_string(),
+      "file",
+      create_mode=CreateNew,
+    )
+    let resolved = resolve_marketplace_skills(
+      root,
+      test_marketplace([("plugin", "plugins/p")]),
+    )
+    inspect(resolved.length(), content="1")
+    inspect(resolved[0].skill_name.value, content="valid")
+  }
+}
+
+///|
+async test "MarketplaceResolution resolve_marketplace_skills - shared names across plugins remain distinct" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-resolution-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    create_test_skill(root, "plugins/a", "shared")
+    create_test_skill(root, "plugins/b", "shared")
+    let resolved = resolve_marketplace_skills(
+      root,
+      test_marketplace([("a", "plugins/a"), ("b", "plugins/b")]),
+    )
+    debug_inspect(
+      resolved.map(skill => skill.plugin_name.value),
+      content="<ReadOnlyArray: [\"a\", \"b\"]>",
+    )
+  }
+}
+
+///|
+async test "MarketplaceResolution resolve_marketplace_skills - invalid discovered name is typed" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-resolution-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    create_test_skill(root, "plugins/p", "bad\\name")
+    let candidate = root.join("plugins/p/skills").join("bad\\name")
+    try
+      resolve_marketplace_skills(
+        root,
+        test_marketplace([("plugin", "plugins/p")]),
+      )
+    catch {
+      SkillResolutionError::InvalidSkillName(path~, reason=_) =>
+        inspect(path == candidate, content="true")
+      _ => fail("expected InvalidSkillName")
+    } noraise {
+      _ => fail("invalid skill name must fail")
+    }
+  }
+}
+
+///|
+async test "MarketplaceResolution resolve_marketplace_skills - file at skills path is IO" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-resolution-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let skills = root.join("plugins/p/skills")
+    @fs.mkdir(skills.dirname().to_string(), recursive=true)
+    @fs.write_file(skills.to_string(), "file", create_mode=CreateNew)
+    try
+      resolve_marketplace_skills(
+        root,
+        test_marketplace([("plugin", "plugins/p")]),
+      )
+    catch {
+      SkillResolutionError::IO(path~, reason=_) =>
+        inspect(path == skills, content="true")
+      _ => fail("expected IO")
+    } noraise {
+      _ => fail("file at skills path must fail")
+    }
+  }
+}
+
+///|
+async test "MarketplaceResolution resolve_marketplace_skills - input and output are snapshots" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-resolution-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    create_test_skill(root, "plugins/p", "stable")
+    let caller = [
+      MarketplacePlugin::MarketplacePlugin(
+        PluginName::PluginName("plugin"),
+        RelativePluginPath::RelativePluginPath(@path.Path("plugins/p")),
+      ),
+    ]
+    let marketplace = Marketplace::Marketplace("test", caller)
+    let resolved = resolve_marketplace_skills(root, marketplace)
+    caller.clear()
+    inspect(marketplace.plugins.length(), content="1")
+    inspect(resolved.length(), content="1")
+    inspect(resolved[0].skill_name.value, content="stable")
+  }
+}
+
+///|
+async test "MarketplaceResolution resolve_marketplace_skills - normalizes dotted root" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-resolution-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    create_test_skill(root, "plugins/p", "stable")
+    let marketplace = test_marketplace([("plugin", "plugins/p")])
+    inspect(
+      resolve_marketplace_skills(root, marketplace) ==
+      resolve_marketplace_skills(root.join("."), marketplace),
+      content="true",
+    )
+  }
+}
+
+///|
+async test "MarketplaceResolution resolve_marketplace_skills - does not suppress sibling IO" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-resolution-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    create_test_skill(root, "plugins/good", "valid")
+    let invalid = root.join("plugins/bad/skills")
+    @fs.mkdir(invalid.dirname().to_string(), recursive=true)
+    @fs.write_file(invalid.to_string(), "file", create_mode=CreateNew)
+    try
+      resolve_marketplace_skills(
+        root,
+        test_marketplace([("good", "plugins/good"), ("bad", "plugins/bad")]),
+      )
+    catch {
+      SkillResolutionError::IO(path~, reason=_) =>
+        inspect(path == invalid, content="true")
+      _ => fail("expected IO")
+    } noraise {
+      _ => fail("IO must not become partial success")
+    }
+  }
+}
+
+///|
+async test "MarketplaceResolution resolve_marketplace_skills - rejects relative repository root" {
+  let relative = @path.Path("relative/repository")
+  try resolve_marketplace_skills(relative, test_marketplace([])) catch {
+    SkillResolutionError::RelativeRepositoryRoot(path~) =>
+      inspect(path == relative, content="true")
+    _ => fail("expected RelativeRepositoryRoot")
+  } noraise {
+    _ => fail("relative root must fail")
+  }
+}


### PR DESCRIPTION
## 概要

- M0で正規化済みの`Marketplace`から、local repository内のplugin skillを型付きで解決します。
- repository rootとresolved skill directoryを`moonbitlang/x/path.Path`で保持し、結果をcaller-ownedな`ReadOnlyArray[ResolvedSkill]`として返します。
- plugin宣言順を維持し、plugin内は既存の`Compare for SkillName`で辞書順に確定します。
- `skills/`欠落だけを空として扱い、relative root、invalid skill name、その他filesystem failureをtyped errorにします。

Linear: [TOT-101](https://linear.app/totto2727/issue/TOT-101/c-plugin-v2-m3-m1-local-skill-resolutionを実装する)

## 処理フロー

```mermaid
flowchart TD
  A[Typed Marketplace and absolute repository Path] --> B[Normalize repository root]
  B --> C[Visit plugins in declaration order]
  C --> D[Read visible skill entries]
  D --> E{skills directory exists?}
  E -->|ENOENT| F[Empty contribution]
  E -->|Other error| G[Typed IO error]
  D --> H{SKILL.md exists?}
  H -->|No| I[Ignore entry]
  H -->|Yes| J[Validate SkillName]
  J -->|Invalid| K[InvalidSkillName error]
  J -->|Valid| L[Sort with SkillName Compare]
  L --> M[ResolvedSkill with directory Path]
  M --> N[Owned ReadOnlyArray snapshot]
```

## テスト条件

```mermaid
flowchart TD
  T[resolve_marketplace_skills] --> H1[Multi-plugin order and typed paths]
  T --> H2[Claude Cursor Codex normalize identically]
  T --> E1[Missing skills directory is empty]
  T --> E2[Hidden or markerless entries are ignored]
  T --> E3[Same skill name across plugins remains distinct]
  T --> E4[Invalid discovered name is typed]
  T --> E5[File at skills path is IO]
  T --> E6[Relative repository root is rejected]
  T --> R1[Input and output snapshots do not alias]
  T --> R2[Dotted root normalizes identically]
  T --> R3[Sibling IO is not suppressed as partial success]
```

## 検証

- RED: placeholder resolverは期待3件に対して空配列を返し、並び順caseが`96 pass / 1 fail`で意図どおり失敗しました。
- `moon fmt --check mbt/app/c-plugin-v2/src`
- `moon check mbt/app/c-plugin-v2/src --target native`
- `moon test mbt/app/c-plugin-v2/src --target native --no-parallelize` (`107/107 PASS`)
- `moon build mbt/app/c-plugin-v2/src --target native --release`
- `git diff --check`

## Scope boundary

- M1はleaf commandではないためDocker E2Eは追加しません。最初のconsumerとなる後続`skill add --local` unitでcommand E2Eを追加します。
- JSON parsing、command registration、lock mutation、symlink reconciliation、Git、TUIは含めません。
- PR #270 / TOT-100を直前dependencyとして維持し、未merge IssueをDoneにしません。

## CI status

- Latest commit SHA: `73803a01c1e9f96f955fa3c9018f8577715a537b`
- Latest `check` job: [CI run 31241446719](https://github.com/totto2727-org/monorepo/actions/runs/31241446719) `success` (`gh run watch --exit-status` = `EXIT=0`, independent `gh run view` = `conclusion=success`)
- Review gate: exact SHAでgoal / code quality / security / context / hands-on QAの`5/5 PASS`
- Retry history: none
