### PR TITLE
c-plugin v2: ownership-safe link reconciliationを実装する

### DIFF
--- a/mbt/app/c-plugin-v2/src/desired_links.mbt
+++ b/mbt/app/c-plugin-v2/src/desired_links.mbt
@@ -72,7 +72,7 @@ fn ownership_source(
 ) -> OwnershipSource {
   match repository {
     GitHub(repository) =>
-      OwnershipSource::github(
+      OwnershipSource::from_github(
         GitHubOwnershipSource::GitHubOwnershipSource(
           repository.repository,
           skill.plugin_name,
@@ -95,13 +95,15 @@ fn desired_entry(
   root : ManagedSkillRoot,
   repository : LockRepository,
   skill : ResolvedSkill,
-) -> OwnershipEntry {
-  let link = root.path.join(skill.skill_name.value)
-  try! OwnershipEntry::OwnershipEntry(
+) -> OwnershipEntry raise {
+  let link = OwnershipLink::OwnershipLink(
+    root.path.join(skill.skill_name.value),
+  )
+  OwnershipEntry::OwnershipEntry(
     link,
     skill.skill_path.relative(base=root.path),
-    skill.skill_path,
-    root.path,
+    OwnershipResolvedTarget::OwnershipResolvedTarget(skill.skill_path),
+    OwnershipManagedRoot::OwnershipManagedRoot(root.path),
     ownership_source(repository, skill),
   )
 }
@@ -113,7 +115,7 @@ pub fn plan_desired_skill_links(
     RepositoryIdentity,
     RepositorySkillResolution,
   ],
-) -> DesiredLinkPlan raise DesiredLinkPlanningError {
+) -> DesiredLinkPlan raise {
   for pair in repositories.to_array() {
     let actual = match pair.1 {
       Available(repository~, skills=_) | Unavailable(repository~, reason=_) =>
@@ -145,7 +147,7 @@ pub fn plan_desired_skill_links(
               for root in managed_roots {
                 let entry = desired_entry(root, repository, skill)
                 let link_identity = OwnershipLinkIdentity::OwnershipLinkIdentity(
-                  entry.link,
+                  entry.link.path,
                 )
                 match candidates.get(link_identity) {
                   Some(existing) if identity.compare(existing.repository) < 0 =>
@@ -165,7 +167,7 @@ pub fn plan_desired_skill_links(
   }
   let entries = candidates.to_array().map(pair => pair.1.entry)
   {
-    ownership_state: try! OwnershipState::OwnershipState(entries),
+    ownership_state: OwnershipState::OwnershipState(entries),
     unavailable_repositories: unavailable,
   }
 }

--- a/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
@@ -364,11 +364,7 @@ test "DesiredLinks plan_desired_skill_links - propagates an invalid resolved ski
       ]),
     )
   catch {
-    Failure::Failure(message) =>
-      inspect(
-        message.contains("ownership resolved target must be absolute"),
-        content="true",
-      )
+    Failure::Failure(_) => ()
     error => raise error
   } noraise {
     _ => fail("invalid resolved skill path must raise")

--- a/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
@@ -335,3 +335,42 @@ test "DesiredLinks plan_desired_skill_links - rejects repository identity mismat
     _ => fail("identity mismatch must fail")
   }
 }
+
+///|
+test "DesiredLinks plan_desired_skill_links - propagates an invalid resolved skill path" {
+  let skill_name = SkillName::SkillName("install")
+  let repository = desired_links_local_repository([skill_name])
+  let invalid_skill : ResolvedSkill = {
+    plugin_name: PluginName::PluginName("plugin"),
+    plugin_path: RelativePluginPath::RelativePluginPath(
+      @path.Path("plugins/plugin"),
+    ),
+    skill_name,
+    skill_path: @path.Path("relative/skill"),
+  }
+  try
+    plan_desired_skill_links(
+      @immut_hashset.HashSet([
+        ManagedSkillRoot::ManagedSkillRoot(@path.Path("/tmp/managed")),
+      ]),
+      @immut_hashmap.HashMap([
+        (
+          repository.identity(),
+          Available(
+            repository~,
+            skills=ReadOnlyArray::from_array([invalid_skill]),
+          ),
+        ),
+      ]),
+    )
+  catch {
+    Failure::Failure(message) =>
+      inspect(
+        message.contains("ownership resolved target must be absolute"),
+        content="true",
+      )
+    error => raise error
+  } noraise {
+    _ => fail("invalid resolved skill path must raise")
+  }
+}

--- a/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
@@ -113,12 +113,12 @@ async test "DesiredLinks plan_desired_skill_links - expands one enabled skill" {
       managed_root in [root.join(".agents/skills"), root.join(".cursor/skills")] {
       let entry = desired_links_entry(plan, managed_root.join("install"))
       inspect(
-        entry.link.to_string(),
+        entry.link.path.to_string(),
         content=managed_root.join("install").to_string(),
       )
       inspect(
         managed_root.join(entry.symlink_target).normalize().to_string(),
-        content=entry.resolved_target.to_string(),
+        content=entry.resolved_target.path.to_string(),
       )
     }
   }
@@ -198,7 +198,7 @@ test "DesiredLinks plan_desired_skill_links - later candidate in one repository 
     ]),
   )
   inspect(
-    desired_links_entry(plan, @path.Path("/tmp/managed/shared")).resolved_target.to_string(),
+    desired_links_entry(plan, @path.Path("/tmp/managed/shared")).resolved_target.path.to_string(),
     content=last.skill_path.to_string(),
   )
 }
@@ -330,6 +330,7 @@ test "DesiredLinks plan_desired_skill_links - rejects repository identity mismat
         error_expected == expected && error_actual == repository.identity(),
         content="true",
       )
+    error => raise error
   } noraise {
     _ => fail("identity mismatch must fail")
   }

