### PR TITLE
Merge Queue向けのCIトリガーを追加

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -6,12 +6,5 @@ plan_mode_reasoning_effort = "xhigh"
 command = "linear-mcp"
 args = []
 
-# Managed by LazyCodex: multi_agent_v2 is re-disabled on every Codex session start
-# because enabling it fails every turn with HTTP 400 (openai/codex#26753).
-# Opt out: LAZYCODEX_CONFIG_MIGRATION_DISABLED=1 (or OMO_CODEX_CONFIG_MIGRATION_DISABLED=1).
 [features.multi_agent_v2]
-enabled = false
 max_concurrent_threads_per_session = 16
-
-[agents]
-max_threads = 1000

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/bun.lock
+++ b/bun.lock
@@ -259,6 +259,14 @@
         "@totto2727/target-file-discovery": "workspace:*",
       },
     },
+    "mbt/app/c-plugin-v2": {
+      "name": "@totto2727/c-plugin-v2",
+      "devDependencies": {
+        "@totto2727/admiral": "workspace:*",
+        "@totto2727/lens": "workspace:*",
+        "@totto2727/target-file-discovery": "workspace:*",
+      },
+    },
     "mbt/app/mdt": {
       "name": "@totto2727/mdt",
       "devDependencies": {
@@ -1218,6 +1226,8 @@
     "@totto2727/bw": ["@totto2727/bw@workspace:mbt/app/bw"],
 
     "@totto2727/c-plugin": ["@totto2727/c-plugin@workspace:mbt/app/c-plugin"],
+
+    "@totto2727/c-plugin-v2": ["@totto2727/c-plugin-v2@workspace:mbt/app/c-plugin-v2"],
 
     "@totto2727/codex-sdk": ["@totto2727/codex-sdk@workspace:mbt/package/codex-sdk"],
 


### PR DESCRIPTION
## 概要

- CIワークフローに`merge_group`トリガーを追加
- 既存のCodex multi-agent設定差分を反映
- `c-plugin-v2`のワークスペース情報を`bun.lock`へ反映

## 背景

Merge Queueが作成する一時コミットでは`pull_request`イベントが発火せず、必須チェック`check`が報告されない状態でした。GitHub ActionsでMerge Queueの必須チェックを実行するため、`merge_group`イベントをCIの起動条件へ追加します。

参考: [GitHub Docs: Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)

## 処理フロー

```mermaid
flowchart TD
  A[PRをMerge Queueへ追加] --> B[merge_groupイベントを送信]
  B --> C[CIワークフローを起動]
  C --> D[checkジョブを実行]
  D --> E[Rulesetの必須チェックへ結果を報告]
```

## 検証

- Rubyによる`.github/workflows/ci.yaml`のYAML構文解析
- `codex --version`
- `bun install --frozen-lockfile --ignore-scripts`
- `git diff --check origin/main...HEAD`
- Goal・QA・Code Quality・Security・Contextの5レビューが同一SHAでPASS

## CI status

- Latest commit SHA: `a72b997`
- Latest `check` job: success ([run 31243165246](https://github.com/totto2727-org/monorepo/actions/runs/31243165246))
- CodeQL: success
- Retry history: none

`merge_group`の実イベントは、このワークフローが対象ブランチへ到達してPRがMerge Queueに追加された時点で確認できます。