### PR TITLE
TOT-115 c-plugin v2: init Runtimeのcompositionをmainへ移動

### DIFF
--- a/mbt/app/c-plugin-v2/src/command_init.mbt
+++ b/mbt/app/c-plugin-v2/src/command_init.mbt
@@ -18,19 +18,6 @@ fn init_options(
 }
 
 ///|
-fn runtime_for_init(paths : RuntimePaths) -> Runtime {
-  Runtime::Runtime(
-    paths~,
-    discover_locks_api=discover_locks,
-    load_lock~,
-    create_lock_exclusive~,
-    write_lock_atomic~,
-    load_ownership_state~,
-    write_ownership_state_atomic~,
-  )
-}
-
-///|
 /// Create an empty project or global v2 lock without replacing existing bytes.
 async fn init_lock(runtime : Runtime, options : InitOptions) -> @path.Path {
   let lock_path = if options.global {

--- a/mbt/app/c-plugin-v2/src/main.mbt
+++ b/mbt/app/c-plugin-v2/src/main.mbt
@@ -1,4 +1,17 @@
 ///|
+fn runtime_for_init(paths : RuntimePaths) -> Runtime {
+  Runtime::Runtime(
+    paths~,
+    discover_locks_api=discover_locks,
+    load_lock~,
+    create_lock_exclusive~,
+    write_lock_atomic~,
+    load_ownership_state~,
+    write_ownership_state_atomic~,
+  )
+}
+
+///|
 fn app(runtime : Runtime) -> @admiral.CliApp {
   @admiral.CliApp::CliApp(
     name="c-plugin",


### PR DESCRIPTION
## 概要

TOT-115として、production `Runtime`を組み立てる`runtime_for_init`を`command_init.mbt`からcomposition rootの`main.mbt`へ移します。command側は入力変換、lock path選択、exclusive create、CLI出力だけを保持し、既存のRuntime注入方式は変更しません。

## 処理フロー

```mermaid
flowchart TD
  A[main] --> B[home/cwd/cache rootを解決]
  B --> C[production adapterをRuntimeへ注入]
  C --> D[init command]
  D --> E[project/global lock pathを選択]
  E --> F[exclusive create]
  F --> G[CLI結果]
```

## テスト条件

```mermaid
flowchart LR
  A[Project init] --> A1[lock生成と出力]
  B[Global init] --> B1[HOME直下へlock生成]
  C[Repeat init] --> C1[既存byteを保持して拒否]
  D[Isolation] --> D1[.agents/cacheを変更しない]
```

## 検証

- Native tests: 88/88 PASS
- Native check / release build / format / diff check: PASS
- Release CLI: project/global/repeat PASS
- 5レーンreview-work: PASS
- Exact SHA: `014fe38726811d483d01a59714b423aa472c2ff2`

Linear: https://linear.app/totto2727/issue/TOT-115