--- a/mbt/app/c-plugin-v2/src/link_reconciliation.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation.mbt
@@ -63,13 +63,10 @@ async fn reconcile_skill_links_with_io(
   let (initial_state, initial_notices) = match previous_ownership {
     Trusted(state) => (state, [])
     Missing =>
-      (
-        try! OwnershipState::OwnershipState([]),
-        [PreviousOwnershipMissing(path=state_path)],
-      )
+      (OwnershipState::empty(), [PreviousOwnershipMissing(path=state_path)])
     Corrupt(reason~) =>
       (
-        try! OwnershipState::OwnershipState([]),
+        OwnershipState::empty(),
         [PreviousOwnershipCorrupt(path=state_path, reason~)],
       )
   }

--- a/mbt/app/c-plugin-v2/src/link_reconciliation.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation.mbt
@@ -28,8 +28,8 @@ pub(all) enum LinkReconciliationOperation {
 ///|
 /// Describes a path that was preserved or an operation that could not complete.
 pub(all) enum LinkReconciliationNotice {
-  PreviousOwnershipMissing(path~ : @path.Path)
-  PreviousOwnershipCorrupt(path~ : @path.Path, reason~ : String)
+  PreviousOwnershipMissing(path~ : OwnershipStatePath)
+  PreviousOwnershipCorrupt(path~ : OwnershipStatePath, reason~ : String)
   UnmanagedPathPreserved(path~ : @path.Path)
   BrokenOwnedLinkPreserved(path~ : @path.Path)
   ReplacedOwnedPathPreserved(path~ : @path.Path)
@@ -40,7 +40,7 @@ pub(all) enum LinkReconciliationNotice {
   )
   CheckpointFailed(
     operation~ : LinkReconciliationOperation,
-    path~ : @path.Path,
+    path~ : OwnershipStatePath,
     reason~ : String
   )
 }
@@ -56,7 +56,7 @@ pub struct LinkReconciliationResult {
 ///|
 async fn reconcile_skill_links_with_io(
   io : LinkReconciliationIO,
-  state_path : @path.Path,
+  state_path : OwnershipStatePath,
   desired_state : OwnershipState,
   previous_ownership : PreviousOwnership,
 ) -> LinkReconciliationResult {
@@ -114,18 +114,15 @@ async fn reconcile_skill_links_with_io(
 ///|
 /// Reconciles desired skill links and checkpoints each ownership mutation.
 ///
-/// The caller must pass a normalized absolute state path and an atomic checkpoint
-/// callback. Repository resolution and ownership-state loading remain outside this
-/// filesystem boundary.
+/// The ownership state path is validated when its value object is constructed.
+/// Repository resolution and ownership-state loading remain outside this filesystem
+/// boundary.
 pub async fn reconcile_skill_links(
-  state_path~ : @path.Path,
+  state_path~ : OwnershipStatePath,
   desired_state~ : OwnershipState,
   previous_ownership~ : PreviousOwnership,
   checkpoint_ownership_state~ : async (@path.Path, OwnershipState) -> Unit raise StateStoreError,
 ) -> LinkReconciliationResult {
-  guard state_path.is_absolute() && state_path.normalize() == state_path else {
-    fail("ownership state path must be normalized and absolute")
-  }
   reconcile_skill_links_with_io(
     production_link_reconciliation_io(checkpoint_ownership_state),
     state_path,

--- a/mbt/app/c-plugin-v2/src/link_reconciliation.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation.mbt
@@ -1,0 +1,138 @@
+///|
+/// Distinguishes trusted deletion authority from unavailable ownership state.
+pub(all) enum PreviousOwnership {
+  Trusted(OwnershipState)
+  Missing
+  Corrupt(reason~ : String)
+}
+
+///|
+/// Reports whether reconciliation reached the entire desired filesystem state.
+pub(all) enum LinkReconciliationStatus {
+  Complete
+  Partial
+} derive(Debug, Eq)
+
+///|
+/// Identifies the filesystem or durability boundary associated with a notice.
+pub(all) enum LinkReconciliationOperation {
+  EnsureManagedRoot
+  ClassifyLink
+  VerifyContainment
+  CreateLink
+  VerifyCreatedLink
+  RemoveLink
+  CheckpointOwnership
+} derive(Debug, Eq)
+
+///|
+/// Describes a path that was preserved or an operation that could not complete.
+pub(all) enum LinkReconciliationNotice {
+  PreviousOwnershipMissing(path~ : @path.Path)
+  PreviousOwnershipCorrupt(path~ : @path.Path, reason~ : String)
+  UnmanagedPathPreserved(path~ : @path.Path)
+  BrokenOwnedLinkPreserved(path~ : @path.Path)
+  ReplacedOwnedPathPreserved(path~ : @path.Path)
+  OperationFailed(
+    operation~ : LinkReconciliationOperation,
+    path~ : @path.Path,
+    reason~ : String
+  )
+  CheckpointFailed(
+    operation~ : LinkReconciliationOperation,
+    path~ : @path.Path,
+    reason~ : String
+  )
+}
+
+///|
+/// Returns the last durably checkpointed ownership state and typed notices.
+pub struct LinkReconciliationResult {
+  status : LinkReconciliationStatus
+  durable_state : OwnershipState
+  notices : ReadOnlyArray[LinkReconciliationNotice]
+}
+
+///|
+async fn reconcile_skill_links_with_io(
+  io : LinkReconciliationIO,
+  state_path : @path.Path,
+  desired_state : OwnershipState,
+  previous_ownership : PreviousOwnership,
+) -> LinkReconciliationResult {
+  let (initial_state, initial_notices) = match previous_ownership {
+    Trusted(state) => (state, [])
+    Missing =>
+      (
+        try! OwnershipState::OwnershipState([]),
+        [PreviousOwnershipMissing(path=state_path)],
+      )
+    Corrupt(reason~) =>
+      (
+        try! OwnershipState::OwnershipState([]),
+        [PreviousOwnershipCorrupt(path=state_path, reason~)],
+      )
+  }
+  let mut durable_state = initial_state
+  let notices = initial_notices
+  let clean_stale_entries = match previous_ownership {
+    Trusted(_) => true
+    Missing | Corrupt(_) => false
+  }
+  let (desired_durable_state, desired_hard_stop) = reconcile_desired_entries(
+    io~,
+    state_path~,
+    desired_state~,
+    durable_state~,
+    notices~,
+  )
+  match desired_hard_stop {
+    Some(result) => return result
+    None => durable_state = desired_durable_state
+  }
+  if clean_stale_entries {
+    let (stale_durable_state, stale_hard_stop) = reconcile_stale_entries(
+      io~,
+      state_path~,
+      desired_state~,
+      durable_state~,
+      notices~,
+    )
+    match stale_hard_stop {
+      Some(result) => return result
+      None => durable_state = stale_durable_state
+    }
+  }
+  {
+    status: if notices.is_empty() {
+      Complete
+    } else {
+      Partial
+    },
+    durable_state,
+    notices: ReadOnlyArray::from_array(notices),
+  }
+}
+
+///|
+/// Reconciles desired skill links and checkpoints each ownership mutation.
+///
+/// The caller must pass a normalized absolute state path and an atomic checkpoint
+/// callback. Repository resolution and ownership-state loading remain outside this
+/// filesystem boundary.
+pub async fn reconcile_skill_links(
+  state_path~ : @path.Path,
+  desired_state~ : OwnershipState,
+  previous_ownership~ : PreviousOwnership,
+  checkpoint_ownership_state~ : async (@path.Path, OwnershipState) -> Unit raise StateStoreError,
+) -> LinkReconciliationResult {
+  guard state_path.is_absolute() && state_path.normalize() == state_path else {
+    fail("ownership state path must be normalized and absolute")
+  }
+  reconcile_skill_links_with_io(
+    production_link_reconciliation_io(checkpoint_ownership_state),
+    state_path,
+    desired_state,
+    previous_ownership,
+  )
+}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_create.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_create.mbt
@@ -13,16 +13,16 @@ async fn create_desired_link(
   desired_entry : OwnershipEntry,
   notices : Array[LinkReconciliationNotice],
 ) -> DesiredLinkCreationResult {
-  (io.symlink)(desired_entry.symlink_target, desired_entry.link) catch {
+  (io.symlink)(desired_entry.symlink_target, desired_entry.link.path) catch {
     @os_error.OSError(_) as error if error.is_EEXIST() => {
-      notices.push(UnmanagedPathPreserved(path=desired_entry.link))
+      notices.push(UnmanagedPathPreserved(path=desired_entry.link.path))
       return Skipped
     }
     error => {
       notices.push(
         OperationFailed(
           operation=CreateLink,
-          path=desired_entry.link,
+          path=desired_entry.link.path,
           reason=error.to_string(),
         ),
       )
@@ -30,11 +30,11 @@ async fn create_desired_link(
     }
   }
   let verified = try {
-    let live_kind = (io.kind)(desired_entry.link)
-    let live_target = (io.realpath)(desired_entry.link).normalize()
+    let live_kind = (io.kind)(desired_entry.link.path)
+    let live_target = (io.realpath)(desired_entry.link.path).normalize()
     let still_contained = is_physically_contained(io, desired_entry)
     live_kind == @fs.FileKind::SymLink &&
-    live_target == desired_entry.resolved_target &&
+    live_target == desired_entry.resolved_target.path &&
     still_contained
   } catch {
     _ => false
@@ -45,7 +45,7 @@ async fn create_desired_link(
     notices.push(
       OperationFailed(
         operation=VerifyCreatedLink,
-        path=desired_entry.link,
+        path=desired_entry.link.path,
         reason="created link could not be verified",
       ),
     )
@@ -62,9 +62,9 @@ async fn create_desired_link(
     HardStop(_) => {
       let mut rollback_check_failed = false
       let rollback_verified = try
-        (io.kind)(desired_entry.link) == @fs.FileKind::SymLink &&
-        (io.realpath)(desired_entry.link).normalize() ==
-        desired_entry.resolved_target &&
+        (io.kind)(desired_entry.link.path) == @fs.FileKind::SymLink &&
+        (io.realpath)(desired_entry.link.path).normalize() ==
+        desired_entry.resolved_target.path &&
         is_physically_contained(io, desired_entry)
       catch {
         error => {
@@ -72,7 +72,7 @@ async fn create_desired_link(
           notices.push(
             OperationFailed(
               operation=VerifyCreatedLink,
-              path=desired_entry.link,
+              path=desired_entry.link.path,
               reason=error.to_string(),
             ),
           )
@@ -82,19 +82,19 @@ async fn create_desired_link(
         value => value
       }
       if rollback_verified {
-        (io.remove)(desired_entry.link) catch {
+        (io.remove)(desired_entry.link.path) catch {
           @os_error.OSError(_) as error if error.is_ENOENT() => ()
           error =>
             notices.push(
               OperationFailed(
                 operation=RemoveLink,
-                path=desired_entry.link,
+                path=desired_entry.link.path,
                 reason=error.to_string(),
               ),
             )
         }
       } else if !rollback_check_failed {
-        notices.push(UnmanagedPathPreserved(path=desired_entry.link))
+        notices.push(UnmanagedPathPreserved(path=desired_entry.link.path))
       }
       CreationHardStop({
         status: Partial,

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_create.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_create.mbt
@@ -8,7 +8,7 @@ enum DesiredLinkCreationResult {
 ///|
 async fn create_desired_link(
   io : LinkReconciliationIO,
-  state_path : @path.Path,
+  state_path : OwnershipStatePath,
   durable_state : OwnershipState,
   desired_entry : OwnershipEntry,
   notices : Array[LinkReconciliationNotice],

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_create.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_create.mbt
@@ -1,0 +1,106 @@
+///|
+enum DesiredLinkCreationResult {
+  Created(OwnershipState)
+  Skipped
+  CreationHardStop(LinkReconciliationResult)
+}
+
+///|
+async fn create_desired_link(
+  io : LinkReconciliationIO,
+  state_path : @path.Path,
+  durable_state : OwnershipState,
+  desired_entry : OwnershipEntry,
+  notices : Array[LinkReconciliationNotice],
+) -> DesiredLinkCreationResult {
+  (io.symlink)(desired_entry.symlink_target, desired_entry.link) catch {
+    @os_error.OSError(_) as error if error.is_EEXIST() => {
+      notices.push(UnmanagedPathPreserved(path=desired_entry.link))
+      return Skipped
+    }
+    error => {
+      notices.push(
+        OperationFailed(
+          operation=CreateLink,
+          path=desired_entry.link,
+          reason=error.to_string(),
+        ),
+      )
+      return Skipped
+    }
+  }
+  let verified = try {
+    let live_kind = (io.kind)(desired_entry.link)
+    let live_target = (io.realpath)(desired_entry.link).normalize()
+    let still_contained = is_physically_contained(io, desired_entry)
+    live_kind == @fs.FileKind::SymLink &&
+    live_target == desired_entry.resolved_target &&
+    still_contained
+  } catch {
+    _ => false
+  } noraise {
+    value => value
+  }
+  if !verified {
+    notices.push(
+      OperationFailed(
+        operation=VerifyCreatedLink,
+        path=desired_entry.link,
+        reason="created link could not be verified",
+      ),
+    )
+    return CreationHardStop({
+      status: Partial,
+      durable_state,
+      notices: ReadOnlyArray::from_array(notices),
+    })
+  }
+  let next_state = state_with_entry(durable_state, desired_entry)
+  match
+    checkpoint_ownership(io, state_path, durable_state, next_state, notices) {
+    Written(state) => Created(state)
+    HardStop(_) => {
+      let mut rollback_check_failed = false
+      let rollback_verified = try
+        (io.kind)(desired_entry.link) == @fs.FileKind::SymLink &&
+        (io.realpath)(desired_entry.link).normalize() ==
+        desired_entry.resolved_target &&
+        is_physically_contained(io, desired_entry)
+      catch {
+        error => {
+          rollback_check_failed = true
+          notices.push(
+            OperationFailed(
+              operation=VerifyCreatedLink,
+              path=desired_entry.link,
+              reason=error.to_string(),
+            ),
+          )
+          false
+        }
+      } noraise {
+        value => value
+      }
+      if rollback_verified {
+        (io.remove)(desired_entry.link) catch {
+          @os_error.OSError(_) as error if error.is_ENOENT() => ()
+          error =>
+            notices.push(
+              OperationFailed(
+                operation=RemoveLink,
+                path=desired_entry.link,
+                reason=error.to_string(),
+              ),
+            )
+        }
+      } else if !rollback_check_failed {
+        notices.push(UnmanagedPathPreserved(path=desired_entry.link))
+      }
+      CreationHardStop({
+        status: Partial,
+        durable_state,
+        notices: ReadOnlyArray::from_array(notices),
+      })
+    }
+  }
+}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_create_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_create_wbtest.mbt
@@ -12,7 +12,7 @@ async test "LinkReconciliation reconcile_skill_links 10 - hard-stops after a cre
     let entry_a = stale_reconciliation_entry(managed_root, "a", target_a)
     let entry_b = stale_reconciliation_entry(managed_root, "b", target_b)
     let desired_state = OwnershipState::OwnershipState([entry_b, entry_a])
-    let state_path = root.join("state.json")
+    let state_path = reconciliation_state_path(root.join("state.json"))
     let empty = OwnershipState::OwnershipState([])
     let fail_checkpoint : async (@path.Path, OwnershipState) -> Unit raise StateStoreError = (
       path,
@@ -106,7 +106,7 @@ async test "LinkReconciliation reconcile_skill_links 12 - preserves an injected 
     let empty = OwnershipState::OwnershipState([])
     let result = reconcile_skill_links_with_io(
       io,
-      root.join("state.json"),
+      reconciliation_state_path(root.join("state.json")),
       OwnershipState::OwnershipState([entry]),
       Trusted(empty),
     )
@@ -166,7 +166,7 @@ async test "LinkReconciliation reconcile_skill_links 17 - hard-stops after succe
     let empty = OwnershipState::OwnershipState([])
     let result = reconcile_skill_links_with_io(
       io,
-      root.join("state.json"),
+      reconciliation_state_path(root.join("state.json")),
       OwnershipState::OwnershipState([entry_b, entry_a]),
       Trusted(empty),
     )

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_create_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_create_wbtest.mbt
@@ -1,0 +1,184 @@
+///|
+async test "LinkReconciliation reconcile_skill_links 10 - hard-stops after a created link checkpoint failure" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-create-fail-")
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let managed_root = root.join("skills")
+    let target_a = root.join("target-a")
+    let target_b = root.join("target-b")
+    @fs.mkdir(target_a.to_string(), recursive=true)
+    @fs.mkdir(target_b.to_string(), recursive=true)
+    let entry_a = stale_reconciliation_entry(managed_root, "a", target_a)
+    let entry_b = stale_reconciliation_entry(managed_root, "b", target_b)
+    let desired_state = OwnershipState::OwnershipState([entry_b, entry_a])
+    let state_path = root.join("state.json")
+    let empty = OwnershipState::OwnershipState([])
+    let fail_checkpoint : async (@path.Path, OwnershipState) -> Unit raise StateStoreError = (
+      path,
+      _state,
+    ) => raise StateStoreError::IO(path~, reason="checkpoint failed")
+    let failed = reconcile_skill_links(
+      state_path~,
+      desired_state~,
+      previous_ownership=Trusted(empty),
+      checkpoint_ownership_state=fail_checkpoint,
+    )
+    debug_inspect(failed.status, content="Partial")
+    inspect(failed.durable_state == empty, content="true")
+    match failed.notices[0] {
+      CheckpointFailed(operation=CheckpointOwnership, path~, reason~) => {
+        inspect(path == state_path, content="true")
+        inspect(reason, content="checkpoint failed")
+      }
+      _ => fail("expected checkpoint failure")
+    }
+    let first_kind = @fs.kind(entry_a.link.to_string(), follow_symlink=false) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    debug_inspect(first_kind, content="Unknown")
+    let second_kind = @fs.kind(entry_b.link.to_string(), follow_symlink=false) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    debug_inspect(second_kind, content="Unknown")
+
+    let checkpoints = []
+    let retried = reconcile_skill_links(
+      state_path~,
+      desired_state~,
+      previous_ownership=Trusted(failed.durable_state),
+      checkpoint_ownership_state=fn(_path, state) { checkpoints.push(state) },
+    )
+    debug_inspect(retried.status, content="Complete")
+    inspect(checkpoints.length(), content="2")
+    inspect(retried.durable_state == desired_state, content="true")
+    inspect(
+      @fs.realpath(entry_a.link.to_string()),
+      content=@fs.realpath(target_a.to_string()),
+    )
+    inspect(
+      @fs.realpath(entry_b.link.to_string()),
+      content=@fs.realpath(target_b.to_string()),
+    )
+  }
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 12 - preserves an injected EEXIST race winner" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-eexist-")
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let managed_root = root.join("skills")
+    let desired_target = root.join("desired")
+    let foreign_target = root.join("foreign")
+    @fs.mkdir(desired_target.to_string(), recursive=true)
+    @fs.mkdir(foreign_target.to_string(), recursive=true)
+    let entry = stale_reconciliation_entry(
+      managed_root, "install", desired_target,
+    )
+    let mut checkpointed = false
+    let io : LinkReconciliationIO = {
+      mkdir: async fn(path) {
+        @fs.mkdir(path.to_string(), recursive=true) catch {
+          @os_error.OSError(_) as error if error.is_EEXIST() => ()
+          error => raise error
+        }
+      },
+      kind: async fn(path) { @fs.kind(path.to_string(), follow_symlink=false) },
+      realpath: async fn(path) { @path.Path(@fs.realpath(path.to_string())) },
+      symlink: async fn(target, link) {
+        @fs.symlink(
+          target=foreign_target.relative(base=managed_root).to_string(),
+          link.to_string(),
+        )
+        @fs.symlink(target=target.to_string(), link.to_string())
+      },
+      remove: async fn(path) { @fs.remove(path.to_string()) },
+      checkpoint: fn(_path, _state) { checkpointed = true },
+    }
+    let empty = OwnershipState::OwnershipState([])
+    let result = reconcile_skill_links_with_io(
+      io,
+      root.join("state.json"),
+      OwnershipState::OwnershipState([entry]),
+      Trusted(empty),
+    )
+    debug_inspect(result.status, content="Partial")
+    inspect(result.durable_state == empty, content="true")
+    inspect(checkpointed, content="false")
+    match result.notices[0] {
+      UnmanagedPathPreserved(path~) =>
+        inspect(path == entry.link, content="true")
+      _ => fail("expected unmanaged EEXIST winner notice")
+    }
+    inspect(
+      @fs.realpath(entry.link.to_string()),
+      content=@fs.realpath(foreign_target.to_string()),
+    )
+  }
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 17 - hard-stops after successful create verifies the wrong target" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-verify-race-")
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let managed_root = root.join("skills")
+    let target_a = root.join("target-a")
+    let target_b = root.join("target-b")
+    let wrong_target = root.join("wrong-target")
+    @fs.mkdir(target_a.to_string(), recursive=true)
+    @fs.mkdir(target_b.to_string(), recursive=true)
+    @fs.mkdir(wrong_target.to_string(), recursive=true)
+    let entry_a = stale_reconciliation_entry(managed_root, "a", target_a)
+    let entry_b = stale_reconciliation_entry(managed_root, "b", target_b)
+    let mut checkpointed = false
+    let io : LinkReconciliationIO = {
+      mkdir: async fn(path) {
+        @fs.mkdir(path.to_string(), recursive=true) catch {
+          @os_error.OSError(_) as error if error.is_EEXIST() => ()
+          error => raise error
+        }
+      },
+      kind: async fn(path) { @fs.kind(path.to_string(), follow_symlink=false) },
+      realpath: async fn(path) { @path.Path(@fs.realpath(path.to_string())) },
+      symlink: async fn(target, link) {
+        if link == entry_a.link {
+          @fs.symlink(
+            target=wrong_target.relative(base=managed_root).to_string(),
+            link.to_string(),
+          )
+        } else {
+          @fs.symlink(target=target.to_string(), link.to_string())
+        }
+      },
+      remove: async fn(path) { @fs.remove(path.to_string()) },
+      checkpoint: fn(_path, _state) { checkpointed = true },
+    }
+    let empty = OwnershipState::OwnershipState([])
+    let result = reconcile_skill_links_with_io(
+      io,
+      root.join("state.json"),
+      OwnershipState::OwnershipState([entry_b, entry_a]),
+      Trusted(empty),
+    )
+    debug_inspect(result.status, content="Partial")
+    inspect(result.durable_state == empty, content="true")
+    inspect(checkpointed, content="false")
+    match result.notices[0] {
+      OperationFailed(operation=VerifyCreatedLink, path~, reason=_) =>
+        inspect(path == entry_a.link, content="true")
+      _ => fail("expected created-link verification failure")
+    }
+    inspect(
+      @fs.realpath(entry_a.link.to_string()),
+      content=@fs.realpath(wrong_target.to_string()),
+    )
+    let later_kind = @fs.kind(entry_b.link.to_string(), follow_symlink=false) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    debug_inspect(later_kind, content="Unknown")
+  }
+}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_create_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_create_wbtest.mbt
@@ -33,11 +33,17 @@ async test "LinkReconciliation reconcile_skill_links 10 - hard-stops after a cre
       }
       _ => fail("expected checkpoint failure")
     }
-    let first_kind = @fs.kind(entry_a.link.to_string(), follow_symlink=false) catch {
+    let first_kind = @fs.kind(
+      entry_a.link.path.to_string(),
+      follow_symlink=false,
+    ) catch {
       _ => @fs.FileKind::Unknown
     }
     debug_inspect(first_kind, content="Unknown")
-    let second_kind = @fs.kind(entry_b.link.to_string(), follow_symlink=false) catch {
+    let second_kind = @fs.kind(
+      entry_b.link.path.to_string(),
+      follow_symlink=false,
+    ) catch {
       _ => @fs.FileKind::Unknown
     }
     debug_inspect(second_kind, content="Unknown")
@@ -53,11 +59,11 @@ async test "LinkReconciliation reconcile_skill_links 10 - hard-stops after a cre
     inspect(checkpoints.length(), content="2")
     inspect(retried.durable_state == desired_state, content="true")
     inspect(
-      @fs.realpath(entry_a.link.to_string()),
+      @fs.realpath(entry_a.link.path.to_string()),
       content=@fs.realpath(target_a.to_string()),
     )
     inspect(
-      @fs.realpath(entry_b.link.to_string()),
+      @fs.realpath(entry_b.link.path.to_string()),
       content=@fs.realpath(target_b.to_string()),
     )
   }
@@ -109,11 +115,11 @@ async test "LinkReconciliation reconcile_skill_links 12 - preserves an injected 
     inspect(checkpointed, content="false")
     match result.notices[0] {
       UnmanagedPathPreserved(path~) =>
-        inspect(path == entry.link, content="true")
+        inspect(path == entry.link.path, content="true")
       _ => fail("expected unmanaged EEXIST winner notice")
     }
     inspect(
-      @fs.realpath(entry.link.to_string()),
+      @fs.realpath(entry.link.path.to_string()),
       content=@fs.realpath(foreign_target.to_string()),
     )
   }
@@ -145,7 +151,7 @@ async test "LinkReconciliation reconcile_skill_links 17 - hard-stops after succe
       kind: async fn(path) { @fs.kind(path.to_string(), follow_symlink=false) },
       realpath: async fn(path) { @path.Path(@fs.realpath(path.to_string())) },
       symlink: async fn(target, link) {
-        if link == entry_a.link {
+        if link == entry_a.link.path {
           @fs.symlink(
             target=wrong_target.relative(base=managed_root).to_string(),
             link.to_string(),
@@ -169,14 +175,17 @@ async test "LinkReconciliation reconcile_skill_links 17 - hard-stops after succe
     inspect(checkpointed, content="false")
     match result.notices[0] {
       OperationFailed(operation=VerifyCreatedLink, path~, reason=_) =>
-        inspect(path == entry_a.link, content="true")
+        inspect(path == entry_a.link.path, content="true")
       _ => fail("expected created-link verification failure")
     }
     inspect(
-      @fs.realpath(entry_a.link.to_string()),
+      @fs.realpath(entry_a.link.path.to_string()),
       content=@fs.realpath(wrong_target.to_string()),
     )
-    let later_kind = @fs.kind(entry_b.link.to_string(), follow_symlink=false) catch {
+    let later_kind = @fs.kind(
+      entry_b.link.path.to_string(),
+      follow_symlink=false,
+    ) catch {
       _ => @fs.FileKind::Unknown
     }
     debug_inspect(later_kind, content="Unknown")

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_desired.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_desired.mbt
@@ -1,7 +1,7 @@
 ///|
 async fn reconcile_desired_entries(
   io~ : LinkReconciliationIO,
-  state_path~ : @path.Path,
+  state_path~ : OwnershipStatePath,
   desired_state~ : OwnershipState,
   durable_state~ : OwnershipState,
   notices~ : Array[LinkReconciliationNotice],

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_desired.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_desired.mbt
@@ -1,0 +1,264 @@
+///|
+async fn reconcile_desired_entries(
+  io~ : LinkReconciliationIO,
+  state_path~ : @path.Path,
+  desired_state~ : OwnershipState,
+  durable_state~ : OwnershipState,
+  notices~ : Array[LinkReconciliationNotice],
+) -> (OwnershipState, LinkReconciliationResult?) {
+  let mut durable_state = durable_state
+  let desired_entries = desired_state.entries.to_array()
+  desired_entries.sort_by((left, right) => left.0.compare(right.0))
+
+  for pair in desired_entries {
+    let identity = pair.0
+    let desired_entry = pair.1
+    (io.mkdir)(desired_entry.managed_root) catch {
+      error => {
+        notices.push(
+          OperationFailed(
+            operation=EnsureManagedRoot,
+            path=desired_entry.managed_root,
+            reason=error.to_string(),
+          ),
+        )
+        continue
+      }
+    }
+    let managed_root_kind = (io.kind)(desired_entry.managed_root) catch {
+      error => {
+        notices.push(
+          OperationFailed(
+            operation=VerifyContainment,
+            path=desired_entry.managed_root,
+            reason=error.to_string(),
+          ),
+        )
+        continue
+      }
+    }
+    if managed_root_kind != @fs.FileKind::Directory {
+      notices.push(
+        OperationFailed(
+          operation=VerifyContainment,
+          path=desired_entry.managed_root,
+          reason="managed root must be a physical directory",
+        ),
+      )
+      continue
+    }
+    let contained = is_physically_contained(io, desired_entry) catch {
+      error => {
+        notices.push(
+          OperationFailed(
+            operation=VerifyContainment,
+            path=desired_entry.link,
+            reason=error.to_string(),
+          ),
+        )
+        continue
+      }
+    }
+    if !contained {
+      notices.push(
+        OperationFailed(
+          operation=VerifyContainment,
+          path=desired_entry.link,
+          reason="link parent resolves outside the managed root",
+        ),
+      )
+      continue
+    }
+    let kind = classify_link(io, desired_entry.link) catch {
+      error => {
+        notices.push(
+          OperationFailed(
+            operation=ClassifyLink,
+            path=desired_entry.link,
+            reason=error.to_string(),
+          ),
+        )
+        continue
+      }
+    }
+    let mut should_create = false
+    match durable_state.entries.get(identity) {
+      None =>
+        match kind {
+          Some(_) =>
+            notices.push(UnmanagedPathPreserved(path=desired_entry.link))
+          None => should_create = true
+        }
+      Some(recorded_entry) =>
+        match kind {
+          None => {
+            let omitted = state_without_entry(durable_state, identity)
+            match
+              checkpoint_ownership(
+                io, state_path, durable_state, omitted, notices,
+              ) {
+              Written(state) => durable_state = state
+              HardStop(result) => return (durable_state, Some(result))
+            }
+            should_create = true
+          }
+          Some(@fs.FileKind::SymLink) => {
+            let mut broken = false
+            let live_target = try (io.realpath)(recorded_entry.link) catch {
+              @os_error.OSError(_) as error if error.is_ENOENT() => {
+                broken = true
+                None
+              }
+              error => {
+                notices.push(
+                  OperationFailed(
+                    operation=ClassifyLink,
+                    path=recorded_entry.link,
+                    reason=error.to_string(),
+                  ),
+                )
+                None
+              }
+            } noraise {
+              target => Some(target.normalize())
+            }
+            if broken {
+              notices.push(BrokenOwnedLinkPreserved(path=recorded_entry.link))
+              let omitted = state_without_entry(durable_state, identity)
+              match
+                checkpoint_ownership(
+                  io, state_path, durable_state, omitted, notices,
+                ) {
+                Written(state) => durable_state = state
+                HardStop(result) => return (durable_state, Some(result))
+              }
+            } else {
+              match live_target {
+                Some(target) if target == recorded_entry.resolved_target =>
+                  if desired_entry.resolved_target ==
+                    recorded_entry.resolved_target {
+                    if desired_entry != recorded_entry {
+                      let refreshed = state_with_entry(
+                        durable_state, desired_entry,
+                      )
+                      match
+                        checkpoint_ownership(
+                          io, state_path, durable_state, refreshed, notices,
+                        ) {
+                        Written(state) => durable_state = state
+                        HardStop(result) => return (durable_state, Some(result))
+                      }
+                    }
+                  } else {
+                    match recheck_stale_link(io, recorded_entry) {
+                      Matching => {
+                        (io.remove)(recorded_entry.link) catch {
+                          @os_error.OSError(_) as error if error.is_ENOENT() =>
+                            ()
+                          error => {
+                            notices.push(
+                              OperationFailed(
+                                operation=RemoveLink,
+                                path=recorded_entry.link,
+                                reason=error.to_string(),
+                              ),
+                            )
+                            continue
+                          }
+                        }
+                        let omitted = state_without_entry(
+                          durable_state, identity,
+                        )
+                        match
+                          checkpoint_ownership(
+                            io, state_path, durable_state, omitted, notices,
+                          ) {
+                          Written(state) => durable_state = state
+                          HardStop(result) =>
+                            return (durable_state, Some(result))
+                        }
+                        should_create = true
+                      }
+                      Missing => {
+                        let omitted = state_without_entry(
+                          durable_state, identity,
+                        )
+                        match
+                          checkpoint_ownership(
+                            io, state_path, durable_state, omitted, notices,
+                          ) {
+                          Written(state) => durable_state = state
+                          HardStop(result) =>
+                            return (durable_state, Some(result))
+                        }
+                        should_create = true
+                      }
+                      Replaced => {
+                        notices.push(
+                          ReplacedOwnedPathPreserved(path=recorded_entry.link),
+                        )
+                        let omitted = state_without_entry(
+                          durable_state, identity,
+                        )
+                        match
+                          checkpoint_ownership(
+                            io, state_path, durable_state, omitted, notices,
+                          ) {
+                          Written(state) => durable_state = state
+                          HardStop(result) =>
+                            return (durable_state, Some(result))
+                        }
+                      }
+                      Failed(operation~, reason~) =>
+                        notices.push(
+                          OperationFailed(
+                            operation~,
+                            path=recorded_entry.link,
+                            reason~,
+                          ),
+                        )
+                    }
+                  }
+                Some(_) => {
+                  notices.push(
+                    ReplacedOwnedPathPreserved(path=recorded_entry.link),
+                  )
+                  let omitted = state_without_entry(durable_state, identity)
+                  match
+                    checkpoint_ownership(
+                      io, state_path, durable_state, omitted, notices,
+                    ) {
+                    Written(state) => durable_state = state
+                    HardStop(result) => return (durable_state, Some(result))
+                  }
+                }
+                None => ()
+              }
+            }
+          }
+          Some(_) => {
+            notices.push(ReplacedOwnedPathPreserved(path=recorded_entry.link))
+            let omitted = state_without_entry(durable_state, identity)
+            match
+              checkpoint_ownership(
+                io, state_path, durable_state, omitted, notices,
+              ) {
+              Written(state) => durable_state = state
+              HardStop(result) => return (durable_state, Some(result))
+            }
+          }
+        }
+    }
+    if should_create {
+      match
+        create_desired_link(
+          io, state_path, durable_state, desired_entry, notices,
+        ) {
+        Created(state) => durable_state = state
+        Skipped => ()
+        CreationHardStop(result) => return (durable_state, Some(result))
+      }
+    }
+  }
+  (durable_state, None)
+}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_desired.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_desired.mbt
@@ -13,24 +13,24 @@ async fn reconcile_desired_entries(
   for pair in desired_entries {
     let identity = pair.0
     let desired_entry = pair.1
-    (io.mkdir)(desired_entry.managed_root) catch {
+    (io.mkdir)(desired_entry.managed_root.path) catch {
       error => {
         notices.push(
           OperationFailed(
             operation=EnsureManagedRoot,
-            path=desired_entry.managed_root,
+            path=desired_entry.managed_root.path,
             reason=error.to_string(),
           ),
         )
         continue
       }
     }
-    let managed_root_kind = (io.kind)(desired_entry.managed_root) catch {
+    let managed_root_kind = (io.kind)(desired_entry.managed_root.path) catch {
       error => {
         notices.push(
           OperationFailed(
             operation=VerifyContainment,
-            path=desired_entry.managed_root,
+            path=desired_entry.managed_root.path,
             reason=error.to_string(),
           ),
         )
@@ -41,7 +41,7 @@ async fn reconcile_desired_entries(
       notices.push(
         OperationFailed(
           operation=VerifyContainment,
-          path=desired_entry.managed_root,
+          path=desired_entry.managed_root.path,
           reason="managed root must be a physical directory",
         ),
       )
@@ -52,7 +52,7 @@ async fn reconcile_desired_entries(
         notices.push(
           OperationFailed(
             operation=VerifyContainment,
-            path=desired_entry.link,
+            path=desired_entry.link.path,
             reason=error.to_string(),
           ),
         )
@@ -63,18 +63,18 @@ async fn reconcile_desired_entries(
       notices.push(
         OperationFailed(
           operation=VerifyContainment,
-          path=desired_entry.link,
+          path=desired_entry.link.path,
           reason="link parent resolves outside the managed root",
         ),
       )
       continue
     }
-    let kind = classify_link(io, desired_entry.link) catch {
+    let kind = classify_link(io, desired_entry.link.path) catch {
       error => {
         notices.push(
           OperationFailed(
             operation=ClassifyLink,
-            path=desired_entry.link,
+            path=desired_entry.link.path,
             reason=error.to_string(),
           ),
         )
@@ -86,7 +86,7 @@ async fn reconcile_desired_entries(
       None =>
         match kind {
           Some(_) =>
-            notices.push(UnmanagedPathPreserved(path=desired_entry.link))
+            notices.push(UnmanagedPathPreserved(path=desired_entry.link.path))
           None => should_create = true
         }
       Some(recorded_entry) =>
@@ -104,7 +104,9 @@ async fn reconcile_desired_entries(
           }
           Some(@fs.FileKind::SymLink) => {
             let mut broken = false
-            let live_target = try (io.realpath)(recorded_entry.link) catch {
+            let live_target = try
+              (io.realpath)(recorded_entry.link.path)
+            catch {
               @os_error.OSError(_) as error if error.is_ENOENT() => {
                 broken = true
                 None
@@ -113,7 +115,7 @@ async fn reconcile_desired_entries(
                 notices.push(
                   OperationFailed(
                     operation=ClassifyLink,
-                    path=recorded_entry.link,
+                    path=recorded_entry.link.path,
                     reason=error.to_string(),
                   ),
                 )
@@ -123,7 +125,9 @@ async fn reconcile_desired_entries(
               target => Some(target.normalize())
             }
             if broken {
-              notices.push(BrokenOwnedLinkPreserved(path=recorded_entry.link))
+              notices.push(
+                BrokenOwnedLinkPreserved(path=recorded_entry.link.path),
+              )
               let omitted = state_without_entry(durable_state, identity)
               match
                 checkpoint_ownership(
@@ -134,9 +138,9 @@ async fn reconcile_desired_entries(
               }
             } else {
               match live_target {
-                Some(target) if target == recorded_entry.resolved_target =>
-                  if desired_entry.resolved_target ==
-                    recorded_entry.resolved_target {
+                Some(target) if target == recorded_entry.resolved_target.path =>
+                  if desired_entry.resolved_target.path ==
+                    recorded_entry.resolved_target.path {
                     if desired_entry != recorded_entry {
                       let refreshed = state_with_entry(
                         durable_state, desired_entry,
@@ -152,14 +156,14 @@ async fn reconcile_desired_entries(
                   } else {
                     match recheck_stale_link(io, recorded_entry) {
                       Matching => {
-                        (io.remove)(recorded_entry.link) catch {
+                        (io.remove)(recorded_entry.link.path) catch {
                           @os_error.OSError(_) as error if error.is_ENOENT() =>
                             ()
                           error => {
                             notices.push(
                               OperationFailed(
                                 operation=RemoveLink,
-                                path=recorded_entry.link,
+                                path=recorded_entry.link.path,
                                 reason=error.to_string(),
                               ),
                             )
@@ -195,7 +199,9 @@ async fn reconcile_desired_entries(
                       }
                       Replaced => {
                         notices.push(
-                          ReplacedOwnedPathPreserved(path=recorded_entry.link),
+                          ReplacedOwnedPathPreserved(
+                            path=recorded_entry.link.path,
+                          ),
                         )
                         let omitted = state_without_entry(
                           durable_state, identity,
@@ -213,7 +219,7 @@ async fn reconcile_desired_entries(
                         notices.push(
                           OperationFailed(
                             operation~,
-                            path=recorded_entry.link,
+                            path=recorded_entry.link.path,
                             reason~,
                           ),
                         )
@@ -221,7 +227,7 @@ async fn reconcile_desired_entries(
                   }
                 Some(_) => {
                   notices.push(
-                    ReplacedOwnedPathPreserved(path=recorded_entry.link),
+                    ReplacedOwnedPathPreserved(path=recorded_entry.link.path),
                   )
                   let omitted = state_without_entry(durable_state, identity)
                   match
@@ -237,7 +243,9 @@ async fn reconcile_desired_entries(
             }
           }
           Some(_) => {
-            notices.push(ReplacedOwnedPathPreserved(path=recorded_entry.link))
+            notices.push(
+              ReplacedOwnedPathPreserved(path=recorded_entry.link.path),
+            )
             let omitted = state_without_entry(durable_state, identity)
             match
               checkpoint_ownership(

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_desired_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_desired_wbtest.mbt
@@ -1,0 +1,238 @@
+///|
+async test "LinkReconciliation reconcile_skill_links 2 - preserves every unrecorded collision without adoption" {
+  @async.with_task_group() <| group => {
+    let fixtures = [
+      UnmanagedCollisionFixture::File,
+      Directory,
+      SameTargetSymlink,
+      DifferentTargetSymlink,
+      BrokenSymlink,
+    ]
+    for fixture in fixtures {
+      let temporary_root : @path.Path = @fs.tmpdir(
+        prefix="c-plugin-v2-reconcile-collision-",
+      )
+      group.add_defer(() => {
+        @fs.rmdir(temporary_root.to_string(), recursive=true)
+      })
+      let root : @path.Path = @fs.realpath(temporary_root.to_string())
+      let managed_root = root.join(".agents").join("skills")
+      let link = managed_root.join("install")
+      let target = root.join("cache").join("skills").join("install")
+      let other_target = root.join("cache").join("skills").join("other")
+      let state_path = root.join(".agents").join("c-plugin-state.json")
+      @fs.mkdir(managed_root.to_string(), recursive=true)
+      @fs.mkdir(target.to_string(), recursive=true)
+      @fs.mkdir(other_target.to_string(), recursive=true)
+      match fixture {
+        File =>
+          @fs.write_file(link.to_string(), "foreign", create_mode=CreateNew)
+        Directory => @fs.mkdir(link.to_string())
+        SameTargetSymlink =>
+          @fs.symlink(
+            target=target.relative(base=managed_root).to_string(),
+            link.to_string(),
+          )
+        DifferentTargetSymlink =>
+          @fs.symlink(
+            target=other_target.relative(base=managed_root).to_string(),
+            link.to_string(),
+          )
+        BrokenSymlink => @fs.symlink(target="missing-target", link.to_string())
+      }
+      let entry = OwnershipEntry::OwnershipEntry(
+        link,
+        target.relative(base=managed_root),
+        target,
+        managed_root,
+        OwnershipSource::from_local(
+          LocalOwnershipSource::LocalOwnershipSource(
+            RelativeSourcePath::RelativeSourcePath(
+              @path.Path("vendor/repository"),
+            ),
+            PluginName::PluginName("plugin"),
+            SkillName::SkillName("install"),
+          ),
+        ),
+      )
+      let desired_state = OwnershipState::OwnershipState([entry])
+      let previous_state = OwnershipState::OwnershipState([])
+      let mut checkpointed = false
+      let result = reconcile_skill_links(
+        state_path~,
+        desired_state~,
+        previous_ownership=PreviousOwnership::Trusted(previous_state),
+        checkpoint_ownership_state=fn(_path, _state) { checkpointed = true },
+      )
+
+      debug_inspect(result.status, content="Partial")
+      inspect(result.durable_state == previous_state, content="true")
+      inspect(checkpointed, content="false")
+      inspect(result.notices.length(), content="1")
+      match result.notices[0] {
+        UnmanagedPathPreserved(path~) => inspect(path == link, content="true")
+        _ => fail("expected unmanaged path notice")
+      }
+      match fixture {
+        File =>
+          inspect(@fs.read_file(link.to_string()).text(), content="foreign")
+        Directory =>
+          debug_inspect(
+            @fs.kind(link.to_string(), follow_symlink=false),
+            content="Directory",
+          )
+        SameTargetSymlink => {
+          debug_inspect(
+            @fs.kind(link.to_string(), follow_symlink=false),
+            content="SymLink",
+          )
+          inspect(
+            @fs.realpath(link.to_string()),
+            content=@fs.realpath(target.to_string()),
+          )
+        }
+        DifferentTargetSymlink => {
+          debug_inspect(
+            @fs.kind(link.to_string(), follow_symlink=false),
+            content="SymLink",
+          )
+          inspect(
+            @fs.realpath(link.to_string()),
+            content=@fs.realpath(other_target.to_string()),
+          )
+        }
+        BrokenSymlink =>
+          debug_inspect(
+            @fs.kind(link.to_string(), follow_symlink=false),
+            content="SymLink",
+          )
+      }
+    }
+  }
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 4 - refreshes same-target ownership metadata" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-metadata-")
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let managed_root = root.join("skills")
+    let target = root.join("target")
+    @fs.mkdir(managed_root.to_string(), recursive=true)
+    @fs.mkdir(target.to_string(), recursive=true)
+    let recorded = desired_owned_entry(managed_root, target, "vendor/old")
+    let desired = desired_owned_entry(managed_root, target, "vendor/new")
+    @fs.symlink(
+      target=recorded.symlink_target.to_string(),
+      recorded.link.to_string(),
+    )
+    let desired_state = OwnershipState::OwnershipState([desired])
+    let checkpoints = []
+    let result = reconcile_skill_links(
+      state_path=root.join("state.json"),
+      desired_state~,
+      previous_ownership=Trusted(OwnershipState::OwnershipState([recorded])),
+      checkpoint_ownership_state=fn(_path, state) { checkpoints.push(state) },
+    )
+    debug_inspect(result.status, content="Complete")
+    inspect(checkpoints.length(), content="1")
+    inspect(checkpoints[0] == desired_state, content="true")
+    debug_inspect(
+      @fs.kind(desired.link.to_string(), follow_symlink=false),
+      content="SymLink",
+    )
+    inspect(
+      @fs.realpath(desired.link.to_string()),
+      content=@fs.realpath(target.to_string()),
+    )
+  }
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 5 - replaces a verified owned target with omission then addition checkpoints" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-replace-")
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let managed_root = root.join("skills")
+    let old_target = root.join("old-target")
+    let new_target = root.join("new-target")
+    @fs.mkdir(managed_root.to_string(), recursive=true)
+    @fs.mkdir(old_target.to_string(), recursive=true)
+    @fs.mkdir(new_target.to_string(), recursive=true)
+    let recorded = desired_owned_entry(managed_root, old_target, "vendor/repo")
+    let desired = desired_owned_entry(managed_root, new_target, "vendor/repo")
+    @fs.symlink(
+      target=recorded.symlink_target.to_string(),
+      recorded.link.to_string(),
+    )
+    let desired_state = OwnershipState::OwnershipState([desired])
+    let checkpoints = []
+    let result = reconcile_skill_links(
+      state_path=root.join("state.json"),
+      desired_state~,
+      previous_ownership=Trusted(OwnershipState::OwnershipState([recorded])),
+      checkpoint_ownership_state=fn(_path, state) { checkpoints.push(state) },
+    )
+    debug_inspect(result.status, content="Complete")
+    inspect(checkpoints.length(), content="2")
+    inspect(checkpoints[0].entries.length(), content="0")
+    inspect(checkpoints[1] == desired_state, content="true")
+    inspect(result.durable_state == desired_state, content="true")
+    inspect(
+      @fs.realpath(desired.link.to_string()),
+      content=@fs.realpath(new_target.to_string()),
+    )
+  }
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 6 - preserves replaced and broken desired-owned paths while dropping ownership" {
+  @async.with_task_group() <| group => {
+    for fixture in ["replaced", "broken"] {
+      let temporary : @path.Path = @fs.tmpdir(
+        prefix="c-plugin-v2-owned-\{fixture}-",
+      )
+      group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+      let root : @path.Path = @fs.realpath(temporary.to_string())
+      let managed_root = root.join("skills")
+      let target = root.join("target")
+      let other = root.join("other")
+      @fs.mkdir(managed_root.to_string(), recursive=true)
+      @fs.mkdir(target.to_string(), recursive=true)
+      @fs.mkdir(other.to_string(), recursive=true)
+      let entry = desired_owned_entry(managed_root, target, "vendor/repo")
+      if fixture == "replaced" {
+        @fs.symlink(
+          target=other.relative(base=managed_root).to_string(),
+          entry.link.to_string(),
+        )
+      } else {
+        @fs.symlink(target="missing-target", entry.link.to_string())
+      }
+      let desired_state = OwnershipState::OwnershipState([entry])
+      let checkpoints = []
+      let result = reconcile_skill_links(
+        state_path=root.join("state.json"),
+        desired_state~,
+        previous_ownership=Trusted(OwnershipState::OwnershipState([entry])),
+        checkpoint_ownership_state=fn(_path, state) { checkpoints.push(state) },
+      )
+      debug_inspect(result.status, content="Partial")
+      inspect(result.durable_state.entries.length(), content="0")
+      inspect(checkpoints.length(), content="1")
+      inspect(checkpoints[0].entries.length(), content="0")
+      debug_inspect(
+        @fs.kind(entry.link.to_string(), follow_symlink=false),
+        content="SymLink",
+      )
+      if fixture == "replaced" {
+        inspect(
+          @fs.realpath(entry.link.to_string()),
+          content=@fs.realpath(other.to_string()),
+        )
+      }
+    }
+  }
+}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_desired_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_desired_wbtest.mbt
@@ -20,7 +20,9 @@ async test "LinkReconciliation reconcile_skill_links 2 - preserves every unrecor
       let link = managed_root.join("install")
       let target = root.join("cache").join("skills").join("install")
       let other_target = root.join("cache").join("skills").join("other")
-      let state_path = root.join(".agents").join("c-plugin-state.json")
+      let state_path = reconciliation_state_path(
+        root.join(".agents").join("c-plugin-state.json"),
+      )
       @fs.mkdir(managed_root.to_string(), recursive=true)
       @fs.mkdir(target.to_string(), recursive=true)
       @fs.mkdir(other_target.to_string(), recursive=true)
@@ -130,7 +132,7 @@ async test "LinkReconciliation reconcile_skill_links 4 - refreshes same-target o
     let desired_state = OwnershipState::OwnershipState([desired])
     let checkpoints = []
     let result = reconcile_skill_links(
-      state_path=root.join("state.json"),
+      state_path=reconciliation_state_path(root.join("state.json")),
       desired_state~,
       previous_ownership=Trusted(OwnershipState::OwnershipState([recorded])),
       checkpoint_ownership_state=fn(_path, state) { checkpoints.push(state) },
@@ -170,7 +172,7 @@ async test "LinkReconciliation reconcile_skill_links 5 - replaces a verified own
     let desired_state = OwnershipState::OwnershipState([desired])
     let checkpoints = []
     let result = reconcile_skill_links(
-      state_path=root.join("state.json"),
+      state_path=reconciliation_state_path(root.join("state.json")),
       desired_state~,
       previous_ownership=Trusted(OwnershipState::OwnershipState([recorded])),
       checkpoint_ownership_state=fn(_path, state) { checkpoints.push(state) },
@@ -214,7 +216,7 @@ async test "LinkReconciliation reconcile_skill_links 6 - preserves replaced and 
       let desired_state = OwnershipState::OwnershipState([entry])
       let checkpoints = []
       let result = reconcile_skill_links(
-        state_path=root.join("state.json"),
+        state_path=reconciliation_state_path(root.join("state.json")),
         desired_state~,
         previous_ownership=Trusted(OwnershipState::OwnershipState([entry])),
         checkpoint_ownership_state=fn(_path, state) { checkpoints.push(state) },

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_desired_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_desired_wbtest.mbt
@@ -41,10 +41,10 @@ async test "LinkReconciliation reconcile_skill_links 2 - preserves every unrecor
         BrokenSymlink => @fs.symlink(target="missing-target", link.to_string())
       }
       let entry = OwnershipEntry::OwnershipEntry(
-        link,
+        OwnershipLink::OwnershipLink(link),
         target.relative(base=managed_root),
-        target,
-        managed_root,
+        OwnershipResolvedTarget::OwnershipResolvedTarget(target),
+        OwnershipManagedRoot::OwnershipManagedRoot(managed_root),
         OwnershipSource::from_local(
           LocalOwnershipSource::LocalOwnershipSource(
             RelativeSourcePath::RelativeSourcePath(
@@ -125,7 +125,7 @@ async test "LinkReconciliation reconcile_skill_links 4 - refreshes same-target o
     let desired = desired_owned_entry(managed_root, target, "vendor/new")
     @fs.symlink(
       target=recorded.symlink_target.to_string(),
-      recorded.link.to_string(),
+      recorded.link.path.to_string(),
     )
     let desired_state = OwnershipState::OwnershipState([desired])
     let checkpoints = []
@@ -139,11 +139,11 @@ async test "LinkReconciliation reconcile_skill_links 4 - refreshes same-target o
     inspect(checkpoints.length(), content="1")
     inspect(checkpoints[0] == desired_state, content="true")
     debug_inspect(
-      @fs.kind(desired.link.to_string(), follow_symlink=false),
+      @fs.kind(desired.link.path.to_string(), follow_symlink=false),
       content="SymLink",
     )
     inspect(
-      @fs.realpath(desired.link.to_string()),
+      @fs.realpath(desired.link.path.to_string()),
       content=@fs.realpath(target.to_string()),
     )
   }
@@ -165,7 +165,7 @@ async test "LinkReconciliation reconcile_skill_links 5 - replaces a verified own
     let desired = desired_owned_entry(managed_root, new_target, "vendor/repo")
     @fs.symlink(
       target=recorded.symlink_target.to_string(),
-      recorded.link.to_string(),
+      recorded.link.path.to_string(),
     )
     let desired_state = OwnershipState::OwnershipState([desired])
     let checkpoints = []
@@ -181,7 +181,7 @@ async test "LinkReconciliation reconcile_skill_links 5 - replaces a verified own
     inspect(checkpoints[1] == desired_state, content="true")
     inspect(result.durable_state == desired_state, content="true")
     inspect(
-      @fs.realpath(desired.link.to_string()),
+      @fs.realpath(desired.link.path.to_string()),
       content=@fs.realpath(new_target.to_string()),
     )
   }
@@ -206,10 +206,10 @@ async test "LinkReconciliation reconcile_skill_links 6 - preserves replaced and 
       if fixture == "replaced" {
         @fs.symlink(
           target=other.relative(base=managed_root).to_string(),
-          entry.link.to_string(),
+          entry.link.path.to_string(),
         )
       } else {
-        @fs.symlink(target="missing-target", entry.link.to_string())
+        @fs.symlink(target="missing-target", entry.link.path.to_string())
       }
       let desired_state = OwnershipState::OwnershipState([entry])
       let checkpoints = []
@@ -224,12 +224,12 @@ async test "LinkReconciliation reconcile_skill_links 6 - preserves replaced and 
       inspect(checkpoints.length(), content="1")
       inspect(checkpoints[0].entries.length(), content="0")
       debug_inspect(
-        @fs.kind(entry.link.to_string(), follow_symlink=false),
+        @fs.kind(entry.link.path.to_string(), follow_symlink=false),
         content="SymLink",
       )
       if fixture == "replaced" {
         inspect(
-          @fs.realpath(entry.link.to_string()),
+          @fs.realpath(entry.link.path.to_string()),
           content=@fs.realpath(other.to_string()),
         )
       }

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_io.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_io.mbt
@@ -55,8 +55,8 @@ async fn is_physically_contained(
   io : LinkReconciliationIO,
   entry : OwnershipEntry,
 ) -> Bool {
-  let physical_root = (io.realpath)(entry.managed_root).normalize()
-  let physical_parent = (io.realpath)(entry.link.dirname()).normalize()
+  let physical_root = (io.realpath)(entry.managed_root.path).normalize()
+  let physical_parent = (io.realpath)(entry.link.path.dirname()).normalize()
   physical_parent == physical_root
 }
 
@@ -65,7 +65,7 @@ async fn recheck_stale_link(
   io : LinkReconciliationIO,
   entry : OwnershipEntry,
 ) -> StaleLinkRecheck {
-  let root_kind = (io.kind)(entry.managed_root) catch {
+  let root_kind = (io.kind)(entry.managed_root.path) catch {
     error =>
       return Failed(operation=VerifyContainment, reason=error.to_string())
   }
@@ -85,18 +85,18 @@ async fn recheck_stale_link(
       reason="physical containment changed",
     )
   }
-  let kind = classify_link(io, entry.link) catch {
+  let kind = classify_link(io, entry.link.path) catch {
     error => return Failed(operation=ClassifyLink, reason=error.to_string())
   }
   match kind {
     None => Missing
     Some(@fs.FileKind::SymLink) =>
-      try (io.realpath)(entry.link) catch {
+      try (io.realpath)(entry.link.path) catch {
         @os_error.OSError(_) as error if error.is_ENOENT() => Replaced
         error => Failed(operation=ClassifyLink, reason=error.to_string())
       } noraise {
         target =>
-          if target.normalize() == entry.resolved_target {
+          if target.normalize() == entry.resolved_target.path {
             Matching
           } else {
             Replaced

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_io.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_io.mbt
@@ -1,0 +1,107 @@
+///|
+struct LinkReconciliationIO {
+  mkdir : async (@path.Path) -> Unit
+  kind : async (@path.Path) -> @fs.FileKind
+  realpath : async (@path.Path) -> @path.Path
+  symlink : async (@path.Path, @path.Path) -> Unit
+  remove : async (@path.Path) -> Unit
+  checkpoint : async (@path.Path, OwnershipState) -> Unit raise StateStoreError
+}
+
+///|
+enum StaleLinkRecheck {
+  Matching
+  Missing
+  Replaced
+  Failed(operation~ : LinkReconciliationOperation, reason~ : String)
+}
+
+///|
+fn production_link_reconciliation_io(
+  checkpoint : async (@path.Path, OwnershipState) -> Unit raise StateStoreError,
+) -> LinkReconciliationIO {
+  {
+    mkdir: async fn(path) {
+      @fs.mkdir(path.to_string(), recursive=true) catch {
+        @os_error.OSError(_) as error if error.is_EEXIST() => ()
+        error => raise error
+      }
+    },
+    kind: async fn(path) { @fs.kind(path.to_string(), follow_symlink=false) },
+    realpath: async fn(path) { @path.Path(@fs.realpath(path.to_string())) },
+    symlink: async fn(target, link) {
+      @fs.symlink(target=target.to_string(), link.to_string())
+    },
+    remove: async fn(path) { @fs.remove(path.to_string()) },
+    checkpoint,
+  }
+}
+
+///|
+async fn classify_link(
+  io : LinkReconciliationIO,
+  path : @path.Path,
+) -> @fs.FileKind? {
+  try (io.kind)(path) catch {
+    @os_error.OSError(_) as error if error.is_ENOENT() => None
+    error => raise error
+  } noraise {
+    kind => Some(kind)
+  }
+}
+
+///|
+async fn is_physically_contained(
+  io : LinkReconciliationIO,
+  entry : OwnershipEntry,
+) -> Bool {
+  let physical_root = (io.realpath)(entry.managed_root).normalize()
+  let physical_parent = (io.realpath)(entry.link.dirname()).normalize()
+  physical_parent == physical_root
+}
+
+///|
+async fn recheck_stale_link(
+  io : LinkReconciliationIO,
+  entry : OwnershipEntry,
+) -> StaleLinkRecheck {
+  let root_kind = (io.kind)(entry.managed_root) catch {
+    error =>
+      return Failed(operation=VerifyContainment, reason=error.to_string())
+  }
+  guard root_kind == @fs.FileKind::Directory else {
+    return Failed(
+      operation=VerifyContainment,
+      reason="recorded managed root must be a physical directory",
+    )
+  }
+  let contained = is_physically_contained(io, entry) catch {
+    error =>
+      return Failed(operation=VerifyContainment, reason=error.to_string())
+  }
+  guard contained else {
+    return Failed(
+      operation=VerifyContainment,
+      reason="physical containment changed",
+    )
+  }
+  let kind = classify_link(io, entry.link) catch {
+    error => return Failed(operation=ClassifyLink, reason=error.to_string())
+  }
+  match kind {
+    None => Missing
+    Some(@fs.FileKind::SymLink) =>
+      try (io.realpath)(entry.link) catch {
+        @os_error.OSError(_) as error if error.is_ENOENT() => Replaced
+        error => Failed(operation=ClassifyLink, reason=error.to_string())
+      } noraise {
+        target =>
+          if target.normalize() == entry.resolved_target {
+            Matching
+          } else {
+            Replaced
+          }
+      }
+    Some(_) => Replaced
+  }
+}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_io_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_io_wbtest.mbt
@@ -47,7 +47,7 @@ async test "LinkReconciliation reconcile_skill_links 14 - continues independent 
     }
     let result = reconcile_skill_links_with_io(
       io,
-      root.join("state.json"),
+      reconciliation_state_path(root.join("state.json")),
       OwnershipState::OwnershipState(entries),
       Trusted(OwnershipState::OwnershipState([])),
     )
@@ -124,7 +124,7 @@ async test "LinkReconciliation reconcile_skill_links 15 - retains failed stale r
     }
     let result = reconcile_skill_links_with_io(
       io,
-      root.join("state.json"),
+      reconciliation_state_path(root.join("state.json")),
       OwnershipState::OwnershipState([]),
       Trusted(OwnershipState::OwnershipState(entries)),
     )

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_io_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_io_wbtest.mbt
@@ -1,0 +1,148 @@
+///|
+async test "LinkReconciliation reconcile_skill_links 14 - continues independent desired links after typed per-link failures" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-link-failures-")
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let names = ["a-mkdir", "b-realpath", "c-kind", "d-create", "e-success"]
+    let entries = []
+    for name in names {
+      let target = root.join("targets").join(name)
+      @fs.mkdir(target.to_string(), recursive=true)
+      entries.push(
+        stale_reconciliation_entry(root.join(name), "install", target),
+      )
+    }
+    let checkpoints = []
+    let io : LinkReconciliationIO = {
+      mkdir: async fn(path) {
+        if path == entries[0].managed_root {
+          fail("mkdir failed")
+        }
+        @fs.mkdir(path.to_string(), recursive=true) catch {
+          @os_error.OSError(_) as error if error.is_EEXIST() => ()
+          error => raise error
+        }
+      },
+      kind: async fn(path) {
+        if path == entries[2].link {
+          fail("kind failed")
+        }
+        @fs.kind(path.to_string(), follow_symlink=false)
+      },
+      realpath: async fn(path) {
+        if path == entries[1].managed_root {
+          fail("realpath failed")
+        }
+        @path.Path(@fs.realpath(path.to_string()))
+      },
+      symlink: async fn(target, link) {
+        if link == entries[3].link {
+          fail("create failed")
+        }
+        @fs.symlink(target=target.to_string(), link.to_string())
+      },
+      remove: async fn(path) { @fs.remove(path.to_string()) },
+      checkpoint: fn(_path, state) { checkpoints.push(state) },
+    }
+    let result = reconcile_skill_links_with_io(
+      io,
+      root.join("state.json"),
+      OwnershipState::OwnershipState(entries),
+      Trusted(OwnershipState::OwnershipState([])),
+    )
+    debug_inspect(result.status, content="Partial")
+    inspect(result.notices.length(), content="4")
+    for
+      index, expected_operation in [
+        EnsureManagedRoot,
+        VerifyContainment,
+        ClassifyLink,
+        CreateLink,
+      ] {
+      match result.notices[index] {
+        OperationFailed(operation~, path~, reason=_) => {
+          inspect(operation == expected_operation, content="true")
+          let expected_path = if index == 0 {
+            entries[index].managed_root
+          } else {
+            entries[index].link
+          }
+          inspect(path == expected_path, content="true")
+        }
+        _ => fail("expected typed per-link operation failure")
+      }
+    }
+    inspect(checkpoints.length(), content="1")
+    inspect(result.durable_state.entries.length(), content="1")
+    inspect(
+      result.durable_state.entries.get(
+        OwnershipLinkIdentity::OwnershipLinkIdentity(entries[4].link),
+      ) ==
+      Some(entries[4]),
+      content="true",
+    )
+  }
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 15 - retains failed stale removal while checkpointing an independent removal" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(
+      prefix="c-plugin-v2-remove-partial-",
+    )
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let entries = []
+    for name in ["a-fail", "b-success"] {
+      let managed_root = root.join(name)
+      let target = root.join("targets").join(name)
+      @fs.mkdir(managed_root.to_string(), recursive=true)
+      @fs.mkdir(target.to_string(), recursive=true)
+      let entry = stale_reconciliation_entry(managed_root, "install", target)
+      @fs.symlink(
+        target=entry.symlink_target.to_string(),
+        entry.link.to_string(),
+      )
+      entries.push(entry)
+    }
+    let checkpoints = []
+    let io : LinkReconciliationIO = {
+      mkdir: async fn(path) { @fs.mkdir(path.to_string(), recursive=true) },
+      kind: async fn(path) { @fs.kind(path.to_string(), follow_symlink=false) },
+      realpath: async fn(path) { @path.Path(@fs.realpath(path.to_string())) },
+      symlink: async fn(target, link) {
+        @fs.symlink(target=target.to_string(), link.to_string())
+      },
+      remove: async fn(path) {
+        if path == entries[0].link {
+          fail("remove failed")
+        }
+        @fs.remove(path.to_string())
+      },
+      checkpoint: fn(_path, state) { checkpoints.push(state) },
+    }
+    let result = reconcile_skill_links_with_io(
+      io,
+      root.join("state.json"),
+      OwnershipState::OwnershipState([]),
+      Trusted(OwnershipState::OwnershipState(entries)),
+    )
+    debug_inspect(result.status, content="Partial")
+    inspect(result.durable_state.entries.length(), content="1")
+    inspect(checkpoints.length(), content="1")
+    match result.notices[0] {
+      OperationFailed(operation=RemoveLink, path~, reason=_) =>
+        inspect(path == entries[0].link, content="true")
+      _ => fail("expected stale remove failure")
+    }
+    debug_inspect(
+      @fs.kind(entries[0].link.to_string(), follow_symlink=false),
+      content="SymLink",
+    )
+    let removed = @fs.kind(entries[1].link.to_string(), follow_symlink=false) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    debug_inspect(removed, content="Unknown")
+  }
+}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_io_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_io_wbtest.mbt
@@ -16,7 +16,7 @@ async test "LinkReconciliation reconcile_skill_links 14 - continues independent 
     let checkpoints = []
     let io : LinkReconciliationIO = {
       mkdir: async fn(path) {
-        if path == entries[0].managed_root {
+        if path == entries[0].managed_root.path {
           fail("mkdir failed")
         }
         @fs.mkdir(path.to_string(), recursive=true) catch {
@@ -25,19 +25,19 @@ async test "LinkReconciliation reconcile_skill_links 14 - continues independent 
         }
       },
       kind: async fn(path) {
-        if path == entries[2].link {
+        if path == entries[2].link.path {
           fail("kind failed")
         }
         @fs.kind(path.to_string(), follow_symlink=false)
       },
       realpath: async fn(path) {
-        if path == entries[1].managed_root {
+        if path == entries[1].managed_root.path {
           fail("realpath failed")
         }
         @path.Path(@fs.realpath(path.to_string()))
       },
       symlink: async fn(target, link) {
-        if link == entries[3].link {
+        if link == entries[3].link.path {
           fail("create failed")
         }
         @fs.symlink(target=target.to_string(), link.to_string())
@@ -64,9 +64,9 @@ async test "LinkReconciliation reconcile_skill_links 14 - continues independent 
         OperationFailed(operation~, path~, reason=_) => {
           inspect(operation == expected_operation, content="true")
           let expected_path = if index == 0 {
-            entries[index].managed_root
+            entries[index].managed_root.path
           } else {
-            entries[index].link
+            entries[index].link.path
           }
           inspect(path == expected_path, content="true")
         }
@@ -77,7 +77,7 @@ async test "LinkReconciliation reconcile_skill_links 14 - continues independent 
     inspect(result.durable_state.entries.length(), content="1")
     inspect(
       result.durable_state.entries.get(
-        OwnershipLinkIdentity::OwnershipLinkIdentity(entries[4].link),
+        OwnershipLinkIdentity::OwnershipLinkIdentity(entries[4].link.path),
       ) ==
       Some(entries[4]),
       content="true",
@@ -102,7 +102,7 @@ async test "LinkReconciliation reconcile_skill_links 15 - retains failed stale r
       let entry = stale_reconciliation_entry(managed_root, "install", target)
       @fs.symlink(
         target=entry.symlink_target.to_string(),
-        entry.link.to_string(),
+        entry.link.path.to_string(),
       )
       entries.push(entry)
     }
@@ -115,7 +115,7 @@ async test "LinkReconciliation reconcile_skill_links 15 - retains failed stale r
         @fs.symlink(target=target.to_string(), link.to_string())
       },
       remove: async fn(path) {
-        if path == entries[0].link {
+        if path == entries[0].link.path {
           fail("remove failed")
         }
         @fs.remove(path.to_string())
@@ -133,14 +133,17 @@ async test "LinkReconciliation reconcile_skill_links 15 - retains failed stale r
     inspect(checkpoints.length(), content="1")
     match result.notices[0] {
       OperationFailed(operation=RemoveLink, path~, reason=_) =>
-        inspect(path == entries[0].link, content="true")
+        inspect(path == entries[0].link.path, content="true")
       _ => fail("expected stale remove failure")
     }
     debug_inspect(
-      @fs.kind(entries[0].link.to_string(), follow_symlink=false),
+      @fs.kind(entries[0].link.path.to_string(), follow_symlink=false),
       content="SymLink",
     )
-    let removed = @fs.kind(entries[1].link.to_string(), follow_symlink=false) catch {
+    let removed = @fs.kind(
+      entries[1].link.path.to_string(),
+      follow_symlink=false,
+    ) catch {
       _ => @fs.FileKind::Unknown
     }
     debug_inspect(removed, content="Unknown")

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_stale.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_stale.mbt
@@ -14,12 +14,12 @@ async fn reconcile_stale_entries(
   for pair in stale_entries {
     let identity = pair.0
     let recorded_entry = pair.1
-    let recorded_root_kind = classify_link(io, recorded_entry.managed_root) catch {
+    let recorded_root_kind = classify_link(io, recorded_entry.managed_root.path) catch {
       error => {
         notices.push(
           OperationFailed(
             operation=VerifyContainment,
-            path=recorded_entry.managed_root,
+            path=recorded_entry.managed_root.path,
             reason=error.to_string(),
           ),
         )
@@ -56,7 +56,7 @@ async fn reconcile_stale_entries(
         notices.push(
           OperationFailed(
             operation=VerifyContainment,
-            path=recorded_entry.managed_root,
+            path=recorded_entry.managed_root.path,
             reason="recorded managed root must be a physical directory",
           ),
         )
@@ -68,7 +68,7 @@ async fn reconcile_stale_entries(
         notices.push(
           OperationFailed(
             operation=VerifyContainment,
-            path=recorded_entry.link,
+            path=recorded_entry.link.path,
             reason=error.to_string(),
           ),
         )
@@ -79,18 +79,18 @@ async fn reconcile_stale_entries(
       notices.push(
         OperationFailed(
           operation=VerifyContainment,
-          path=recorded_entry.link,
+          path=recorded_entry.link.path,
           reason="link parent resolves outside the recorded managed root",
         ),
       )
       continue
     }
-    let kind = classify_link(io, recorded_entry.link) catch {
+    let kind = classify_link(io, recorded_entry.link.path) catch {
       error => {
         notices.push(
           OperationFailed(
             operation=ClassifyLink,
-            path=recorded_entry.link,
+            path=recorded_entry.link.path,
             reason=error.to_string(),
           ),
         )
@@ -101,9 +101,11 @@ async fn reconcile_stale_entries(
     match kind {
       None => omit_ownership = true
       Some(@fs.FileKind::SymLink) => {
-        let target = try (io.realpath)(recorded_entry.link) catch {
+        let target = try (io.realpath)(recorded_entry.link.path) catch {
           @os_error.OSError(_) as error if error.is_ENOENT() => {
-            notices.push(BrokenOwnedLinkPreserved(path=recorded_entry.link))
+            notices.push(
+              BrokenOwnedLinkPreserved(path=recorded_entry.link.path),
+            )
             omit_ownership = true
             None
           }
@@ -111,7 +113,7 @@ async fn reconcile_stale_entries(
             notices.push(
               OperationFailed(
                 operation=ClassifyLink,
-                path=recorded_entry.link,
+                path=recorded_entry.link.path,
                 reason=error.to_string(),
               ),
             )
@@ -121,16 +123,17 @@ async fn reconcile_stale_entries(
           path => Some(path.normalize())
         }
         match target {
-          Some(live_target) if live_target == recorded_entry.resolved_target =>
+          Some(live_target) if live_target ==
+            recorded_entry.resolved_target.path =>
             match recheck_stale_link(io, recorded_entry) {
               Matching => {
-                (io.remove)(recorded_entry.link) catch {
+                (io.remove)(recorded_entry.link.path) catch {
                   @os_error.OSError(_) as error if error.is_ENOENT() => ()
                   error => {
                     notices.push(
                       OperationFailed(
                         operation=RemoveLink,
-                        path=recorded_entry.link,
+                        path=recorded_entry.link.path,
                         reason=error.to_string(),
                       ),
                     )
@@ -142,24 +145,30 @@ async fn reconcile_stale_entries(
               Missing => omit_ownership = true
               Replaced => {
                 notices.push(
-                  ReplacedOwnedPathPreserved(path=recorded_entry.link),
+                  ReplacedOwnedPathPreserved(path=recorded_entry.link.path),
                 )
                 omit_ownership = true
               }
               Failed(operation~, reason~) =>
                 notices.push(
-                  OperationFailed(operation~, path=recorded_entry.link, reason~),
+                  OperationFailed(
+                    operation~,
+                    path=recorded_entry.link.path,
+                    reason~,
+                  ),
                 )
             }
           Some(_) => {
-            notices.push(ReplacedOwnedPathPreserved(path=recorded_entry.link))
+            notices.push(
+              ReplacedOwnedPathPreserved(path=recorded_entry.link.path),
+            )
             omit_ownership = true
           }
           None => ()
         }
       }
       Some(_) => {
-        notices.push(ReplacedOwnedPathPreserved(path=recorded_entry.link))
+        notices.push(ReplacedOwnedPathPreserved(path=recorded_entry.link.path))
         omit_ownership = true
       }
     }

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_stale.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_stale.mbt
@@ -1,7 +1,7 @@
 ///|
 async fn reconcile_stale_entries(
   io~ : LinkReconciliationIO,
-  state_path~ : @path.Path,
+  state_path~ : OwnershipStatePath,
   desired_state~ : OwnershipState,
   durable_state~ : OwnershipState,
   notices~ : Array[LinkReconciliationNotice],
@@ -29,7 +29,7 @@ async fn reconcile_stale_entries(
     match recorded_root_kind {
       None => {
         let checkpointed_state = state_without_entry(durable_state, identity)
-        (io.checkpoint)(state_path, checkpointed_state) catch {
+        (io.checkpoint)(state_path.path, checkpointed_state) catch {
           error => {
             notices.push(
               CheckpointFailed(
@@ -174,7 +174,7 @@ async fn reconcile_stale_entries(
     }
     if omit_ownership {
       let checkpointed_state = state_without_entry(durable_state, identity)
-      (io.checkpoint)(state_path, checkpointed_state) catch {
+      (io.checkpoint)(state_path.path, checkpointed_state) catch {
         error => {
           notices.push(
             CheckpointFailed(

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_stale.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_stale.mbt
@@ -1,0 +1,191 @@
+///|
+async fn reconcile_stale_entries(
+  io~ : LinkReconciliationIO,
+  state_path~ : @path.Path,
+  desired_state~ : OwnershipState,
+  durable_state~ : OwnershipState,
+  notices~ : Array[LinkReconciliationNotice],
+) -> (OwnershipState, LinkReconciliationResult?) {
+  let mut durable_state = durable_state
+  let stale_entries = durable_state.entries
+    .to_array()
+    .filter(pair => desired_state.entries.get(pair.0) is None)
+  stale_entries.sort_by((left, right) => left.0.compare(right.0))
+  for pair in stale_entries {
+    let identity = pair.0
+    let recorded_entry = pair.1
+    let recorded_root_kind = classify_link(io, recorded_entry.managed_root) catch {
+      error => {
+        notices.push(
+          OperationFailed(
+            operation=VerifyContainment,
+            path=recorded_entry.managed_root,
+            reason=error.to_string(),
+          ),
+        )
+        continue
+      }
+    }
+    match recorded_root_kind {
+      None => {
+        let checkpointed_state = state_without_entry(durable_state, identity)
+        (io.checkpoint)(state_path, checkpointed_state) catch {
+          error => {
+            notices.push(
+              CheckpointFailed(
+                operation=CheckpointOwnership,
+                path=state_path,
+                reason=state_store_error_reason(error),
+              ),
+            )
+            return (
+              durable_state,
+              Some({
+                status: Partial,
+                durable_state,
+                notices: ReadOnlyArray::from_array(notices),
+              }),
+            )
+          }
+        }
+        durable_state = checkpointed_state
+        continue
+      }
+      Some(@fs.FileKind::Directory) => ()
+      Some(_) => {
+        notices.push(
+          OperationFailed(
+            operation=VerifyContainment,
+            path=recorded_entry.managed_root,
+            reason="recorded managed root must be a physical directory",
+          ),
+        )
+        continue
+      }
+    }
+    let contained = is_physically_contained(io, recorded_entry) catch {
+      error => {
+        notices.push(
+          OperationFailed(
+            operation=VerifyContainment,
+            path=recorded_entry.link,
+            reason=error.to_string(),
+          ),
+        )
+        continue
+      }
+    }
+    if !contained {
+      notices.push(
+        OperationFailed(
+          operation=VerifyContainment,
+          path=recorded_entry.link,
+          reason="link parent resolves outside the recorded managed root",
+        ),
+      )
+      continue
+    }
+    let kind = classify_link(io, recorded_entry.link) catch {
+      error => {
+        notices.push(
+          OperationFailed(
+            operation=ClassifyLink,
+            path=recorded_entry.link,
+            reason=error.to_string(),
+          ),
+        )
+        continue
+      }
+    }
+    let mut omit_ownership = false
+    match kind {
+      None => omit_ownership = true
+      Some(@fs.FileKind::SymLink) => {
+        let target = try (io.realpath)(recorded_entry.link) catch {
+          @os_error.OSError(_) as error if error.is_ENOENT() => {
+            notices.push(BrokenOwnedLinkPreserved(path=recorded_entry.link))
+            omit_ownership = true
+            None
+          }
+          error => {
+            notices.push(
+              OperationFailed(
+                operation=ClassifyLink,
+                path=recorded_entry.link,
+                reason=error.to_string(),
+              ),
+            )
+            None
+          }
+        } noraise {
+          path => Some(path.normalize())
+        }
+        match target {
+          Some(live_target) if live_target == recorded_entry.resolved_target =>
+            match recheck_stale_link(io, recorded_entry) {
+              Matching => {
+                (io.remove)(recorded_entry.link) catch {
+                  @os_error.OSError(_) as error if error.is_ENOENT() => ()
+                  error => {
+                    notices.push(
+                      OperationFailed(
+                        operation=RemoveLink,
+                        path=recorded_entry.link,
+                        reason=error.to_string(),
+                      ),
+                    )
+                    continue
+                  }
+                }
+                omit_ownership = true
+              }
+              Missing => omit_ownership = true
+              Replaced => {
+                notices.push(
+                  ReplacedOwnedPathPreserved(path=recorded_entry.link),
+                )
+                omit_ownership = true
+              }
+              Failed(operation~, reason~) =>
+                notices.push(
+                  OperationFailed(operation~, path=recorded_entry.link, reason~),
+                )
+            }
+          Some(_) => {
+            notices.push(ReplacedOwnedPathPreserved(path=recorded_entry.link))
+            omit_ownership = true
+          }
+          None => ()
+        }
+      }
+      Some(_) => {
+        notices.push(ReplacedOwnedPathPreserved(path=recorded_entry.link))
+        omit_ownership = true
+      }
+    }
+    if omit_ownership {
+      let checkpointed_state = state_without_entry(durable_state, identity)
+      (io.checkpoint)(state_path, checkpointed_state) catch {
+        error => {
+          notices.push(
+            CheckpointFailed(
+              operation=CheckpointOwnership,
+              path=state_path,
+              reason=state_store_error_reason(error),
+            ),
+          )
+          return (
+            durable_state,
+            Some({
+              status: Partial,
+              durable_state,
+              notices: ReadOnlyArray::from_array(notices),
+            }),
+          )
+        }
+      }
+      durable_state = checkpointed_state
+    }
+  }
+  (durable_state, None)
+}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_stale_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_stale_wbtest.mbt
@@ -53,7 +53,9 @@ async test "LinkReconciliation reconcile_skill_links 3 - reconciles trusted stal
     @fs.write_file(neighbor.to_string(), "keep", create_mode=CreateNew)
     let previous_state = OwnershipState::OwnershipState(entries)
     let desired_state = OwnershipState::OwnershipState([])
-    let state_path = root.join("ownership-state.json")
+    let state_path = reconciliation_state_path(
+      root.join("ownership-state.json"),
+    )
     let mut checkpoint_count = 0
     let mut checkpoint_state = None
 
@@ -132,7 +134,7 @@ async test "LinkReconciliation reconcile_skill_links 8 - isolates stale deletion
     )
     let desired_state = OwnershipState::OwnershipState([])
     let result_a = reconcile_skill_links(
-      state_path=root.join("state-a.json"),
+      state_path=reconciliation_state_path(root.join("state-a.json")),
       desired_state~,
       previous_ownership=Trusted(OwnershipState::OwnershipState([entry_a])),
       checkpoint_ownership_state=fn(_path, _state) { () },
@@ -150,7 +152,7 @@ async test "LinkReconciliation reconcile_skill_links 8 - isolates stale deletion
       content="SymLink",
     )
     let result_b = reconcile_skill_links(
-      state_path=root.join("state-b.json"),
+      state_path=reconciliation_state_path(root.join("state-b.json")),
       desired_state~,
       previous_ownership=Trusted(OwnershipState::OwnershipState([entry_b])),
       checkpoint_ownership_state=fn(_path, _state) { () },
@@ -183,7 +185,7 @@ async test "LinkReconciliation reconcile_skill_links 11 - retries stale omission
     )
     let previous = OwnershipState::OwnershipState([entry])
     let desired_state = OwnershipState::OwnershipState([])
-    let state_path = root.join("state.json")
+    let state_path = reconciliation_state_path(root.join("state.json"))
     let fail_checkpoint : async (@path.Path, OwnershipState) -> Unit raise StateStoreError = (
       path,
       _state,
@@ -238,7 +240,7 @@ async test "LinkReconciliation reconcile_skill_links 13 - rejects a replaced sta
     let previous = OwnershipState::OwnershipState([entry])
     let mut checkpointed = false
     let result = reconcile_skill_links(
-      state_path=root.join("state.json"),
+      state_path=reconciliation_state_path(root.join("state.json")),
       desired_state=OwnershipState::OwnershipState([]),
       previous_ownership=Trusted(previous),
       checkpoint_ownership_state=fn(_path, _state) { checkpointed = true },
@@ -307,7 +309,7 @@ async test "LinkReconciliation reconcile_skill_links 16 - preserves a foreign re
     }
     let result = reconcile_skill_links_with_io(
       io,
-      root.join("state.json"),
+      reconciliation_state_path(root.join("state.json")),
       OwnershipState::OwnershipState([]),
       Trusted(OwnershipState::OwnershipState([entry])),
     )

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_stale_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_stale_wbtest.mbt
@@ -24,31 +24,32 @@ async test "LinkReconciliation reconcile_skill_links 3 - reconciles trusted stal
         "matching" =>
           @fs.symlink(
             target=entry.symlink_target.to_string(),
-            entry.link.to_string(),
+            entry.link.path.to_string(),
           )
         "removed-root" =>
-          @fs.rmdir(entry.managed_root.to_string(), recursive=true)
+          @fs.rmdir(entry.managed_root.path.to_string(), recursive=true)
         "missing" => ()
         "file" =>
           @fs.write_file(
-            entry.link.to_string(),
+            entry.link.path.to_string(),
             "foreign",
             create_mode=CreateNew,
           )
-        "directory" => @fs.mkdir(entry.link.to_string())
+        "directory" => @fs.mkdir(entry.link.path.to_string())
         "different" => {
           let other = target_root.join("different-other")
           @fs.mkdir(other.to_string())
           @fs.symlink(
-            target=other.relative(base=entry.managed_root).to_string(),
-            entry.link.to_string(),
+            target=other.relative(base=entry.managed_root.path).to_string(),
+            entry.link.path.to_string(),
           )
         }
-        "broken" => @fs.symlink(target="missing-target", entry.link.to_string())
+        "broken" =>
+          @fs.symlink(target="missing-target", entry.link.path.to_string())
         _ => fail("unexpected fixture")
       }
     }
-    let neighbor = entries[0].managed_root.join("foreign-neighbor")
+    let neighbor = entries[0].managed_root.path.join("foreign-neighbor")
     @fs.write_file(neighbor.to_string(), "keep", create_mode=CreateNew)
     let previous_state = OwnershipState::OwnershipState(entries)
     let desired_state = OwnershipState::OwnershipState([])
@@ -73,29 +74,32 @@ async test "LinkReconciliation reconcile_skill_links 3 - reconciles trusted stal
     inspect(result.notices.length(), content="4")
     inspect(@fs.read_file(neighbor.to_string()).text(), content="keep")
     inspect(
-      @fs.read_file(entries[2].link.to_string()).text(),
+      @fs.read_file(entries[2].link.path.to_string()).text(),
       content="foreign",
     )
     debug_inspect(
-      @fs.kind(entries[3].link.to_string(), follow_symlink=false),
+      @fs.kind(entries[3].link.path.to_string(), follow_symlink=false),
       content="Directory",
     )
     debug_inspect(
-      @fs.kind(entries[4].link.to_string(), follow_symlink=false),
+      @fs.kind(entries[4].link.path.to_string(), follow_symlink=false),
       content="SymLink",
     )
     debug_inspect(
-      @fs.kind(entries[5].link.to_string(), follow_symlink=false),
+      @fs.kind(entries[5].link.path.to_string(), follow_symlink=false),
       content="SymLink",
     )
     for index in [0, 1, 6] {
-      let kind = @fs.kind(entries[index].link.to_string(), follow_symlink=false) catch {
+      let kind = @fs.kind(
+        entries[index].link.path.to_string(),
+        follow_symlink=false,
+      ) catch {
         _ => @fs.FileKind::Unknown
       }
       debug_inspect(kind, content="Unknown")
     }
     let removed_root_kind = @fs.kind(
-      entries[6].managed_root.to_string(),
+      entries[6].managed_root.path.to_string(),
       follow_symlink=false,
     ) catch {
       _ => @fs.FileKind::Unknown
@@ -120,11 +124,11 @@ async test "LinkReconciliation reconcile_skill_links 8 - isolates stale deletion
     let entry_b = stale_reconciliation_entry(managed_root, "b", target_b)
     @fs.symlink(
       target=entry_a.symlink_target.to_string(),
-      entry_a.link.to_string(),
+      entry_a.link.path.to_string(),
     )
     @fs.symlink(
       target=entry_b.symlink_target.to_string(),
-      entry_b.link.to_string(),
+      entry_b.link.path.to_string(),
     )
     let desired_state = OwnershipState::OwnershipState([])
     let result_a = reconcile_skill_links(
@@ -134,12 +138,15 @@ async test "LinkReconciliation reconcile_skill_links 8 - isolates stale deletion
       checkpoint_ownership_state=fn(_path, _state) { () },
     )
     debug_inspect(result_a.status, content="Complete")
-    let removed_a = @fs.kind(entry_a.link.to_string(), follow_symlink=false) catch {
+    let removed_a = @fs.kind(
+      entry_a.link.path.to_string(),
+      follow_symlink=false,
+    ) catch {
       _ => @fs.FileKind::Unknown
     }
     debug_inspect(removed_a, content="Unknown")
     debug_inspect(
-      @fs.kind(entry_b.link.to_string(), follow_symlink=false),
+      @fs.kind(entry_b.link.path.to_string(), follow_symlink=false),
       content="SymLink",
     )
     let result_b = reconcile_skill_links(
@@ -149,7 +156,10 @@ async test "LinkReconciliation reconcile_skill_links 8 - isolates stale deletion
       checkpoint_ownership_state=fn(_path, _state) { () },
     )
     debug_inspect(result_b.status, content="Complete")
-    let removed_b = @fs.kind(entry_b.link.to_string(), follow_symlink=false) catch {
+    let removed_b = @fs.kind(
+      entry_b.link.path.to_string(),
+      follow_symlink=false,
+    ) catch {
       _ => @fs.FileKind::Unknown
     }
     debug_inspect(removed_b, content="Unknown")
@@ -167,7 +177,10 @@ async test "LinkReconciliation reconcile_skill_links 11 - retries stale omission
     @fs.mkdir(managed_root.to_string(), recursive=true)
     @fs.mkdir(target.to_string(), recursive=true)
     let entry = stale_reconciliation_entry(managed_root, "stale", target)
-    @fs.symlink(target=entry.symlink_target.to_string(), entry.link.to_string())
+    @fs.symlink(
+      target=entry.symlink_target.to_string(),
+      entry.link.path.to_string(),
+    )
     let previous = OwnershipState::OwnershipState([entry])
     let desired_state = OwnershipState::OwnershipState([])
     let state_path = root.join("state.json")
@@ -190,7 +203,7 @@ async test "LinkReconciliation reconcile_skill_links 11 - retries stale omission
       }
       _ => fail("expected stale checkpoint failure")
     }
-    let removed = @fs.kind(entry.link.to_string(), follow_symlink=false) catch {
+    let removed = @fs.kind(entry.link.path.to_string(), follow_symlink=false) catch {
       _ => @fs.FileKind::Unknown
     }
     debug_inspect(removed, content="Unknown")
@@ -260,14 +273,17 @@ async test "LinkReconciliation reconcile_skill_links 16 - preserves a foreign re
     let entry = stale_reconciliation_entry(
       managed_root, "install", recorded_target,
     )
-    @fs.symlink(target=entry.symlink_target.to_string(), entry.link.to_string())
+    @fs.symlink(
+      target=entry.symlink_target.to_string(),
+      entry.link.path.to_string(),
+    )
     let mut link_kind_calls = 0
     let mut remove_called = false
     let checkpoints = []
     let io : LinkReconciliationIO = {
       mkdir: async fn(path) { @fs.mkdir(path.to_string(), recursive=true) },
       kind: async fn(path) {
-        if path == entry.link {
+        if path == entry.link.path {
           link_kind_calls = link_kind_calls + 1
           if link_kind_calls == 2 {
             @fs.remove(path.to_string())
@@ -302,11 +318,11 @@ async test "LinkReconciliation reconcile_skill_links 16 - preserves a foreign re
     inspect(result.durable_state.entries.length(), content="0")
     match result.notices[0] {
       ReplacedOwnedPathPreserved(path~) =>
-        inspect(path == entry.link, content="true")
+        inspect(path == entry.link.path, content="true")
       _ => fail("expected final-recheck replacement notice")
     }
     inspect(
-      @fs.realpath(entry.link.to_string()),
+      @fs.realpath(entry.link.path.to_string()),
       content=@fs.realpath(foreign_target.to_string()),
     )
   }

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_stale_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_stale_wbtest.mbt
@@ -1,0 +1,313 @@
+///|
+async test "LinkReconciliation reconcile_skill_links 3 - reconciles trusted stale ownership safely" {
+  @async.with_task_group() <| group => {
+    let temporary_root : @path.Path = @fs.tmpdir(
+      prefix="c-plugin-v2-reconcile-stale-",
+    )
+    group.add_defer(() => @fs.rmdir(temporary_root.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary_root.to_string())
+    let target_root = root.join("targets")
+    @fs.mkdir(target_root.to_string(), recursive=true)
+    let names = [
+      "matching", "missing", "file", "directory", "different", "broken", "removed-root",
+    ]
+    let entries = []
+    for name in names {
+      let managed_root = root.join("managed").join(name)
+      let target = target_root.join(name)
+      @fs.mkdir(managed_root.to_string(), recursive=true)
+      @fs.mkdir(target.to_string(), recursive=true)
+      entries.push(stale_reconciliation_entry(managed_root, "install", target))
+    }
+    for index, entry in entries {
+      match names[index] {
+        "matching" =>
+          @fs.symlink(
+            target=entry.symlink_target.to_string(),
+            entry.link.to_string(),
+          )
+        "removed-root" =>
+          @fs.rmdir(entry.managed_root.to_string(), recursive=true)
+        "missing" => ()
+        "file" =>
+          @fs.write_file(
+            entry.link.to_string(),
+            "foreign",
+            create_mode=CreateNew,
+          )
+        "directory" => @fs.mkdir(entry.link.to_string())
+        "different" => {
+          let other = target_root.join("different-other")
+          @fs.mkdir(other.to_string())
+          @fs.symlink(
+            target=other.relative(base=entry.managed_root).to_string(),
+            entry.link.to_string(),
+          )
+        }
+        "broken" => @fs.symlink(target="missing-target", entry.link.to_string())
+        _ => fail("unexpected fixture")
+      }
+    }
+    let neighbor = entries[0].managed_root.join("foreign-neighbor")
+    @fs.write_file(neighbor.to_string(), "keep", create_mode=CreateNew)
+    let previous_state = OwnershipState::OwnershipState(entries)
+    let desired_state = OwnershipState::OwnershipState([])
+    let state_path = root.join("ownership-state.json")
+    let mut checkpoint_count = 0
+    let mut checkpoint_state = None
+
+    let result = reconcile_skill_links(
+      state_path~,
+      desired_state~,
+      previous_ownership=PreviousOwnership::Trusted(previous_state),
+      checkpoint_ownership_state=fn(_path, state) {
+        checkpoint_count = checkpoint_count + 1
+        checkpoint_state = Some(state)
+      },
+    )
+
+    debug_inspect(result.status, content="Partial")
+    inspect(result.durable_state.entries.length(), content="0")
+    inspect(checkpoint_count, content="7")
+    inspect(checkpoint_state == Some(result.durable_state), content="true")
+    inspect(result.notices.length(), content="4")
+    inspect(@fs.read_file(neighbor.to_string()).text(), content="keep")
+    inspect(
+      @fs.read_file(entries[2].link.to_string()).text(),
+      content="foreign",
+    )
+    debug_inspect(
+      @fs.kind(entries[3].link.to_string(), follow_symlink=false),
+      content="Directory",
+    )
+    debug_inspect(
+      @fs.kind(entries[4].link.to_string(), follow_symlink=false),
+      content="SymLink",
+    )
+    debug_inspect(
+      @fs.kind(entries[5].link.to_string(), follow_symlink=false),
+      content="SymLink",
+    )
+    for index in [0, 1, 6] {
+      let kind = @fs.kind(entries[index].link.to_string(), follow_symlink=false) catch {
+        _ => @fs.FileKind::Unknown
+      }
+      debug_inspect(kind, content="Unknown")
+    }
+    let removed_root_kind = @fs.kind(
+      entries[6].managed_root.to_string(),
+      follow_symlink=false,
+    ) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    debug_inspect(removed_root_kind, content="Unknown")
+  }
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 8 - isolates stale deletion authority by ownership state" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-cross-lock-")
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let managed_root = root.join("shared-skills")
+    let target_a = root.join("target-a")
+    let target_b = root.join("target-b")
+    @fs.mkdir(managed_root.to_string(), recursive=true)
+    @fs.mkdir(target_a.to_string(), recursive=true)
+    @fs.mkdir(target_b.to_string(), recursive=true)
+    let entry_a = stale_reconciliation_entry(managed_root, "a", target_a)
+    let entry_b = stale_reconciliation_entry(managed_root, "b", target_b)
+    @fs.symlink(
+      target=entry_a.symlink_target.to_string(),
+      entry_a.link.to_string(),
+    )
+    @fs.symlink(
+      target=entry_b.symlink_target.to_string(),
+      entry_b.link.to_string(),
+    )
+    let desired_state = OwnershipState::OwnershipState([])
+    let result_a = reconcile_skill_links(
+      state_path=root.join("state-a.json"),
+      desired_state~,
+      previous_ownership=Trusted(OwnershipState::OwnershipState([entry_a])),
+      checkpoint_ownership_state=fn(_path, _state) { () },
+    )
+    debug_inspect(result_a.status, content="Complete")
+    let removed_a = @fs.kind(entry_a.link.to_string(), follow_symlink=false) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    debug_inspect(removed_a, content="Unknown")
+    debug_inspect(
+      @fs.kind(entry_b.link.to_string(), follow_symlink=false),
+      content="SymLink",
+    )
+    let result_b = reconcile_skill_links(
+      state_path=root.join("state-b.json"),
+      desired_state~,
+      previous_ownership=Trusted(OwnershipState::OwnershipState([entry_b])),
+      checkpoint_ownership_state=fn(_path, _state) { () },
+    )
+    debug_inspect(result_b.status, content="Complete")
+    let removed_b = @fs.kind(entry_b.link.to_string(), follow_symlink=false) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    debug_inspect(removed_b, content="Unknown")
+  }
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 11 - retries stale omission after checkpoint failure" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-remove-fail-")
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let managed_root = root.join("skills")
+    let target = root.join("target")
+    @fs.mkdir(managed_root.to_string(), recursive=true)
+    @fs.mkdir(target.to_string(), recursive=true)
+    let entry = stale_reconciliation_entry(managed_root, "stale", target)
+    @fs.symlink(target=entry.symlink_target.to_string(), entry.link.to_string())
+    let previous = OwnershipState::OwnershipState([entry])
+    let desired_state = OwnershipState::OwnershipState([])
+    let state_path = root.join("state.json")
+    let fail_checkpoint : async (@path.Path, OwnershipState) -> Unit raise StateStoreError = (
+      path,
+      _state,
+    ) => raise StateStoreError::IO(path~, reason="remove checkpoint failed")
+    let failed = reconcile_skill_links(
+      state_path~,
+      desired_state~,
+      previous_ownership=Trusted(previous),
+      checkpoint_ownership_state=fail_checkpoint,
+    )
+    debug_inspect(failed.status, content="Partial")
+    inspect(failed.durable_state == previous, content="true")
+    match failed.notices[0] {
+      CheckpointFailed(operation=CheckpointOwnership, path~, reason~) => {
+        inspect(path == state_path, content="true")
+        inspect(reason, content="remove checkpoint failed")
+      }
+      _ => fail("expected stale checkpoint failure")
+    }
+    let removed = @fs.kind(entry.link.to_string(), follow_symlink=false) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    debug_inspect(removed, content="Unknown")
+    let retried = reconcile_skill_links(
+      state_path~,
+      desired_state~,
+      previous_ownership=Trusted(failed.durable_state),
+      checkpoint_ownership_state=fn(_path, _state) { () },
+    )
+    debug_inspect(retried.status, content="Complete")
+    inspect(retried.durable_state.entries.length(), content="0")
+  }
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 13 - rejects a replaced stale managed root" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-stale-root-")
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let recorded_root = root.join("recorded-skills")
+    let outside_root = root.join("outside-skills")
+    let target = root.join("target")
+    @fs.mkdir(outside_root.to_string(), recursive=true)
+    @fs.mkdir(target.to_string(), recursive=true)
+    let entry = stale_reconciliation_entry(recorded_root, "install", target)
+    @fs.symlink(
+      target=target.relative(base=outside_root).to_string(),
+      outside_root.join("install").to_string(),
+    )
+    @fs.symlink(target=outside_root.to_string(), recorded_root.to_string())
+    let previous = OwnershipState::OwnershipState([entry])
+    let mut checkpointed = false
+    let result = reconcile_skill_links(
+      state_path=root.join("state.json"),
+      desired_state=OwnershipState::OwnershipState([]),
+      previous_ownership=Trusted(previous),
+      checkpoint_ownership_state=fn(_path, _state) { checkpointed = true },
+    )
+    debug_inspect(result.status, content="Partial")
+    inspect(result.durable_state == previous, content="true")
+    inspect(checkpointed, content="false")
+    match result.notices[0] {
+      OperationFailed(operation=VerifyContainment, path~, reason=_) =>
+        inspect(path == recorded_root, content="true")
+      _ => fail("expected stale-root containment failure")
+    }
+    debug_inspect(
+      @fs.kind(outside_root.join("install").to_string(), follow_symlink=false),
+      content="SymLink",
+    )
+  }
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 16 - preserves a foreign replacement during stale final recheck" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-recheck-race-")
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let managed_root = root.join("skills")
+    let recorded_target = root.join("recorded-target")
+    let foreign_target = root.join("foreign-target")
+    @fs.mkdir(managed_root.to_string(), recursive=true)
+    @fs.mkdir(recorded_target.to_string(), recursive=true)
+    @fs.mkdir(foreign_target.to_string(), recursive=true)
+    let entry = stale_reconciliation_entry(
+      managed_root, "install", recorded_target,
+    )
+    @fs.symlink(target=entry.symlink_target.to_string(), entry.link.to_string())
+    let mut link_kind_calls = 0
+    let mut remove_called = false
+    let checkpoints = []
+    let io : LinkReconciliationIO = {
+      mkdir: async fn(path) { @fs.mkdir(path.to_string(), recursive=true) },
+      kind: async fn(path) {
+        if path == entry.link {
+          link_kind_calls = link_kind_calls + 1
+          if link_kind_calls == 2 {
+            @fs.remove(path.to_string())
+            @fs.symlink(
+              target=foreign_target.relative(base=managed_root).to_string(),
+              path.to_string(),
+            )
+          }
+        }
+        @fs.kind(path.to_string(), follow_symlink=false)
+      },
+      realpath: async fn(path) { @path.Path(@fs.realpath(path.to_string())) },
+      symlink: async fn(target, link) {
+        @fs.symlink(target=target.to_string(), link.to_string())
+      },
+      remove: async fn(path) {
+        remove_called = true
+        @fs.remove(path.to_string())
+      },
+      checkpoint: fn(_path, state) { checkpoints.push(state) },
+    }
+    let result = reconcile_skill_links_with_io(
+      io,
+      root.join("state.json"),
+      OwnershipState::OwnershipState([]),
+      Trusted(OwnershipState::OwnershipState([entry])),
+    )
+    debug_inspect(result.status, content="Partial")
+    inspect(remove_called, content="false")
+    inspect(checkpoints.length(), content="1")
+    inspect(checkpoints[0].entries.length(), content="0")
+    inspect(result.durable_state.entries.length(), content="0")
+    match result.notices[0] {
+      ReplacedOwnedPathPreserved(path~) =>
+        inspect(path == entry.link, content="true")
+      _ => fail("expected final-recheck replacement notice")
+    }
+    inspect(
+      @fs.realpath(entry.link.to_string()),
+      content=@fs.realpath(foreign_target.to_string()),
+    )
+  }
+}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_state.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_state.mbt
@@ -1,0 +1,61 @@
+///|
+enum OwnershipCheckpointResult {
+  Written(OwnershipState)
+  HardStop(LinkReconciliationResult)
+}
+
+///|
+fn state_with_entry(
+  state : OwnershipState,
+  entry : OwnershipEntry,
+) -> OwnershipState {
+  let entries = state.entries
+    .add(OwnershipLinkIdentity::OwnershipLinkIdentity(entry.link), entry)
+    .to_array()
+    .map(pair => pair.1)
+  try! OwnershipState::OwnershipState(entries)
+}
+
+///|
+fn state_without_entry(
+  state : OwnershipState,
+  identity : OwnershipLinkIdentity,
+) -> OwnershipState {
+  let entries = state.entries.remove(identity).to_array().map(pair => pair.1)
+  try! OwnershipState::OwnershipState(entries)
+}
+
+///|
+fn state_store_error_reason(error : StateStoreError) -> String {
+  match error {
+    AlreadyExists(path~) => "already exists: \{path.to_string()}"
+    Decode(reason~, path=_) | IO(reason~, path=_) => reason
+  }
+}
+
+///|
+async fn checkpoint_ownership(
+  io : LinkReconciliationIO,
+  state_path : @path.Path,
+  durable_state : OwnershipState,
+  checkpointed_state : OwnershipState,
+  notices : Array[LinkReconciliationNotice],
+) -> OwnershipCheckpointResult {
+  (io.checkpoint)(state_path, checkpointed_state) catch {
+    error => {
+      notices.push(
+        CheckpointFailed(
+          operation=CheckpointOwnership,
+          path=state_path,
+          reason=state_store_error_reason(error),
+        ),
+      )
+      return HardStop({
+        status: Partial,
+        durable_state,
+        notices: ReadOnlyArray::from_array(notices),
+      })
+    }
+  }
+  Written(checkpointed_state)
+}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_state.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_state.mbt
@@ -37,12 +37,12 @@ fn state_store_error_reason(error : StateStoreError) -> String {
 ///|
 async fn checkpoint_ownership(
   io : LinkReconciliationIO,
-  state_path : @path.Path,
+  state_path : OwnershipStatePath,
   durable_state : OwnershipState,
   checkpointed_state : OwnershipState,
   notices : Array[LinkReconciliationNotice],
 ) -> OwnershipCheckpointResult {
-  (io.checkpoint)(state_path, checkpointed_state) catch {
+  (io.checkpoint)(state_path.path, checkpointed_state) catch {
     error => {
       notices.push(
         CheckpointFailed(

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_state.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_state.mbt
@@ -9,11 +9,13 @@ fn state_with_entry(
   state : OwnershipState,
   entry : OwnershipEntry,
 ) -> OwnershipState {
-  let entries = state.entries
-    .add(OwnershipLinkIdentity::OwnershipLinkIdentity(entry.link), entry)
-    .to_array()
-    .map(pair => pair.1)
-  try! OwnershipState::OwnershipState(entries)
+  {
+    version: state.version,
+    entries: state.entries.add(
+      OwnershipLinkIdentity::OwnershipLinkIdentity(entry.link.path),
+      entry,
+    ),
+  }
 }
 
 ///|
@@ -21,8 +23,7 @@ fn state_without_entry(
   state : OwnershipState,
   identity : OwnershipLinkIdentity,
 ) -> OwnershipState {
-  let entries = state.entries.remove(identity).to_array().map(pair => pair.1)
-  try! OwnershipState::OwnershipState(entries)
+  { version: state.version, entries: state.entries.remove(identity) }
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_wbtest.mbt
@@ -1,4 +1,9 @@
 ///|
+fn reconciliation_state_path(path : @path.Path) -> OwnershipStatePath raise {
+  OwnershipStatePath::OwnershipStatePath(path)
+}
+
+///|
 async test "LinkReconciliation reconcile_skill_links 1 - creates a missing desired link and checkpoints ownership" {
   @async.with_task_group() <| group => {
     let temporary_root : @path.Path = @fs.tmpdir(
@@ -9,7 +14,9 @@ async test "LinkReconciliation reconcile_skill_links 1 - creates a missing desir
     let managed_root = root.join(".agents").join("skills")
     let link = managed_root.join("install")
     let target = root.join("cache").join("skills").join("install")
-    let state_path = root.join(".agents").join("c-plugin-state.json")
+    let state_path = reconciliation_state_path(
+      root.join(".agents").join("c-plugin-state.json"),
+    )
     @fs.mkdir(target.to_string(), recursive=true)
     let entry = OwnershipEntry::OwnershipEntry(
       OwnershipLink::OwnershipLink(link),
@@ -49,7 +56,7 @@ async test "LinkReconciliation reconcile_skill_links 1 - creates a missing desir
       @fs.realpath(link.to_string()),
       content=@fs.realpath(target.to_string()),
     )
-    inspect(checkpoint_path == Some(state_path), content="true")
+    inspect(checkpoint_path == Some(state_path.path), content="true")
     inspect(checkpoint_state == Some(desired_state), content="true")
     debug_inspect(result.status, content="Complete")
     inspect(result.durable_state == desired_state, content="true")
@@ -146,9 +153,10 @@ async test "LinkReconciliation reconcile_skill_links 7 - distinguishes unavailab
         collision.link.path.to_string(),
       )
       let desired_state = OwnershipState::OwnershipState([collision, absent])
+      let state_path = reconciliation_state_path(root.join("state.json"))
       let checkpoints = []
       let result = reconcile_skill_links(
-        state_path=root.join("state.json"),
+        state_path~,
         desired_state~,
         previous_ownership=mode,
         checkpoint_ownership_state=fn(_path, state) { checkpoints.push(state) },
@@ -165,8 +173,10 @@ async test "LinkReconciliation reconcile_skill_links 7 - distinguishes unavailab
       )
       inspect(result.notices.length(), content="2")
       match (mode, result.notices[0]) {
-        (PreviousOwnership::Missing, PreviousOwnershipMissing(_)) => ()
-        (Corrupt(_), PreviousOwnershipCorrupt(_)) => ()
+        (PreviousOwnership::Missing, PreviousOwnershipMissing(path~)) =>
+          inspect(path == state_path, content="true")
+        (Corrupt(_), PreviousOwnershipCorrupt(path~, reason=_)) =>
+          inspect(path == state_path, content="true")
         _ => fail("expected distinct unavailable ownership notice")
       }
       inspect(
@@ -196,7 +206,7 @@ async test "LinkReconciliation reconcile_skill_links 9 - rejects a symlink manag
     let entry = desired_owned_entry(managed_root, target, "vendor/repo")
     let mut checkpointed = false
     let result = reconcile_skill_links(
-      state_path=root.join("state.json"),
+      state_path=reconciliation_state_path(root.join("state.json")),
       desired_state=OwnershipState::OwnershipState([entry]),
       previous_ownership=Trusted(OwnershipState::OwnershipState([])),
       checkpoint_ownership_state=fn(_path, _state) { checkpointed = true },

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_wbtest.mbt
@@ -1,0 +1,220 @@
+///|
+async test "LinkReconciliation reconcile_skill_links 1 - creates a missing desired link and checkpoints ownership" {
+  @async.with_task_group() <| group => {
+    let temporary_root : @path.Path = @fs.tmpdir(
+      prefix="c-plugin-v2-reconcile-red-",
+    )
+    group.add_defer(() => @fs.rmdir(temporary_root.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary_root.to_string())
+    let managed_root = root.join(".agents").join("skills")
+    let link = managed_root.join("install")
+    let target = root.join("cache").join("skills").join("install")
+    let state_path = root.join(".agents").join("c-plugin-state.json")
+    @fs.mkdir(target.to_string(), recursive=true)
+    let entry = OwnershipEntry::OwnershipEntry(
+      link,
+      target.relative(base=managed_root),
+      target,
+      managed_root,
+      OwnershipSource::from_local(
+        LocalOwnershipSource::LocalOwnershipSource(
+          RelativeSourcePath::RelativeSourcePath(
+            @path.Path("vendor/repository"),
+          ),
+          PluginName::PluginName("plugin"),
+          SkillName::SkillName("install"),
+        ),
+      ),
+    )
+    let desired_state = OwnershipState::OwnershipState([entry])
+    let previous_state = OwnershipState::OwnershipState([])
+    let mut checkpoint_path = None
+    let mut checkpoint_state = None
+
+    let result = reconcile_skill_links(
+      state_path~,
+      desired_state~,
+      previous_ownership=PreviousOwnership::Trusted(previous_state),
+      checkpoint_ownership_state=fn(path, state) {
+        checkpoint_path = Some(path)
+        checkpoint_state = Some(state)
+      },
+    )
+
+    let link_kind = @fs.kind(link.to_string(), follow_symlink=false) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    debug_inspect(link_kind, content="SymLink")
+    inspect(
+      @fs.realpath(link.to_string()),
+      content=@fs.realpath(target.to_string()),
+    )
+    inspect(checkpoint_path == Some(state_path), content="true")
+    inspect(checkpoint_state == Some(desired_state), content="true")
+    debug_inspect(result.status, content="Complete")
+    inspect(result.durable_state == desired_state, content="true")
+
+    let mut second_checkpointed = false
+    let second = reconcile_skill_links(
+      state_path~,
+      desired_state~,
+      previous_ownership=PreviousOwnership::Trusted(result.durable_state),
+      checkpoint_ownership_state=fn(_path, _state) {
+        second_checkpointed = true
+      },
+    )
+    inspect(second_checkpointed, content="false")
+    debug_inspect(second.status, content="Complete")
+    inspect(second.durable_state == result.durable_state, content="true")
+  }
+}
+
+///|
+enum UnmanagedCollisionFixture {
+  File
+  Directory
+  SameTargetSymlink
+  DifferentTargetSymlink
+  BrokenSymlink
+}
+
+///|
+fn stale_reconciliation_entry(
+  managed_root : @path.Path,
+  name : String,
+  target : @path.Path,
+) -> OwnershipEntry raise {
+  OwnershipEntry::OwnershipEntry(
+    managed_root.join(name),
+    target.relative(base=managed_root),
+    target,
+    managed_root,
+    OwnershipSource::from_local(
+      LocalOwnershipSource::LocalOwnershipSource(
+        RelativeSourcePath::RelativeSourcePath(@path.Path("vendor/repository")),
+        PluginName::PluginName("plugin"),
+        SkillName::SkillName(name),
+      ),
+    ),
+  )
+}
+
+///|
+fn desired_owned_entry(
+  managed_root : @path.Path,
+  target : @path.Path,
+  repository : String,
+) -> OwnershipEntry raise {
+  OwnershipEntry::OwnershipEntry(
+    managed_root.join("install"),
+    target.relative(base=managed_root),
+    target,
+    managed_root,
+    OwnershipSource::from_local(
+      LocalOwnershipSource::LocalOwnershipSource(
+        RelativeSourcePath::RelativeSourcePath(@path.Path(repository)),
+        PluginName::PluginName("plugin"),
+        SkillName::SkillName("install"),
+      ),
+    ),
+  )
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 7 - distinguishes unavailable ownership while creating only an absent link" {
+  @async.with_task_group() <| group => {
+    for mode in [PreviousOwnership::Missing, Corrupt(reason="invalid json")] {
+      let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-unavailable-")
+      group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+      let root : @path.Path = @fs.realpath(temporary.to_string())
+      let managed_root = root.join("skills")
+      let desired_target = root.join("desired-target")
+      let absent_target = root.join("absent-target")
+      let foreign_target = root.join("foreign-target")
+      @fs.mkdir(managed_root.to_string(), recursive=true)
+      @fs.mkdir(desired_target.to_string(), recursive=true)
+      @fs.mkdir(absent_target.to_string(), recursive=true)
+      @fs.mkdir(foreign_target.to_string(), recursive=true)
+      let collision = stale_reconciliation_entry(
+        managed_root, "collision", desired_target,
+      )
+      let absent = stale_reconciliation_entry(
+        managed_root, "absent", absent_target,
+      )
+      @fs.symlink(
+        target=foreign_target.relative(base=managed_root).to_string(),
+        collision.link.to_string(),
+      )
+      let desired_state = OwnershipState::OwnershipState([collision, absent])
+      let checkpoints = []
+      let result = reconcile_skill_links(
+        state_path=root.join("state.json"),
+        desired_state~,
+        previous_ownership=mode,
+        checkpoint_ownership_state=fn(_path, state) { checkpoints.push(state) },
+      )
+      debug_inspect(result.status, content="Partial")
+      inspect(checkpoints.length(), content="1")
+      inspect(result.durable_state.entries.length(), content="1")
+      inspect(
+        result.durable_state.entries.get(
+          OwnershipLinkIdentity::OwnershipLinkIdentity(absent.link),
+        ) ==
+        Some(absent),
+        content="true",
+      )
+      inspect(result.notices.length(), content="2")
+      match (mode, result.notices[0]) {
+        (PreviousOwnership::Missing, PreviousOwnershipMissing(_)) => ()
+        (Corrupt(_), PreviousOwnershipCorrupt(_)) => ()
+        _ => fail("expected distinct unavailable ownership notice")
+      }
+      inspect(
+        @fs.realpath(collision.link.to_string()),
+        content=@fs.realpath(foreign_target.to_string()),
+      )
+      inspect(
+        @fs.realpath(absent.link.to_string()),
+        content=@fs.realpath(absent_target.to_string()),
+      )
+    }
+  }
+}
+
+///|
+async test "LinkReconciliation reconcile_skill_links 9 - rejects a symlink managed root without child mutation" {
+  @async.with_task_group() <| group => {
+    let temporary : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-root-link-")
+    group.add_defer(() => @fs.rmdir(temporary.to_string(), recursive=true))
+    let root : @path.Path = @fs.realpath(temporary.to_string())
+    let physical_root = root.join("physical-skills")
+    let managed_root = root.join("managed-skills")
+    let target = root.join("target")
+    @fs.mkdir(physical_root.to_string(), recursive=true)
+    @fs.mkdir(target.to_string(), recursive=true)
+    @fs.symlink(target=physical_root.to_string(), managed_root.to_string())
+    let entry = desired_owned_entry(managed_root, target, "vendor/repo")
+    let mut checkpointed = false
+    let result = reconcile_skill_links(
+      state_path=root.join("state.json"),
+      desired_state=OwnershipState::OwnershipState([entry]),
+      previous_ownership=Trusted(OwnershipState::OwnershipState([])),
+      checkpoint_ownership_state=fn(_path, _state) { checkpointed = true },
+    )
+    debug_inspect(result.status, content="Partial")
+    inspect(checkpointed, content="false")
+    inspect(result.notices.length(), content="1")
+    match result.notices[0] {
+      OperationFailed(operation=VerifyContainment, path~, reason=_) =>
+        inspect(path == managed_root, content="true")
+      _ => fail("expected managed-root containment notice")
+    }
+    let child_kind = @fs.kind(
+      physical_root.join("install").to_string(),
+      follow_symlink=false,
+    ) catch {
+      _ => @fs.FileKind::Unknown
+    }
+    debug_inspect(child_kind, content="Unknown")
+  }
+}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_wbtest.mbt
@@ -12,10 +12,10 @@ async test "LinkReconciliation reconcile_skill_links 1 - creates a missing desir
     let state_path = root.join(".agents").join("c-plugin-state.json")
     @fs.mkdir(target.to_string(), recursive=true)
     let entry = OwnershipEntry::OwnershipEntry(
-      link,
+      OwnershipLink::OwnershipLink(link),
       target.relative(base=managed_root),
-      target,
-      managed_root,
+      OwnershipResolvedTarget::OwnershipResolvedTarget(target),
+      OwnershipManagedRoot::OwnershipManagedRoot(managed_root),
       OwnershipSource::from_local(
         LocalOwnershipSource::LocalOwnershipSource(
           RelativeSourcePath::RelativeSourcePath(
@@ -85,10 +85,10 @@ fn stale_reconciliation_entry(
   target : @path.Path,
 ) -> OwnershipEntry raise {
   OwnershipEntry::OwnershipEntry(
-    managed_root.join(name),
+    OwnershipLink::OwnershipLink(managed_root.join(name)),
     target.relative(base=managed_root),
-    target,
-    managed_root,
+    OwnershipResolvedTarget::OwnershipResolvedTarget(target),
+    OwnershipManagedRoot::OwnershipManagedRoot(managed_root),
     OwnershipSource::from_local(
       LocalOwnershipSource::LocalOwnershipSource(
         RelativeSourcePath::RelativeSourcePath(@path.Path("vendor/repository")),
@@ -106,10 +106,10 @@ fn desired_owned_entry(
   repository : String,
 ) -> OwnershipEntry raise {
   OwnershipEntry::OwnershipEntry(
-    managed_root.join("install"),
+    OwnershipLink::OwnershipLink(managed_root.join("install")),
     target.relative(base=managed_root),
-    target,
-    managed_root,
+    OwnershipResolvedTarget::OwnershipResolvedTarget(target),
+    OwnershipManagedRoot::OwnershipManagedRoot(managed_root),
     OwnershipSource::from_local(
       LocalOwnershipSource::LocalOwnershipSource(
         RelativeSourcePath::RelativeSourcePath(@path.Path(repository)),
@@ -143,7 +143,7 @@ async test "LinkReconciliation reconcile_skill_links 7 - distinguishes unavailab
       )
       @fs.symlink(
         target=foreign_target.relative(base=managed_root).to_string(),
-        collision.link.to_string(),
+        collision.link.path.to_string(),
       )
       let desired_state = OwnershipState::OwnershipState([collision, absent])
       let checkpoints = []
@@ -158,7 +158,7 @@ async test "LinkReconciliation reconcile_skill_links 7 - distinguishes unavailab
       inspect(result.durable_state.entries.length(), content="1")
       inspect(
         result.durable_state.entries.get(
-          OwnershipLinkIdentity::OwnershipLinkIdentity(absent.link),
+          OwnershipLinkIdentity::OwnershipLinkIdentity(absent.link.path),
         ) ==
         Some(absent),
         content="true",
@@ -170,11 +170,11 @@ async test "LinkReconciliation reconcile_skill_links 7 - distinguishes unavailab
         _ => fail("expected distinct unavailable ownership notice")
       }
       inspect(
-        @fs.realpath(collision.link.to_string()),
+        @fs.realpath(collision.link.path.to_string()),
         content=@fs.realpath(foreign_target.to_string()),
       )
       inspect(
-        @fs.realpath(absent.link.to_string()),
+        @fs.realpath(absent.link.path.to_string()),
         content=@fs.realpath(absent_target.to_string()),
       )
     }

--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -91,6 +91,21 @@ pub fn OwnershipSource::from_local(
 }
 
 ///|
+pub struct OwnershipStatePath {
+  path : @path.Path
+} derive(Eq)
+
+///|
+pub fn OwnershipStatePath::OwnershipStatePath(
+  path : @path.Path,
+) -> OwnershipStatePath raise {
+  guard path.is_absolute() else {
+    fail("ownership state path must be absolute")
+  }
+  { path: path.normalize() }
+}
+
+///|
 pub struct OwnershipLink {
   path : @path.Path
 } derive(Eq)

--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -236,3 +236,8 @@ pub fn OwnershipState::OwnershipState(
   }
   { version: 1, entries: stored_entries }
 }
+
+///|
+pub fn OwnershipState::empty() -> OwnershipState {
+  { version: 1, entries: @immut_hashmap.HashMap([]) }
+}

--- a/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
@@ -17,6 +17,16 @@ test "Ownership path values OwnershipLink - normalize absolute paths" {
 }
 
 ///|
+test "OwnershipStatePath OwnershipStatePath - normalizes an absolute path" {
+  inspect(
+    OwnershipStatePath::OwnershipStatePath(
+      "/workspace/project/.agents/./c-plugin-state.json",
+    ).path.to_string(),
+    content="/workspace/project/.agents/c-plugin-state.json",
+  )
+}
+
+///|
 test "panic_OwnershipLink OwnershipLink - rejects a relative path" {
   try! (OwnershipLink::OwnershipLink("skills/sync") |> ignore)
 }
@@ -29,6 +39,12 @@ test "panic_OwnershipResolvedTarget OwnershipResolvedTarget - rejects a relative
 ///|
 test "panic_OwnershipManagedRoot OwnershipManagedRoot - rejects a relative path" {
   try! (OwnershipManagedRoot::OwnershipManagedRoot("workspace/skills") |> ignore)
+}
+
+///|
+test "panic_OwnershipStatePath OwnershipStatePath - rejects a relative path" {
+  try! (OwnershipStatePath::OwnershipStatePath(".agents/c-plugin-state.json")
+  |> ignore)
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/runtime_paths.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime_paths.mbt
@@ -52,18 +52,22 @@ pub fn RuntimePaths::global_lock_path(self : RuntimePaths) -> @path.Path {
 pub fn RuntimePaths::project_ownership_state_path(
   self : RuntimePaths,
   project_root : @path.Path,
-) -> @path.Path raise RuntimePathsError {
+) -> OwnershipStatePath raise {
   ignore(self)
-  normalized_absolute_root("project root", project_root)
-  .join(".agents")
-  .join("c-plugin-state.json")
+  OwnershipStatePath::OwnershipStatePath(
+    normalized_absolute_root("project root", project_root)
+    .join(".agents")
+    .join("c-plugin-state.json"),
+  )
 }
 
 ///|
 pub fn RuntimePaths::global_ownership_state_path(
   self : RuntimePaths,
-) -> @path.Path {
-  self.home.join(".agents").join("c-plugin-state.json")
+) -> OwnershipStatePath {
+  OwnershipStatePath::{
+    path: self.home.join(".agents").join("c-plugin-state.json"),
+  }
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/runtime_paths.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime_paths.mbt
@@ -64,10 +64,10 @@ pub fn RuntimePaths::project_ownership_state_path(
 ///|
 pub fn RuntimePaths::global_ownership_state_path(
   self : RuntimePaths,
-) -> OwnershipStatePath {
-  OwnershipStatePath::{
-    path: self.home.join(".agents").join("c-plugin-state.json"),
-  }
+) -> OwnershipStatePath raise {
+  OwnershipStatePath::OwnershipStatePath(
+    self.home.join(".agents").join("c-plugin-state.json"),
+  )
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/runtime_paths.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime_paths.mbt
@@ -52,19 +52,22 @@ pub fn RuntimePaths::global_lock_path(self : RuntimePaths) -> @path.Path {
 pub fn RuntimePaths::project_ownership_state_path(
   self : RuntimePaths,
   project_root : @path.Path,
-) -> OwnershipStatePath raise RuntimePathsError {
+) -> OwnershipStatePath raise {
   ignore(self)
-  let root = normalized_absolute_root("project root", project_root)
-  OwnershipStatePath::{ path: root.join(".agents").join("c-plugin-state.json") }
+  OwnershipStatePath::OwnershipStatePath(
+    normalized_absolute_root("project root", project_root)
+    .join(".agents")
+    .join("c-plugin-state.json"),
+  )
 }
 
 ///|
 pub fn RuntimePaths::global_ownership_state_path(
   self : RuntimePaths,
-) -> OwnershipStatePath {
-  OwnershipStatePath::{
-    path: self.home.join(".agents").join("c-plugin-state.json"),
-  }
+) -> OwnershipStatePath raise {
+  OwnershipStatePath::OwnershipStatePath(
+    self.home.join(".agents").join("c-plugin-state.json"),
+  )
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/runtime_paths.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime_paths.mbt
@@ -52,22 +52,19 @@ pub fn RuntimePaths::global_lock_path(self : RuntimePaths) -> @path.Path {
 pub fn RuntimePaths::project_ownership_state_path(
   self : RuntimePaths,
   project_root : @path.Path,
-) -> OwnershipStatePath raise {
+) -> OwnershipStatePath raise RuntimePathsError {
   ignore(self)
-  OwnershipStatePath::OwnershipStatePath(
-    normalized_absolute_root("project root", project_root)
-    .join(".agents")
-    .join("c-plugin-state.json"),
-  )
+  let root = normalized_absolute_root("project root", project_root)
+  OwnershipStatePath::{ path: root.join(".agents").join("c-plugin-state.json") }
 }
 
 ///|
 pub fn RuntimePaths::global_ownership_state_path(
   self : RuntimePaths,
-) -> OwnershipStatePath raise {
-  OwnershipStatePath::OwnershipStatePath(
-    self.home.join(".agents").join("c-plugin-state.json"),
-  )
+) -> OwnershipStatePath {
+  OwnershipStatePath::{
+    path: self.home.join(".agents").join("c-plugin-state.json"),
+  }
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/runtime_paths_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime_paths_wbtest.mbt
@@ -14,12 +14,15 @@ test "RuntimePaths project paths - derive lock ownership state and managed skill
     "/synthetic/home", "/synthetic/work", "/synthetic/cache/repositories",
   )
   let project_root : @path.Path = "/synthetic/work/project/./plugin"
+  let ownership_state_path : OwnershipStatePath = paths.project_ownership_state_path(
+    project_root,
+  )
   inspect(
     paths.project_lock_path(project_root).to_string(),
     content="/synthetic/work/project/plugin/c-plugin-lock.json",
   )
   inspect(
-    paths.project_ownership_state_path(project_root).to_string(),
+    ownership_state_path.path.to_string(),
     content="/synthetic/work/project/plugin/.agents/c-plugin-state.json",
   )
   inspect(
@@ -33,12 +36,13 @@ test "RuntimePaths global paths - derive all paths below synthetic home" {
   let paths = RuntimePaths::RuntimePaths(
     "/synthetic/home/./user", "/synthetic/work", "/synthetic/cache/repositories",
   )
+  let ownership_state_path : OwnershipStatePath = paths.global_ownership_state_path()
   inspect(
     paths.global_lock_path().to_string(),
     content="/synthetic/home/user/c-plugin-lock.json",
   )
   inspect(
-    paths.global_ownership_state_path().to_string(),
+    ownership_state_path.path.to_string(),
     content="/synthetic/home/user/.agents/c-plugin-state.json",
   )
   inspect(

--- a/plugins/totto2727-coding/skills/mbt-coding/references/errors.md
+++ b/plugins/totto2727-coding/skills/mbt-coding/references/errors.md
@@ -31,7 +31,7 @@ Do not catch merely to log, rename, stringify, or rethrow the same failure. Fina
 
 When translating an error, retain the original failure as structured context when the target error type supports it. Do not replace an unknown error with a generic string that loses its identity.
 
-Use `try?` only when `Result` is the required boundary contract. Avoid `try!` in production paths unless the invariant making failure impossible is local and evident.
+Use `try?` only when `Result` is the required boundary contract. Do not use `try!` outside tests: call the raising operation directly so the `raise` effect remains visible and propagates, or remove the failure path with a non-raising construction whose invariant is represented by its inputs. If production code cannot avoid `try!`, add an adjacent comment explaining why failure is impossible and why the function cannot expose or propagate the error; an undocumented production use is prohibited.
 
 Do not define a new `suberror` merely to replace a generic message with another name. A custom error is justified when a caller branches on its variants or needs typed context such as a path, identifier, status, or original failure.
 


### PR DESCRIPTION
## 概要

Linear [TOT-107](https://linear.app/totto2727/issue/TOT-107/c-plugin-v2-m3-r1-fs-ownership-safe-link-reconciliationを実装する) のR1-FSとして、R1-Pが生成したdesired `OwnershipState`とlock単位のprevious ownership stateをlive filesystemへ安全に反映するcomponentを追加します。

- `Trusted` / `Missing` / `Corrupt`を明示し、missing/corrupt時は削除・adoptionを禁止
- `Path`をfilesystem境界まで維持し、`kind(follow_symlink=false)`・`realpath`・no-clobber `symlink`・`remove`を小さなadapterへ分離
- recorded targetとlive resolved targetが一致するsymlinkだけを削除・置換
- 管理外file/directory/symlink、外部置換、broken symlinkを保護し、typed noticeとして返却
- symlink作成・削除・ownership dropの各mutation直後にatomic ownership checkpointを実行
- lock/state scopeごとのprevious state以外から所有権を推測せず、cross-lock削除を防止
- productionの`try!`を排除し、constructor failureを`raise`として呼び出し側へ伝播

## エラー処理契約

productionでは`try!`を使用しません。失敗し得るconstructorは通常呼び出しで`raise`を伝播し、入力によって失敗不能なstate遷移は`OwnershipState::empty`またはimmutable mapの直接更新として表現します。将来どうしてもproductionで`try!`が必要な場合は、失敗不能である理由とerrorを公開・伝播できない理由を隣接コメントへ必須記載とします。

## ownership state pathの型境界

- 正規化済み絶対パスという不変条件は `OwnershipStatePath` が所有します。
- 公開constructorは相対パスを拒否し、絶対パスを正規化して保持します。
- `RuntimePaths` のproject/global両factoryは `OwnershipStatePath::OwnershipStatePath` を必ず呼び出し、constructor failureをopen `raise`として呼び出し側へ伝播します。互換性のためにValue Objectの生成境界を迂回しません。
- reconciliation内部では `OwnershipStatePath` を引き回し、raw `Path` への展開はatomic checkpoint adapterの呼び出し境界だけに限定します。
- 末端のreconciliation関数ではabsolute/normalized guardを重複実装しません。

## 処理フロー

```mermaid
flowchart TD
  A["R1-P desired OwnershipState"] --> B["Previous ownership: Trusted / Missing / Corrupt"]
  B --> C["Desired linksをCompare順で処理"]
  C --> D{"live path"}
  D -->|missing| E["no-clobber symlink作成"]
  E --> F["kind / realpath / containmentを再検証"]
  F --> G["atomic ownership checkpoint"]
  D -->|unrecorded path| H["preserve + typed notice"]
  D -->|trusted owned| I{"recorded targetと一致"}
  I -->|一致| J["keep / verified replacement"]
  I -->|不一致・broken| K["preserve + ownership drop checkpoint"]
  B -->|Trusted only| L["stale owned linksを処理"]
  L --> M{"最終recheckも一致"}
  M -->|yes| N["remove + omission checkpoint"]
  M -->|no| O["preserve + typed notice"]
  G --> P["last durable OwnershipStateを返却"]
  H --> P
  J --> P
  K --> P
  N --> P
  O --> P
```

## durabilityと競合時の契約

通常の`OwnershipEntry`をsymlink作成前には書きません。現行schemaではpendingとverified ownershipを区別できず、外部プロセスが同じtargetのsymlinkを先に作った場合に誤adoptionするためです。

作成成功後はlive検証とatomic checkpointを直ちに行い、checkpoint失敗時は後続mutationを停止して`Partial`を返します。この時点のlinkはownership stateへ記録されていないため、再実行では管理外として保護されます。public async filesystem APIにはliteral `readlink`やinode/object identityがないため、作成からcheckpointまでのcrash windowを安全に自動adoptionする保証は行いません。

- [moonbitlang/async v0.20.3: realpath / symlink](https://github.com/moonbitlang/async/blob/3f68b7932d8094c3c4e750b927b07be6ad6c0f78/src/fs/utils.mbt#L113-L147)
- [moonbitlang/async v0.20.3: remove](https://github.com/moonbitlang/async/blob/3f68b7932d8094c3c4e750b927b07be6ad6c0f78/src/fs/file.mbt#L417-L421)
- [MoonBit公式エラー処理仕様](https://docs.moonbitlang.com/en/stable/language/error-handling.html)

## テスト設計

```mermaid
flowchart LR
  T["145 package tests"] --> A["create / checkpoint / idempotency"]
  T --> B["file / directory / same-target / different-target / broken collision"]
  T --> C["stale / missing / removed root / target replacement"]
  T --> D["Missing / Corrupt previous state"]
  T --> E["cross-lock isolation"]
  T --> F["EEXIST / final-recheck replacement"]
  T --> G["mkdir / realpath / kind / symlink / remove failures"]
  T --> H["create and stale checkpoint failures + retry"]
  T --> I["invalid resolved path raises Failure"]
  A --> P["145 / 145 PASS"]
  B --> P
  C --> P
  D --> P
  E --> P
  F --> P
  G --> P
  H --> P
  I --> P
```

実行結果（exact SHA `908e1c15a5633d79ef007030d9550ad107806011`）:

- production `try!` scan: 0件
- `moon fmt --check`: PASS
- `moon check -d --target native mbt/app/c-plugin-v2/src`: PASS
- `moon test --target native mbt/app/c-plugin-v2/src --no-parallelize`: 145/145 PASS
- `moon build --release --target native mbt/app/c-plugin-v2/src`: PASS
- 5系統レビュー（goal / QA / code / security / context）: exact SHAでPASS
- runtime / error-propagation audit: exact SHAでPASS
- `git diff --check`: PASS
- GitHub Actions CI: PASS https://github.com/totto2727-org/monorepo/actions/runs/31350756715
- CodeQL: PASS https://github.com/totto2727-org/monorepo/actions/runs/31350754763
- CodeQL: PASS https://github.com/totto2727-org/monorepo/actions/runs/31350754891

## 対象外

- command wiring / lock mutation / `persist_and_sync`
- recursive sync
- Docker E2E（leaf commandの`C-sync`で追加）
- ownership schema migration、`readlink`またはnative inode adapter

## Stack

- Base: PR #273 (`codex/cpv2-m3-r1-reconciliation`)
- このPRはTOT-107のstack layerです。