### PR TITLE
TOT-102 c-plugin v2: repository codecを標準FromJsonへ委譲

### DIFF
--- a/mbt/app/c-plugin-v2/src/lock_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_codec.mbt
@@ -228,10 +228,13 @@ fn sorted_plugins_for_json(
 }
 
 ///|
-fn decode_github_repository_payload(
-  json : Json,
-  path : @json.JsonPath,
-) -> GitHubLockRepository raise @json.JsonDecodeError {
+pub impl @json.FromJson for GitHubLockRepository with fn from_json(json, path) {
+  let type_ = repository_type_lens.get_or_json_decode_error(json, path)
+  guard type_ == "github" else {
+    raise repository_type_lens.json_decode_error(
+      path, "expected repository type github",
+    )
+  }
   let repository : GitHubRepository = @json.from_json(
     github_repository_lens.get_or_json_decode_error(json, path),
     path=github_repository_lens.add_to_json_path(path),
@@ -254,17 +257,6 @@ fn decode_github_repository_payload(
 }
 
 ///|
-pub impl @json.FromJson for GitHubLockRepository with fn from_json(json, path) {
-  let type_ = repository_type_lens.get_or_json_decode_error(json, path)
-  guard type_ == "github" else {
-    raise repository_type_lens.json_decode_error(
-      path, "expected repository type github",
-    )
-  }
-  decode_github_repository_payload(json, path)
-}
-
-///|
 pub impl ToJson for GitHubLockRepository with fn to_json(self) -> Json {
   let builder = @lens.JsonBuilder::JsonBuilder()
   repository_type_lens.set_or_abort(builder, "github")
@@ -282,10 +274,13 @@ pub impl ToJson for GitHubLockRepository with fn to_json(self) -> Json {
 }
 
 ///|
-fn decode_local_repository_payload(
-  json : Json,
-  path : @json.JsonPath,
-) -> LocalLockRepository raise @json.JsonDecodeError {
+pub impl @json.FromJson for LocalLockRepository with fn from_json(json, path) {
+  let type_ = repository_type_lens.get_or_json_decode_error(json, path)
+  guard type_ == "local" else {
+    raise repository_type_lens.json_decode_error(
+      path, "expected repository type local",
+    )
+  }
   let source_path : RelativeSourcePath = @json.from_json(
     local_path_lens.get_or_json_decode_error(json, path),
     path=local_path_lens.add_to_json_path(path),
@@ -301,17 +296,6 @@ fn decode_local_repository_payload(
   LocalLockRepository(source_path, marketplace_kind, plugins) catch {
     error => raise @json.JsonDecodeError((path, error.to_string()))
   }
-}
-
-///|
-pub impl @json.FromJson for LocalLockRepository with fn from_json(json, path) {
-  let type_ = repository_type_lens.get_or_json_decode_error(json, path)
-  guard type_ == "local" else {
-    raise repository_type_lens.json_decode_error(
-      path, "expected repository type local",
-    )
-  }
-  decode_local_repository_payload(json, path)
 }
 
 ///|
@@ -334,10 +318,14 @@ pub impl ToJson for LocalLockRepository with fn to_json(self) -> Json {
 pub impl @json.FromJson for LockRepository with fn from_json(json, path) {
   let type_ = repository_type_lens.get_or_json_decode_error(json, path)
   match type_ {
-    "github" =>
-      LockRepository::github(decode_github_repository_payload(json, path))
-    "local" =>
-      LockRepository::from_local(decode_local_repository_payload(json, path))
+    "github" => {
+      let repository : GitHubLockRepository = @json.from_json(json, path~)
+      LockRepository::github(repository)
+    }
+    "local" => {
+      let repository : LocalLockRepository = @json.from_json(json, path~)
+      LockRepository::from_local(repository)
+    }
     _ =>
       raise repository_type_lens.json_decode_error(
         path,

--- a/mbt/app/c-plugin-v2/src/lock_codec_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_codec_wbtest.mbt
@@ -1,4 +1,15 @@
 ///|
+fn lock_root_json_path() -> @json.JsonPath raise {
+  try {
+    let _ : Bool = @json.from_json(Json::null())
+    fail("expected JsonDecodeError")
+  } catch {
+    @json.JsonDecodeError::JsonDecodeError((path, _)) => path
+    _ => fail("unexpected error")
+  }
+}
+
+///|
 fn expect_json_rejection(
   action : () -> Unit raise,
   detail : String,
@@ -166,6 +177,33 @@ test "LockRepository FromJson - dispatches each top-level type" {
   match local_repository {
     Local(_) => inspect(true, content="true")
     GitHub(_) => fail("expected local repository")
+  }
+}
+
+///|
+test "LockRepository FromJson - preserves variant and nested error paths" {
+  let prefixed_path = lock_root_json_path().add_key("request")
+  try {
+    let json = @json.parse(
+      "{\"type\":\"local\",\"repository\":\"openai/codex\",\"marketplaceKind\":\"codex\",\"commit\":\"0123456789abcdef0123456789abcdef01234567\",\"plugins\":[]}",
+    )
+    let _ : GitHubLockRepository = @json.from_json(json, path=prefixed_path)
+    fail("expected GitHub repository type mismatch")
+  } catch {
+    @json.JsonDecodeError::JsonDecodeError((path, _)) =>
+      inspect(path.to_string(), content="/request/type")
+    _ => fail("expected JsonDecodeError")
+  }
+  try {
+    let json = @json.parse(
+      "{\"type\":\"github\",\"repository\":\"openai/codex\",\"marketplaceKind\":\"codex\",\"commit\":\"invalid\",\"plugins\":[]}",
+    )
+    let _ : LockRepository = @json.from_json(json, path=prefixed_path)
+    fail("expected nested commit rejection")
+  } catch {
+    @json.JsonDecodeError::JsonDecodeError((path, _)) =>
+      inspect(path.to_string(), content="/request/commit")
+    _ => fail("expected JsonDecodeError")
   }
 }
 

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
@@ -48,57 +48,45 @@ let ownership_state_entries_lens : @lens.Lens[Json] = @lens.root().json(
 )
 
 ///|
-fn decode_github_ownership_source(
-  json : Json,
-  path : @json.JsonPath,
-) -> OwnershipSource raise @json.JsonDecodeError {
-  let repository : GitHubRepository = @json.from_json(
-    ownership_source_repository_lens.get_or_json_decode_error(json, path),
-    path=ownership_source_repository_lens.add_to_json_path(path),
-  )
-  let plugin : PluginName = @json.from_json(
-    ownership_source_plugin_lens.get_or_json_decode_error(json, path),
-    path=ownership_source_plugin_lens.add_to_json_path(path),
-  )
-  let skill : SkillName = @json.from_json(
-    ownership_source_skill_lens.get_or_json_decode_error(json, path),
-    path=ownership_source_skill_lens.add_to_json_path(path),
-  )
-  OwnershipSource::github(
-    GitHubOwnershipSource::GitHubOwnershipSource(repository, plugin, skill),
-  )
-}
-
-///|
-fn decode_local_ownership_source(
-  json : Json,
-  path : @json.JsonPath,
-) -> OwnershipSource raise @json.JsonDecodeError {
-  let repository : RelativeSourcePath = @json.from_json(
-    ownership_source_repository_lens.get_or_json_decode_error(json, path),
-    path=ownership_source_repository_lens.add_to_json_path(path),
-  )
-  let plugin : PluginName = @json.from_json(
-    ownership_source_plugin_lens.get_or_json_decode_error(json, path),
-    path=ownership_source_plugin_lens.add_to_json_path(path),
-  )
-  let skill : SkillName = @json.from_json(
-    ownership_source_skill_lens.get_or_json_decode_error(json, path),
-    path=ownership_source_skill_lens.add_to_json_path(path),
-  )
-  OwnershipSource::from_local(
-    LocalOwnershipSource::LocalOwnershipSource(repository, plugin, skill),
-  )
-}
-
-///|
 pub impl FromJson for OwnershipSource with fn from_json(json, path) {
   let source_type = ownership_source_type_lens.get_or_json_decode_error(
     json, path,
   )
   match source_type {
-    "github" => decode_github_ownership_source(json, path)
-    "local" => decode_local_ownership_source(json, path)
+    "github" => {
+      let repository : GitHubRepository = @json.from_json(
+        ownership_source_repository_lens.get_or_json_decode_error(json, path),
+        path=ownership_source_repository_lens.add_to_json_path(path),
+      )
+      let plugin : PluginName = @json.from_json(
+        ownership_source_plugin_lens.get_or_json_decode_error(json, path),
+        path=ownership_source_plugin_lens.add_to_json_path(path),
+      )
+      let skill : SkillName = @json.from_json(
+        ownership_source_skill_lens.get_or_json_decode_error(json, path),
+        path=ownership_source_skill_lens.add_to_json_path(path),
+      )
+      OwnershipSource::github(
+        GitHubOwnershipSource::GitHubOwnershipSource(repository, plugin, skill),
+      )
+    }
+    "local" => {
+      let repository : RelativeSourcePath = @json.from_json(
+        ownership_source_repository_lens.get_or_json_decode_error(json, path),
+        path=ownership_source_repository_lens.add_to_json_path(path),
+      )
+      let plugin : PluginName = @json.from_json(
+        ownership_source_plugin_lens.get_or_json_decode_error(json, path),
+        path=ownership_source_plugin_lens.add_to_json_path(path),
+      )
+      let skill : SkillName = @json.from_json(
+        ownership_source_skill_lens.get_or_json_decode_error(json, path),
+        path=ownership_source_skill_lens.add_to_json_path(path),
+      )
+      OwnershipSource::from_local(
+        LocalOwnershipSource::LocalOwnershipSource(repository, plugin, skill),
+      )
+    }
     _ =>
       raise ownership_source_type_lens.json_decode_error(
         path,

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
@@ -106,6 +106,22 @@ test "OwnershipSource FromJson::from_json - reports an invalid plugin at its exa
 }
 
 ///|
+test "OwnershipSource FromJson::from_json - preserves a prefixed local repository path" {
+  let json = @json.parse(
+    "{\"type\":\"local\",\"repository\":\"../outside\",\"plugin\":\"c-plugin\",\"skill\":\"sync\"}",
+  )
+  let path = ownership_root_json_path().add_key("source")
+  try {
+    let _ : OwnershipSource = @json.from_json(json, path~)
+    fail("expected JsonDecodeError")
+  } catch {
+    @json.JsonDecodeError::JsonDecodeError((error_path, _)) =>
+      inspect(error_path.to_string(), content="/source/repository")
+    _ => fail("unexpected error")
+  }
+}
+
+///|
 test "OwnershipEntry FromJson::from_json - reports invalid absolute fields at their exact paths" {
   let resolved_target_json = @json.parse(
     "{\"link\":\"/home/alice/project/.agents/skills/sync\",\"symlinkTarget\":\"../../../cache/skills/sync\",\"resolvedTarget\":\"cache/skills/sync\",\"managedRoot\":\"/home/alice/project/.agents/skills\",\"source\":{\"type\":\"github\",\"repository\":\"OpenAI/Codex\",\"plugin\":\"c-plugin\",\"skill\":\"sync\"}}",


### PR DESCRIPTION
## 概要

`LockRepository::from_json`は最上位の`type`を一度だけ選択し、GitHub/Localの完全なvariant `FromJson`へ元のJSONとpathを委譲します。重複payload helperを削除し、Linearの追加コメントに従いownership sourceの形式別helperもtop-level branchへinline化します。

## 処理フロー

```mermaid
flowchart TD
  A[repository JSON] --> B[typeを一度decode]
  B -->|github| C[GitHubLockRepository FromJson]
  B -->|local| D[LocalLockRepository FromJson]
  C --> E[LockRepository GitHub]
  D --> F[LockRepository Local]
```

## テスト条件

```mermaid
flowchart LR
  A[GitHub正常系] --> A1[round trip]
  B[Local正常系] --> B1[round trip]
  C[type mismatch] --> C1[正確なpath]
  D[nested malformed] --> D1[完全なnested path]
  E[unknown type] --> E1[reject]
  F[canonical output] --> F1[不変]
```

## 検証

- Native tests: 90/90 PASS
- Format / check / release build / diff check: PASS
- 5レーンreview-work: PASS
- Exact SHA: `ccfa4920001b818a953abd2ffbb7d44d3c6ee4bc`
- Parent: TOT-108 `3b7422c2`

Linear: https://linear.app/totto2727/issue/TOT-102