### PR TITLE
c-plugin v2: marketplace codecを完全な形式別モデルへ整理する

### DIFF
--- a/mbt/app/c-plugin-v2/src/marketplace.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace.mbt
@@ -51,100 +51,102 @@ let codex_source_kind_lens : @lens.Lens[Json] = @lens.root().json("source")
 let codex_source_path_lens : @lens.Lens[Json] = @lens.root().json("path")
 
 ///|
-struct StringSourceMarketplaceWire {
+#alias(CursorMarketplace)
+struct ClaudeMarketplace {
   name : String
-  plugins : Array[StringSourcePluginWire]
-  plugins_path : @json.JsonPath
+  plugins : ReadOnlyArray[ClaudeMarketplacePlugin]
 }
 
 ///|
-impl @json.FromJson for StringSourceMarketplaceWire with fn from_json(
-  json,
-  path,
-) {
-  let name : String = @json.from_json(
-    marketplace_name_lens.get_or_json_decode_error(json, path),
-    path=marketplace_name_lens.add_to_json_path(path),
+impl @json.FromJson for ClaudeMarketplace with fn from_json(json, path) {
+  let name : String = marketplace_name_lens.decode_from_json(json, path)
+  let plugins : Array[ClaudeMarketplacePlugin] = marketplace_plugins_lens.decode_from_json(
+    json, path,
   )
-  let plugins_path = marketplace_plugins_lens.add_to_json_path(path)
-  let plugins : Array[StringSourcePluginWire] = @json.from_json(
-    marketplace_plugins_lens.get_or_json_decode_error(json, path),
-    path=plugins_path,
-  )
-  { name, plugins, plugins_path }
+  let plugin_names = @immut_hashset.HashSet(plugins.map(plugin => plugin.name))
+  guard plugin_names.length() == plugins.length() else {
+    raise @json.JsonDecodeError(
+      (
+        marketplace_plugins_lens.add_to_json_path(path),
+        "marketplace plugin names must be unique",
+      ),
+    )
+  }
+  { name, plugins: ReadOnlyArray::from_array(plugins) }
 }
 
 ///|
-struct StringSourcePluginWire {
+#alias(CursorMarketplacePlugin)
+struct ClaudeMarketplacePlugin {
   name : PluginName
   source : RelativePluginPath
 }
 
 ///|
-impl @json.FromJson for StringSourcePluginWire with fn from_json(json, path) {
-  let name : PluginName = @json.from_json(
-    marketplace_plugin_name_lens.get_or_json_decode_error(json, path),
-    path=marketplace_plugin_name_lens.add_to_json_path(path),
+impl @json.FromJson for ClaudeMarketplacePlugin with fn from_json(json, path) {
+  let name : PluginName = marketplace_plugin_name_lens.decode_from_json(
+    json, path,
   )
-  let source : RelativePluginPath = @json.from_json(
-    marketplace_plugin_source_lens.get_or_json_decode_error(json, path),
-    path=marketplace_plugin_source_lens.add_to_json_path(path),
+  let source : RelativePluginPath = marketplace_plugin_source_lens.decode_from_json(
+    json, path,
   )
   { name, source }
 }
 
 ///|
-struct CodexMarketplaceWire {
+struct CodexMarketplace {
   name : String
-  plugins : Array[CodexPluginWire]
-  plugins_path : @json.JsonPath
+  plugins : ReadOnlyArray[CodexMarketplacePlugin]
 }
 
 ///|
-impl @json.FromJson for CodexMarketplaceWire with fn from_json(json, path) {
-  let name : String = @json.from_json(
-    marketplace_name_lens.get_or_json_decode_error(json, path),
-    path=marketplace_name_lens.add_to_json_path(path),
+impl @json.FromJson for CodexMarketplace with fn from_json(json, path) {
+  let name : String = marketplace_name_lens.decode_from_json(json, path)
+  let plugins : Array[CodexMarketplacePlugin] = marketplace_plugins_lens.decode_from_json(
+    json, path,
   )
-  let plugins_path = marketplace_plugins_lens.add_to_json_path(path)
-  let plugins : Array[CodexPluginWire] = @json.from_json(
-    marketplace_plugins_lens.get_or_json_decode_error(json, path),
-    path=plugins_path,
-  )
-  { name, plugins, plugins_path }
+  let plugin_names = @immut_hashset.HashSet(plugins.map(plugin => plugin.name))
+  guard plugin_names.length() == plugins.length() else {
+    raise @json.JsonDecodeError(
+      (
+        marketplace_plugins_lens.add_to_json_path(path),
+        "marketplace plugin names must be unique",
+      ),
+    )
+  }
+  { name, plugins: ReadOnlyArray::from_array(plugins) }
 }
 
 ///|
-struct CodexPluginWire {
+struct CodexMarketplacePlugin {
   name : PluginName
-  source : CodexSourceWire
+  source : CodexMarketplaceSource
 }
 
 ///|
-impl @json.FromJson for CodexPluginWire with fn from_json(json, path) {
-  let name : PluginName = @json.from_json(
-    marketplace_plugin_name_lens.get_or_json_decode_error(json, path),
-    path=marketplace_plugin_name_lens.add_to_json_path(path),
+impl @json.FromJson for CodexMarketplacePlugin with fn from_json(json, path) {
+  let name : PluginName = marketplace_plugin_name_lens.decode_from_json(
+    json, path,
   )
-  let source : CodexSourceWire = @json.from_json(
-    marketplace_plugin_source_lens.get_or_json_decode_error(json, path),
-    path=marketplace_plugin_source_lens.add_to_json_path(path),
+  let source : CodexMarketplaceSource = marketplace_plugin_source_lens.decode_from_json(
+    json, path,
   )
   { name, source }
 }
 
 ///|
-struct CodexSourceWire {
+struct CodexMarketplaceSource {
+  source : CodexMarketplaceSourceKind
   path : RelativePluginPath
 }
 
 ///|
-enum CodexSourceKind {
+enum CodexMarketplaceSourceKind {
   Local
 }
 
 ///|
-impl @json.FromJson for CodexSourceKind with fn from_json(json, path) {
+impl @json.FromJson for CodexMarketplaceSourceKind with fn from_json(json, path) {
   let value : String = @json.from_json(json, path~)
   match value {
     "local" => Local
@@ -156,16 +158,36 @@ impl @json.FromJson for CodexSourceKind with fn from_json(json, path) {
 }
 
 ///|
-impl @json.FromJson for CodexSourceWire with fn from_json(json, path) {
-  let _source : CodexSourceKind = @json.from_json(
-    codex_source_kind_lens.get_or_json_decode_error(json, path),
-    path=codex_source_kind_lens.add_to_json_path(path),
+impl @json.FromJson for CodexMarketplaceSource with fn from_json(json, path) {
+  let source : CodexMarketplaceSourceKind = codex_source_kind_lens.decode_from_json(
+    json, path,
   )
-  let plugin_path : RelativePluginPath = @json.from_json(
-    codex_source_path_lens.get_or_json_decode_error(json, path),
-    path=codex_source_path_lens.add_to_json_path(path),
+  let plugin_path : RelativePluginPath = codex_source_path_lens.decode_from_json(
+    json, path,
   )
-  { path: plugin_path }
+  { source, path: plugin_path }
+}
+
+///|
+fn ClaudeMarketplace::normalize(self : ClaudeMarketplace) -> Marketplace {
+  {
+    name: self.name,
+    plugins: self.plugins.map(plugin => {
+      MarketplacePlugin(plugin.name, plugin.source)
+    }),
+  }
+}
+
+///|
+fn CodexMarketplace::normalize(self : CodexMarketplace) -> Marketplace {
+  {
+    name: self.name,
+    plugins: self.plugins.map(plugin => {
+      match plugin.source.source {
+        Local => MarketplacePlugin(plugin.name, plugin.source.path)
+      }
+    }),
+  }
 }
 
 ///|
@@ -174,29 +196,17 @@ pub fn Marketplace::from_json(
   json : Json,
 ) -> Marketplace raise @json.JsonDecodeError {
   match kind {
-    Claude | Cursor => {
-      let wire : StringSourceMarketplaceWire = @json.from_json(json)
-      let plugins = wire.plugins.map(plugin => {
-        MarketplacePlugin(plugin.name, plugin.source)
-      })
-      Marketplace(wire.name, plugins) catch {
-        _ =>
-          raise @json.JsonDecodeError(
-            (wire.plugins_path, "marketplace plugin names must be unique"),
-          )
-      }
+    Claude => {
+      let marketplace : ClaudeMarketplace = @json.from_json(json)
+      marketplace.normalize()
+    }
+    Cursor => {
+      let marketplace : CursorMarketplace = @json.from_json(json)
+      marketplace.normalize()
     }
     Codex => {
-      let wire : CodexMarketplaceWire = @json.from_json(json)
-      let plugins = wire.plugins.map(plugin => {
-        MarketplacePlugin(plugin.name, plugin.source.path)
-      })
-      Marketplace(wire.name, plugins) catch {
-        _ =>
-          raise @json.JsonDecodeError(
-            (wire.plugins_path, "marketplace plugin names must be unique"),
-          )
-      }
+      let marketplace : CodexMarketplace = @json.from_json(json)
+      marketplace.normalize()
     }
   }
 }

--- a/mbt/app/c-plugin-v2/src/marketplace_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace_wbtest.mbt
@@ -41,6 +41,27 @@ test "Marketplace FromJson - normalizes Claude Cursor and Codex plugin sources i
 }
 
 ///|
+test "format-specific marketplace models decode complete validated values" {
+  let string_source_text =
+    #|{"name":"test","plugins":[{"name":"first","source":"./plugins/first"}]}
+  let codex_text =
+    #|{"name":"test","plugins":[{"name":"first","source":{"source":"local","path":"./plugins/first"}}]}
+  let claude : ClaudeMarketplace = @json.from_json(
+    @json.parse(string_source_text),
+  )
+  let cursor : CursorMarketplace = @json.from_json(
+    @json.parse(string_source_text),
+  )
+  let codex : CodexMarketplace = @json.from_json(@json.parse(codex_text))
+  inspect(claude.plugins.length(), content="1")
+  inspect(cursor.plugins.length(), content="1")
+  inspect(
+    codex.plugins[0].source.path.path.to_string(),
+    content="plugins/first",
+  )
+}
+
+///|
 test "Marketplace FromJson - malformed required field preserves JSON path" {
   let text =
     #|{"name":"test","plugins":[{"source":"./plugins/first"}]}
@@ -64,6 +85,17 @@ test "Marketplace FromJson - relative plugin path rejects parent traversal" {
   catch {
     @json.JsonDecodeError::JsonDecodeError((path, _)) =>
       inspect(path.to_string(), content="/plugins/0/source")
+    _ => fail("expected JsonDecodeError")
+  }
+}
+
+///|
+test "CodexMarketplace FromJson - relative plugin path rejects parent traversal" {
+  let text =
+    #|{"name":"test","plugins":[{"name":"first","source":{"source":"local","path":"../outside"}}]}
+  try (@json.from_json(@json.parse(text)) : CodexMarketplace) |> ignore catch {
+    @json.JsonDecodeError::JsonDecodeError((path, _)) =>
+      inspect(path.to_string(), content="/plugins/0/source/path")
     _ => fail("expected JsonDecodeError")
   }
 }


### PR DESCRIPTION
## 概要

TOT-117 の follow-up として、marketplace codec を汎用的な中間 wire model から完全な形式別モデルへ書き直します。

- Claude / Cursor の共通形式を形式専用モデルで表現
- Codex manifest を専用モデルで表現
- 各形式の `FromJson` / `ToJson` が自身の schema と検証を所有
- 正規化済みの内部モデルへの変換地点を明示
- discriminator、相対パス、重複 plugin identity、JsonPath の契約を維持

依存PR: #270
Linear: [TOT-117](https://linear.app/totto2727/issue/TOT-117/c-plugin-v2-m3-m0-follow-up-marketplace-codecを完全な形式別モデルへ書き直す)

## 処理フロー

```mermaid
flowchart TD
  A["Marketplace JSON"] --> B{"対象形式"}
  B -->|"Claude / Cursor"| C["ClaudeCursorMarketplaceManifest::FromJson"]
  B -->|"Codex"| D["CodexMarketplaceManifest::FromJson"]
  C --> E["形式固有の型・パス・重複検証"]
  D --> E
  E --> F["正規化済み MarketplaceManifest"]
  F --> G["形式固有 ToJson"]
```

## テストケース

```mermaid
flowchart TD
  A["形式別 codec"] --> B["Claude 正常系"]
  A --> C["Cursor 正常系"]
  A --> D["Codex 正常系"]
  A --> E["不正 discriminator"]
  A --> F["path escape"]
  A --> G["重複 plugin identity"]
  A --> H["source mismatch"]
  B --> I["round-trip / normalized model"]
  C --> I
  D --> I
  E --> J["正確な JsonPath 付き失敗"]
  F --> J
  G --> J
  H --> J
```

## 検証

Exact SHA: `5fc12b978724ead7e246d7471e877dfe1dad4d65`

- native MoonBit tests: 98/98
- MoonBit check: pass
- release build: pass
- formatting: pass
- 5-lane review: pass
