### PR TITLE
c-plugin v2: ownership path検証をvalue objectへ委譲する

### DIFF
--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -51,42 +51,67 @@ pub fn OwnershipSource::from_local(
 }
 
 ///|
+pub struct OwnershipLink {
+  path : @path.Path
+} derive(Eq)
+
+///|
+pub fn OwnershipLink::OwnershipLink(path : @path.Path) -> OwnershipLink raise {
+  guard path.is_absolute() else { fail("ownership link must be absolute") }
+  { path: path.normalize() }
+}
+
+///|
+pub struct OwnershipResolvedTarget {
+  path : @path.Path
+} derive(Eq)
+
+///|
+pub fn OwnershipResolvedTarget::OwnershipResolvedTarget(
+  path : @path.Path,
+) -> OwnershipResolvedTarget raise {
+  guard path.is_absolute() else {
+    fail("ownership resolved target must be absolute")
+  }
+  { path: path.normalize() }
+}
+
+///|
+pub struct OwnershipManagedRoot {
+  path : @path.Path
+} derive(Eq)
+
+///|
+pub fn OwnershipManagedRoot::OwnershipManagedRoot(
+  path : @path.Path,
+) -> OwnershipManagedRoot raise {
+  guard path.is_absolute() else {
+    fail("ownership managed root must be absolute")
+  }
+  { path: path.normalize() }
+}
+
+///|
 pub struct OwnershipEntry {
-  link : @path.Path
+  link : OwnershipLink
   symlink_target : @path.Path
-  resolved_target : @path.Path
-  managed_root : @path.Path
+  resolved_target : OwnershipResolvedTarget
+  managed_root : OwnershipManagedRoot
   source : OwnershipSource
 } derive(Eq)
 
 ///|
 pub fn OwnershipEntry::OwnershipEntry(
-  link : @path.Path,
+  link : OwnershipLink,
   symlink_target : @path.Path,
-  resolved_target : @path.Path,
-  managed_root : @path.Path,
+  resolved_target : OwnershipResolvedTarget,
+  managed_root : OwnershipManagedRoot,
   source : OwnershipSource,
 ) -> OwnershipEntry raise {
-  guard link.is_absolute() else { fail("ownership link must be absolute") }
-  guard resolved_target.is_absolute() else {
-    fail("ownership resolved target must be absolute")
-  }
-  guard managed_root.is_absolute() else {
-    fail("ownership managed root must be absolute")
-  }
-  let normalized_link = link.normalize()
-  let normalized_resolved_target = resolved_target.normalize()
-  let normalized_managed_root = managed_root.normalize()
-  guard normalized_link.dirname() == normalized_managed_root else {
+  guard link.path.dirname() == managed_root.path else {
     fail("ownership link must be a direct child of its managed root")
   }
-  {
-    link: normalized_link,
-    symlink_target,
-    resolved_target: normalized_resolved_target,
-    managed_root: normalized_managed_root,
-    source,
-  }
+  { link, symlink_target, resolved_target, managed_root, source }
 }
 
 ///|
@@ -122,7 +147,7 @@ pub fn OwnershipState::OwnershipState(
   entries : Array[OwnershipEntry],
 ) -> OwnershipState raise {
   let stored_entries = @immut_hashmap.HashMap(
-    entries.map(entry => (OwnershipLinkIdentity(entry.link), entry)),
+    entries.map(entry => (OwnershipLinkIdentity(entry.link.path), entry)),
   )
   guard stored_entries.length() == entries.length() else {
     fail("ownership links must be unique")

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
@@ -134,45 +134,67 @@ pub impl ToJson for OwnershipSource with fn to_json(self) -> Json {
 }
 
 ///|
+pub impl FromJson for OwnershipLink with fn from_json(json, path) {
+  let value : String = @json.from_json(json, path~)
+  OwnershipLink::OwnershipLink(@path.Path(value)) catch {
+    _ => raise @json.JsonDecodeError((path, "ownership link must be absolute"))
+  }
+}
+
+///|
+pub impl ToJson for OwnershipLink with fn to_json(self) -> Json {
+  self.path.to_string().to_json()
+}
+
+///|
+pub impl FromJson for OwnershipResolvedTarget with fn from_json(json, path) {
+  let value : String = @json.from_json(json, path~)
+  OwnershipResolvedTarget::OwnershipResolvedTarget(@path.Path(value)) catch {
+    _ =>
+      raise @json.JsonDecodeError(
+        (path, "ownership resolved target must be absolute"),
+      )
+  }
+}
+
+///|
+pub impl ToJson for OwnershipResolvedTarget with fn to_json(self) -> Json {
+  self.path.to_string().to_json()
+}
+
+///|
+pub impl FromJson for OwnershipManagedRoot with fn from_json(json, path) {
+  let value : String = @json.from_json(json, path~)
+  OwnershipManagedRoot::OwnershipManagedRoot(@path.Path(value)) catch {
+    _ =>
+      raise @json.JsonDecodeError(
+        (path, "ownership managed root must be absolute"),
+      )
+  }
+}
+
+///|
+pub impl ToJson for OwnershipManagedRoot with fn to_json(self) -> Json {
+  self.path.to_string().to_json()
+}
+
+///|
 pub impl FromJson for OwnershipEntry with fn from_json(json, path) {
-  let link_value : String = @json.from_json(
-    ownership_entry_link_lens.get_or_json_decode_error(json, path),
-    path=ownership_entry_link_lens.add_to_json_path(path),
+  let link : OwnershipLink = ownership_entry_link_lens.decode_from_json(
+    json, path,
   )
-  let symlink_target_value : String = @json.from_json(
-    ownership_entry_symlink_target_lens.get_or_json_decode_error(json, path),
-    path=ownership_entry_symlink_target_lens.add_to_json_path(path),
+  let symlink_target_value : String = ownership_entry_symlink_target_lens.decode_from_json(
+    json, path,
   )
-  let resolved_target_value : String = @json.from_json(
-    ownership_entry_resolved_target_lens.get_or_json_decode_error(json, path),
-    path=ownership_entry_resolved_target_lens.add_to_json_path(path),
+  let resolved_target : OwnershipResolvedTarget = ownership_entry_resolved_target_lens.decode_from_json(
+    json, path,
   )
-  let managed_root_value : String = @json.from_json(
-    ownership_entry_managed_root_lens.get_or_json_decode_error(json, path),
-    path=ownership_entry_managed_root_lens.add_to_json_path(path),
+  let managed_root : OwnershipManagedRoot = ownership_entry_managed_root_lens.decode_from_json(
+    json, path,
   )
-  let source : OwnershipSource = @json.from_json(
-    ownership_entry_source_lens.get_or_json_decode_error(json, path),
-    path=ownership_entry_source_lens.add_to_json_path(path),
+  let source : OwnershipSource = ownership_entry_source_lens.decode_from_json(
+    json, path,
   )
-  let link = @path.Path(link_value)
-  guard link.is_absolute() else {
-    raise ownership_entry_link_lens.json_decode_error(
-      path, "ownership link must be absolute",
-    )
-  }
-  let resolved_target = @path.Path(resolved_target_value)
-  guard resolved_target.is_absolute() else {
-    raise ownership_entry_resolved_target_lens.json_decode_error(
-      path, "ownership resolved target must be absolute",
-    )
-  }
-  let managed_root = @path.Path(managed_root_value)
-  guard managed_root.is_absolute() else {
-    raise ownership_entry_managed_root_lens.json_decode_error(
-      path, "ownership managed root must be absolute",
-    )
-  }
   OwnershipEntry::OwnershipEntry(
     link,
     @path.Path(symlink_target_value),
@@ -190,21 +212,18 @@ pub impl FromJson for OwnershipEntry with fn from_json(json, path) {
 ///|
 pub impl ToJson for OwnershipEntry with fn to_json(self) -> Json {
   let builder = @lens.JsonBuilder::JsonBuilder()
-  ownership_entry_link_lens.set_or_abort(
-    builder,
-    self.link.to_string().to_json(),
-  )
+  ownership_entry_link_lens.set_or_abort(builder, ToJson::to_json(self.link))
   ownership_entry_symlink_target_lens.set_or_abort(
     builder,
     self.symlink_target.to_string().to_json(),
   )
   ownership_entry_resolved_target_lens.set_or_abort(
     builder,
-    self.resolved_target.to_string().to_json(),
+    ToJson::to_json(self.resolved_target),
   )
   ownership_entry_managed_root_lens.set_or_abort(
     builder,
-    self.managed_root.to_string().to_json(),
+    ToJson::to_json(self.managed_root),
   )
   ownership_entry_source_lens.set_or_abort(
     builder,

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
@@ -25,10 +25,14 @@ fn expect_ownership_rejection(
 test "OwnershipState ToJson::to_json - round trips ownership metadata" {
   let state = OwnershipState::OwnershipState([
     OwnershipEntry::OwnershipEntry(
-      "/home/alice/project/.agents/skills/./sync",
+      OwnershipLink::OwnershipLink("/home/alice/project/.agents/skills/./sync"),
       "../../../cache/skills/sync",
-      "/home/alice/.cache/c-plugin/skills/sync",
-      "/home/alice/project/.agents/skills",
+      OwnershipResolvedTarget::OwnershipResolvedTarget(
+        "/home/alice/.cache/c-plugin/skills/sync",
+      ),
+      OwnershipManagedRoot::OwnershipManagedRoot(
+        "/home/alice/project/.agents/skills",
+      ),
       OwnershipSource::github(
         GitHubOwnershipSource::GitHubOwnershipSource(
           GitHubRepository::from_route("OpenAI/Codex"),
@@ -58,8 +62,14 @@ test "OwnershipState ToJson::to_json - round trips local ownership metadata" {
   )
   let state = OwnershipState::OwnershipState([
     OwnershipEntry::OwnershipEntry(
-      "/home/alice/project/.agents/skills/sync", "../../../vendor/c-plugin/skills/sync",
-      "/home/alice/project/vendor/c-plugin/skills/sync", "/home/alice/project/.agents/skills",
+      OwnershipLink::OwnershipLink("/home/alice/project/.agents/skills/sync"),
+      "../../../vendor/c-plugin/skills/sync",
+      OwnershipResolvedTarget::OwnershipResolvedTarget(
+        "/home/alice/project/vendor/c-plugin/skills/sync",
+      ),
+      OwnershipManagedRoot::OwnershipManagedRoot(
+        "/home/alice/project/.agents/skills",
+      ),
       source,
     ),
   ])

--- a/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
@@ -1,4 +1,37 @@
 ///|
+test "Ownership path values OwnershipLink - normalize absolute paths" {
+  inspect(
+    OwnershipLink::OwnershipLink("/workspace/skills/./sync").path.to_string(),
+    content="/workspace/skills/sync",
+  )
+  inspect(
+    OwnershipResolvedTarget::OwnershipResolvedTarget(
+      "/cache/skills/../skills/sync",
+    ).path.to_string(),
+    content="/cache/skills/sync",
+  )
+  inspect(
+    OwnershipManagedRoot::OwnershipManagedRoot("/workspace/./skills").path.to_string(),
+    content="/workspace/skills",
+  )
+}
+
+///|
+test "panic_OwnershipLink OwnershipLink - rejects a relative path" {
+  try! (OwnershipLink::OwnershipLink("skills/sync") |> ignore)
+}
+
+///|
+test "panic_OwnershipResolvedTarget OwnershipResolvedTarget - rejects a relative path" {
+  try! (OwnershipResolvedTarget::OwnershipResolvedTarget("cache/sync") |> ignore)
+}
+
+///|
+test "panic_OwnershipManagedRoot OwnershipManagedRoot - rejects a relative path" {
+  try! (OwnershipManagedRoot::OwnershipManagedRoot("workspace/skills") |> ignore)
+}
+
+///|
 fn github_ownership_source() -> OwnershipSource raise {
   OwnershipSource::github(
     GitHubOwnershipSource::GitHubOwnershipSource(
@@ -12,10 +45,14 @@ fn github_ownership_source() -> OwnershipSource raise {
 ///|
 fn ownership_entry(link : @path.Path) -> OwnershipEntry raise {
   OwnershipEntry::OwnershipEntry(
-    link,
+    OwnershipLink::OwnershipLink(link),
     "../../../cache/skills/sync",
-    "/home/alice/.cache/c-plugin/skills/sync",
-    "/home/alice/project/.agents/skills",
+    OwnershipResolvedTarget::OwnershipResolvedTarget(
+      "/home/alice/.cache/c-plugin/skills/sync",
+    ),
+    OwnershipManagedRoot::OwnershipManagedRoot(
+      "/home/alice/project/.agents/skills",
+    ),
     github_ownership_source(),
   )
 }
@@ -26,7 +63,7 @@ test "OwnershipEntry OwnershipEntry - normalizes absolute paths but preserves sy
     "/home/alice/project/.agents/skills/../skills/sync",
   )
   inspect(
-    entry.link.to_string(),
+    entry.link.path.to_string(),
     content="/home/alice/project/.agents/skills/sync",
   )
   inspect(
@@ -34,11 +71,11 @@ test "OwnershipEntry OwnershipEntry - normalizes absolute paths but preserves sy
     content="../../../cache/skills/sync",
   )
   inspect(
-    entry.resolved_target.to_string(),
+    entry.resolved_target.path.to_string(),
     content="/home/alice/.cache/c-plugin/skills/sync",
   )
   inspect(
-    entry.managed_root.to_string(),
+    entry.managed_root.path.to_string(),
     content="/home/alice/project/.agents/skills",
   )
 }
@@ -53,7 +90,7 @@ test "OwnershipState entries - stores an immutable hash map" {
     "/home/alice/project/.agents/skills/install",
   )
   let expanded_entries = state.entries.add(
-    OwnershipLinkIdentity(added_entry.link),
+    OwnershipLinkIdentity(added_entry.link.path),
     added_entry,
   )
   inspect(entries.length(), content="1")
@@ -76,48 +113,6 @@ test "OwnershipLinkIdentity Compare::compare - uses normalized lexical path orde
   )
   let last = OwnershipLinkIdentity("/home/alice/project/.agents/skills/z")
   inspect(first.compare(last), content="-1")
-}
-
-///|
-test "OwnershipEntry OwnershipEntry - rejects a relative link" {
-  expect_ownership_rejection(
-    fn() -> Unit raise { ownership_entry(".agents/skills/sync") |> ignore },
-    "relative link",
-  )
-}
-
-///|
-test "OwnershipEntry OwnershipEntry - rejects a relative resolved target" {
-  expect_ownership_rejection(
-    fn() -> Unit raise {
-      OwnershipEntry::OwnershipEntry(
-        "/home/alice/project/.agents/skills/sync",
-        "../../../cache/skills/sync",
-        "cache/skills/sync",
-        "/home/alice/project/.agents/skills",
-        github_ownership_source(),
-      )
-      |> ignore
-    },
-    "relative resolved target",
-  )
-}
-
-///|
-test "OwnershipEntry OwnershipEntry - rejects a relative managed root" {
-  expect_ownership_rejection(
-    fn() -> Unit raise {
-      OwnershipEntry::OwnershipEntry(
-        "/home/alice/project/.agents/skills/sync",
-        "../../../cache/skills/sync",
-        "/home/alice/.cache/c-plugin/skills/sync",
-        ".agents",
-        github_ownership_source(),
-      )
-      |> ignore
-    },
-    "relative managed root",
-  )
 }
 
 ///|


### PR DESCRIPTION
## 概要

TOT-110 として ownership path の単一値検証を value object へ集約します。

- `OwnershipLink`、`OwnershipResolvedTarget`、`OwnershipManagedRoot` が絶対パス検証と正規化を所有
- `OwnershipEntry` には link が managed root の直下であるという複数値制約だけを残す
- codec は Lens から各 value object の標準 `FromJson` へ委譲
- wire format と JsonPath を維持

依存PR: #281
Linear: [TOT-110](https://linear.app/totto2727/issue/TOT-110/c-plugin-v2-f3-follow-up-ownership-path検証をvalue-objectへ委譲する)

## 処理フロー

```mermaid
flowchart TD
  A["ownership JSON"] --> B["Lensで各pathを選択"]
  B --> C["Path value object::FromJson"]
  C --> D["絶対パス検証と正規化"]
  D --> E["OwnershipEntry"]
  E --> F["managed root直下のcross-field検証"]
```

## テストケース

```mermaid
flowchart TD
  A["ownership path"] --> B["3種の正常な絶対パス"]
  A --> C["正規化"]
  A --> D["3種の相対パス拒否"]
  A --> E["managed root直下検証"]
  A --> F["正確なJsonPath"]
  B --> G["round-trip"]
  C --> G
  D --> H["typed failure"]
  E --> H
  F --> H
```

## 検証

Exact SHA: `82a46fec7fcefdd19ddd46d12124814c72b9a548`

- native tests: 91/91
- check / release build / format: pass
- 5-lane review: pass
