### PR TITLE
c-plugin v2: OwnershipSource constructor名を対称にする

### DIFF
--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -37,7 +37,7 @@ pub enum OwnershipSource {
 } derive(Eq)
 
 ///|
-pub fn OwnershipSource::github(
+pub fn OwnershipSource::from_github(
   source : GitHubOwnershipSource,
 ) -> OwnershipSource {
   GitHub(source)

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
@@ -66,7 +66,7 @@ pub impl FromJson for OwnershipSource with fn from_json(json, path) {
         ownership_source_skill_lens.get_or_json_decode_error(json, path),
         path=ownership_source_skill_lens.add_to_json_path(path),
       )
-      OwnershipSource::github(
+      OwnershipSource::from_github(
         GitHubOwnershipSource::GitHubOwnershipSource(repository, plugin, skill),
       )
     }

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
@@ -33,7 +33,7 @@ test "OwnershipState ToJson::to_json - round trips ownership metadata" {
       OwnershipManagedRoot::OwnershipManagedRoot(
         "/home/alice/project/.agents/skills",
       ),
-      OwnershipSource::github(
+      OwnershipSource::from_github(
         GitHubOwnershipSource::GitHubOwnershipSource(
           GitHubRepository::from_route("OpenAI/Codex"),
           PluginName::PluginName("c-plugin"),

--- a/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
@@ -33,7 +33,7 @@ test "panic_OwnershipManagedRoot OwnershipManagedRoot - rejects a relative path"
 
 ///|
 fn github_ownership_source() -> OwnershipSource raise {
-  OwnershipSource::github(
+  OwnershipSource::from_github(
     GitHubOwnershipSource::GitHubOwnershipSource(
       GitHubRepository::from_route("OpenAI/Codex"),
       PluginName::PluginName("c-plugin"),


### PR DESCRIPTION
## 概要

TOT-109 として `OwnershipSource` の constructor 名を対称にします。

- `github` を `from_github` へ変更
- 既存の `from_local` と命名を整合
- codec と全call siteを更新
- wire format・domain behaviorは変更しない

依存PR: TOT-110 のPR
Linear: [TOT-109](https://linear.app/totto2727/issue/TOT-109/c-plugin-v2-f3-follow-up-ownershipsource-constructor名を対称にする)

## 処理フロー

```mermaid
flowchart LR
  A["GitHub source"] --> B["OwnershipSource::from_github"]
  C["Local source"] --> D["OwnershipSource::from_local"]
  B --> E["OwnershipSource"]
  D --> E
```

## テストケース

```mermaid
flowchart TD
  A["constructor rename"] --> B["GitHub decode"]
  A --> C["Local decode"]
  A --> D["round-trip"]
  A --> E["旧call site残存なし"]
  B --> F["既存wireを維持"]
  C --> F
  D --> F
  E --> F
```

## 検証

Exact SHA: `289c9b365b49a231023dcd4f69f304fd6951c919`

- native tests: 91/91
- check / release build / format: pass
- 5-lane review: pass
