### PR TITLE
TOT-114 c-plugin v2: LockDiscoveryOptionsを有効状態のみのenumへ変更

### DIFF
--- a/mbt/app/c-plugin-v2/src/lock_discovery.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_discovery.mbt
@@ -7,7 +7,7 @@ pub(all) enum LockDiscoveryScope {
 ///|
 pub(all) enum LockDiscoveryOptions {
   Global
-  Project(Bool)
+  Project(recursive~ : Bool)
 } derive(Debug, Eq)
 
 ///|
@@ -91,7 +91,7 @@ pub async fn discover_locks(
 ) -> ReadOnlyArray[@path.Path] raise LockDiscoveryError {
   match options {
     Global => ReadOnlyArray::from_array([find_global_lock(paths.home)])
-    Project(recursive) => {
+    Project(recursive~) => {
       let nearest_lock = find_project_lock(paths.home, paths.cwd)
       if recursive {
         find_recursive_project_locks(paths.home, nearest_lock)

--- a/mbt/app/c-plugin-v2/src/lock_discovery.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_discovery.mbt
@@ -5,22 +5,13 @@ pub(all) enum LockDiscoveryScope {
 } derive(Debug, Eq)
 
 ///|
-pub struct LockDiscoveryOptions {
-  scope : LockDiscoveryScope
-  recursive : Bool
-}
-
-///|
-pub fn LockDiscoveryOptions::LockDiscoveryOptions(
-  scope : LockDiscoveryScope,
-  recursive : Bool,
-) -> LockDiscoveryOptions {
-  { scope, recursive }
-}
+pub(all) enum LockDiscoveryOptions {
+  Global
+  Project(Bool)
+} derive(Debug, Eq)
 
 ///|
 pub(all) suberror LockDiscoveryError {
-  GlobalRecursiveUnsupported
   LockFileNotFound(scope~ : LockDiscoveryScope, boundary~ : @path.Path)
 } derive(Debug)
 
@@ -98,14 +89,11 @@ pub async fn discover_locks(
   paths : RuntimePaths,
   options : LockDiscoveryOptions,
 ) -> ReadOnlyArray[@path.Path] raise LockDiscoveryError {
-  match options.scope {
-    Global => {
-      guard !options.recursive else { raise GlobalRecursiveUnsupported }
-      ReadOnlyArray::from_array([find_global_lock(paths.home)])
-    }
-    Project => {
+  match options {
+    Global => ReadOnlyArray::from_array([find_global_lock(paths.home)])
+    Project(recursive) => {
       let nearest_lock = find_project_lock(paths.home, paths.cwd)
-      if options.recursive {
+      if recursive {
         find_recursive_project_locks(paths.home, nearest_lock)
       } else {
         ReadOnlyArray::from_array([nearest_lock])

--- a/mbt/app/c-plugin-v2/src/lock_discovery_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_discovery_wbtest.mbt
@@ -52,10 +52,7 @@ async test "discover_locks - finds the nearest project lock below the synthetic 
     )
     let locks = discover_locks(
       fixture.paths,
-      LockDiscoveryOptions::LockDiscoveryOptions(
-        LockDiscoveryScope::Project,
-        false,
-      ),
+      LockDiscoveryOptions::Project(false),
     )
     inspect(locks[0].to_string(), content=nearest_lock.to_string())
     assert_false(locks.contains(outer_lock))
@@ -72,13 +69,7 @@ async test "discover_locks - resolves the global lock exactly below the syntheti
       .join("package")
       .join("c-plugin-lock.json"),
     )
-    let locks = discover_locks(
-      fixture.paths,
-      LockDiscoveryOptions::LockDiscoveryOptions(
-        LockDiscoveryScope::Global,
-        false,
-      ),
-    )
+    let locks = discover_locks(fixture.paths, LockDiscoveryOptions::Global)
     inspect(locks[0].to_string(), content=global_lock.to_string())
   })
 }
@@ -109,10 +100,7 @@ async test "discover_locks - includes the nearest project lock and visible desce
     )
     let locks = discover_locks(
       fixture.paths,
-      LockDiscoveryOptions::LockDiscoveryOptions(
-        LockDiscoveryScope::Project,
-        true,
-      ),
+      LockDiscoveryOptions::Project(true),
     )
     assert_true(locks.contains(nearest_lock))
     assert_true(locks.contains(child_lock))
@@ -138,10 +126,7 @@ async test "discover_locks - excludes descendants in gitignored directories" {
     )
     let locks = discover_locks(
       fixture.paths,
-      LockDiscoveryOptions::LockDiscoveryOptions(
-        LockDiscoveryScope::Project,
-        true,
-      ),
+      LockDiscoveryOptions::Project(true),
     )
     assert_true(locks.contains(nearest_lock))
     assert_true(locks.contains(visible_lock))
@@ -154,13 +139,7 @@ async test "discover_locks - does not search for project locks above the synthet
   with_lock_discovery_fixture(async fn(fixture) {
     let outside_lock = write_lock(fixture.root.join("c-plugin-lock.json"))
     let detail = try {
-      discover_locks(
-        fixture.paths,
-        LockDiscoveryOptions::LockDiscoveryOptions(
-          LockDiscoveryScope::Project,
-          false,
-        ),
-      )
+      discover_locks(fixture.paths, LockDiscoveryOptions::Project(false))
       |> ignore
       "no error"
     } catch {
@@ -173,37 +152,10 @@ async test "discover_locks - does not search for project locks above the synthet
 }
 
 ///|
-async test "discover_locks - rejects global recursive discovery before reading locks" {
-  with_lock_discovery_fixture(async fn(fixture) {
-    let detail = try {
-      discover_locks(
-        fixture.paths,
-        LockDiscoveryOptions::LockDiscoveryOptions(
-          LockDiscoveryScope::Global,
-          true,
-        ),
-      )
-      |> ignore
-      "no error"
-    } catch {
-      GlobalRecursiveUnsupported => "global recursive unsupported"
-      _ => "wrong error"
-    }
-    inspect(detail, content="global recursive unsupported")
-  })
-}
-
-///|
 async test "discover_locks - reports a typed error when no project lock exists" {
   with_lock_discovery_fixture(async fn(fixture) {
     let detail = try {
-      discover_locks(
-        fixture.paths,
-        LockDiscoveryOptions::LockDiscoveryOptions(
-          LockDiscoveryScope::Project,
-          false,
-        ),
-      )
+      discover_locks(fixture.paths, LockDiscoveryOptions::Project(false))
       |> ignore
       "no error"
     } catch {
@@ -228,14 +180,7 @@ async test "discover_locks - rejects a cwd outside the synthetic home" {
       fixture.paths.cache_root,
     )
     let detail = try {
-      discover_locks(
-        paths,
-        LockDiscoveryOptions::LockDiscoveryOptions(
-          LockDiscoveryScope::Project,
-          false,
-        ),
-      )
-      |> ignore
+      discover_locks(paths, LockDiscoveryOptions::Project(false)) |> ignore
       "no error"
     } catch {
       LockFileNotFound(scope=Project, boundary~) => boundary.to_string()
@@ -250,14 +195,7 @@ async test "discover_locks - rejects a cwd outside the synthetic home" {
 async test "discover_locks - reports a typed error when no global lock exists" {
   with_lock_discovery_fixture(async fn(fixture) {
     let detail = try {
-      discover_locks(
-        fixture.paths,
-        LockDiscoveryOptions::LockDiscoveryOptions(
-          LockDiscoveryScope::Global,
-          false,
-        ),
-      )
-      |> ignore
+      discover_locks(fixture.paths, LockDiscoveryOptions::Global) |> ignore
       "no error"
     } catch {
       LockFileNotFound(scope=Global, boundary~) => boundary.to_string()

--- a/mbt/app/c-plugin-v2/src/lock_discovery_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_discovery_wbtest.mbt
@@ -52,7 +52,7 @@ async test "discover_locks - finds the nearest project lock below the synthetic 
     )
     let locks = discover_locks(
       fixture.paths,
-      LockDiscoveryOptions::Project(false),
+      LockDiscoveryOptions::Project(recursive=false),
     )
     inspect(locks[0].to_string(), content=nearest_lock.to_string())
     assert_false(locks.contains(outer_lock))
@@ -100,7 +100,7 @@ async test "discover_locks - includes the nearest project lock and visible desce
     )
     let locks = discover_locks(
       fixture.paths,
-      LockDiscoveryOptions::Project(true),
+      LockDiscoveryOptions::Project(recursive=true),
     )
     assert_true(locks.contains(nearest_lock))
     assert_true(locks.contains(child_lock))
@@ -126,7 +126,7 @@ async test "discover_locks - excludes descendants in gitignored directories" {
     )
     let locks = discover_locks(
       fixture.paths,
-      LockDiscoveryOptions::Project(true),
+      LockDiscoveryOptions::Project(recursive=true),
     )
     assert_true(locks.contains(nearest_lock))
     assert_true(locks.contains(visible_lock))
@@ -139,7 +139,10 @@ async test "discover_locks - does not search for project locks above the synthet
   with_lock_discovery_fixture(async fn(fixture) {
     let outside_lock = write_lock(fixture.root.join("c-plugin-lock.json"))
     let detail = try {
-      discover_locks(fixture.paths, LockDiscoveryOptions::Project(false))
+      discover_locks(
+        fixture.paths,
+        LockDiscoveryOptions::Project(recursive=false),
+      )
       |> ignore
       "no error"
     } catch {
@@ -155,7 +158,10 @@ async test "discover_locks - does not search for project locks above the synthet
 async test "discover_locks - reports a typed error when no project lock exists" {
   with_lock_discovery_fixture(async fn(fixture) {
     let detail = try {
-      discover_locks(fixture.paths, LockDiscoveryOptions::Project(false))
+      discover_locks(
+        fixture.paths,
+        LockDiscoveryOptions::Project(recursive=false),
+      )
       |> ignore
       "no error"
     } catch {
@@ -180,7 +186,8 @@ async test "discover_locks - rejects a cwd outside the synthetic home" {
       fixture.paths.cache_root,
     )
     let detail = try {
-      discover_locks(paths, LockDiscoveryOptions::Project(false)) |> ignore
+      discover_locks(paths, LockDiscoveryOptions::Project(recursive=false))
+      |> ignore
       "no error"
     } catch {
       LockFileNotFound(scope=Project, boundary~) => boundary.to_string()

--- a/mbt/app/c-plugin-v2/src/runtime_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime_wbtest.mbt
@@ -23,7 +23,9 @@ async test "Runtime discover_locks - injects synthetic runtime paths" {
     write_ownership_state_atomic=fn(_path, _state) { () },
   )
 
-  let discovered = runtime.discover_locks(LockDiscoveryOptions::Project(false))
+  let discovered = runtime.discover_locks(
+    LockDiscoveryOptions::Project(recursive=false),
+  )
 
   inspect(received[0].to_string(), content="/synthetic/home")
   inspect(received[1].to_string(), content="/synthetic/work/project")

--- a/mbt/app/c-plugin-v2/src/runtime_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime_wbtest.mbt
@@ -23,12 +23,7 @@ async test "Runtime discover_locks - injects synthetic runtime paths" {
     write_ownership_state_atomic=fn(_path, _state) { () },
   )
 
-  let discovered = runtime.discover_locks(
-    LockDiscoveryOptions::LockDiscoveryOptions(
-      LockDiscoveryScope::Project,
-      false,
-    ),
-  )
+  let discovered = runtime.discover_locks(LockDiscoveryOptions::Project(false))
 
   inspect(received[0].to_string(), content="/synthetic/home")
   inspect(received[1].to_string(), content="/synthetic/work/project")


### PR DESCRIPTION
## 概要

TOT-114として、`LockDiscoveryOptions`を`Global | Project(recursive~ : Bool)`へ変更し、`Global + recursive=true`という無効状態を型で表現できないようにします。

`Project`だけではBool payloadの意味を推測できないため、enum定義・構築・pattern matchのすべてで`recursive` labelを必須にしています。専用payload型とvariantの意味が一致するケースではないため、positional payloadは使用しません。

## 処理フロー

```mermaid
flowchart TD
  A["CLIまたはRuntime入力"] --> B{"LockDiscoveryOptions"}
  B -->|Global| C["home lockのみ探索"]
  B -->|"Project(recursive=false)"| D["project lockを非再帰探索"]
  B -->|"Project(recursive=true)"| E["project lockを再帰探索"]
  C --> F["Path配列"]
  D --> F
  E --> F
```

## テスト条件

```mermaid
flowchart LR
  A["Global"] --> A1["home lockのみ"]
  B["Project(recursive=false)"] --> B1["非再帰結果を維持"]
  C["Project(recursive=true)"] --> C1["再帰結果を維持"]
  D["型検査"] --> D1["無効なGlobal recursiveを構築不能"]
  E["API可読性"] --> E1["Bool payloadはrecursive label必須"]
```

## 検証

- Native tests: 87/87 PASS
- Native check / release build / format / diff check: PASS
- 5レーンreview-work: PASS
- Exact SHA: `eab3d2877a73f59cf32a87c0939d4043a7757582`

Linear: https://linear.app/totto2727/issue/TOT-114

## CI status

- Latest commit SHA: `eab3d2877a73f59cf32a87c0939d4043a7757582`
- Latest `check` job: success ([run 31306860384](https://github.com/totto2727-org/monorepo/actions/runs/31306860384), attempt: 1)
- `gh run watch --exit-status`: `EXIT=0`
- Independent `gh run view --json conclusion`: `success`
- CodeQL: all success
- Retry history: none
