### PR TITLE
TOT-113 c-plugin v2: path containmentを正規化済みprefix判定へ簡素化

### DIFF
--- a/mbt/app/c-plugin-v2/src/lock_discovery.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_discovery.mbt
@@ -20,16 +20,15 @@ let lock_file_name = "c-plugin-lock.json"
 
 ///|
 fn path_is_within(base : @path.Path, target : @path.Path) -> Bool {
-  let normalized_base = base.normalize()
-  let mut current = target.normalize()
-  while current != normalized_base {
-    let parent = current.dirname()
-    if parent == current {
-      return false
-    }
-    current = parent
+  let normalized_base = base.normalize().to_string()
+  let normalized_target = target.normalize().to_string()
+  let base_prefix = if normalized_base == "/" {
+    normalized_base
+  } else {
+    "\{normalized_base}/"
   }
-  true
+  normalized_target == normalized_base ||
+  normalized_target.has_prefix(base_prefix)
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/lock_discovery_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_discovery_wbtest.mbt
@@ -5,6 +5,36 @@ struct LockDiscoveryFixture {
 }
 
 ///|
+test "path_is_within - accepts a normalized base itself" {
+  let base : @path.Path = "/synthetic/home/workspace/./package"
+  let target : @path.Path = "/synthetic/home/workspace/package"
+  assert_true(path_is_within(base, target))
+}
+
+///|
+test "path_is_within - accepts direct and deep normalized descendants" {
+  let base : @path.Path = "/synthetic/home/workspace/package"
+  let direct : @path.Path = "/synthetic/home/workspace/package/child"
+  let deep : @path.Path = "/synthetic/home/workspace/package/child/../nested/deep"
+  assert_true(path_is_within(base, direct))
+  assert_true(path_is_within(base, deep))
+}
+
+///|
+test "path_is_within - rejects a common lexical prefix sibling" {
+  let base : @path.Path = "/synthetic/home/foo"
+  let sibling : @path.Path = "/synthetic/home/foobar"
+  assert_false(path_is_within(base, sibling))
+}
+
+///|
+test "path_is_within - rejects a normalized escape" {
+  let base : @path.Path = "/synthetic/home/workspace/package"
+  let escaped : @path.Path = "/synthetic/home/workspace/package/../../outside"
+  assert_false(path_is_within(base, escaped))
+}
+
+///|
 async fn with_lock_discovery_fixture(
   action : async (LockDiscoveryFixture) -> Unit,
 ) -> Unit {


### PR DESCRIPTION
## 概要

`Path`をcontainment predicateまで保持し、両値をnormalizeした終端でのみ文字列化します。base自身または`base + separator`のprefixで判定し、`/foo`と`/foobar`の誤判定を防ぎます。

TOT-114のlabelled enum follow-upを取り込んだ親SHAへ、固有patchを変更せずrestackしています。

## 処理フロー

```mermaid
flowchart TD
  A["base Path / target Path"] --> B["両方normalize"]
  B --> C["terminal predicateでString化"]
  C --> D{"完全一致"}
  D -->|yes| E["within"]
  D -->|no| F{"base + separator prefix"}
  F -->|yes| E
  F -->|no| G["outside"]
```

## テスト条件

```mermaid
flowchart LR
  A["base自身"] --> A1["inside"]
  B["直下/深い子孫"] --> B1["inside"]
  C["共通文字列sibling"] --> C1["outside"]
  D["dot/dotdot"] --> D1["normalize後に判定"]
  E["home外project"] --> E1["reject維持"]
  F["restack"] --> F1["旧commitとpatch-id一致"]
```

## 検証

- Native tests: 91/91 PASS
- Focused containment 4/4 / discovery 8/8 PASS
- Format / check / release build / diff check: PASS
- 5レーンreview-work: PASS
- Exact SHA: `0fae1f390dedc7af0d3316f9c0d331b81214a60a`
- Parent: TOT-114 PR #278 / `eab3d2877a73f59cf32a87c0939d4043a7757582`
- 旧SHA `85d73ac76a3cdc3afd4ed8bd63a21b9f05f2558e`とstable patch-id一致

Linear: https://linear.app/totto2727/issue/TOT-113

## CI status

- Latest commit SHA: `0fae1f390dedc7af0d3316f9c0d331b81214a60a`
- Latest `check` job: success ([run 31306860473](https://github.com/totto2727-org/monorepo/actions/runs/31306860473), attempt: 1)
- `gh run watch --exit-status`: `EXIT=0`
- Independent `gh run view --json conclusion`: `success`
- CodeQL: all success
- Retry history: none
