### PR TITLE
c-plugin v2: OwnershipEntryのcanonical ordering契約を整理する

### DIFF
--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -15,6 +15,21 @@ pub fn GitHubOwnershipSource::GitHubOwnershipSource(
 }
 
 ///|
+pub impl Compare for GitHubOwnershipSource with fn compare(self, other) {
+  let repository = self.repository.compare(other.repository)
+  if repository != 0 {
+    repository
+  } else {
+    let plugin = self.plugin.compare(other.plugin)
+    if plugin != 0 {
+      plugin
+    } else {
+      self.skill.compare(other.skill)
+    }
+  }
+}
+
+///|
 pub struct LocalOwnershipSource {
   repository : RelativeSourcePath
   plugin : PluginName
@@ -31,10 +46,35 @@ pub fn LocalOwnershipSource::LocalOwnershipSource(
 }
 
 ///|
+pub impl Compare for LocalOwnershipSource with fn compare(self, other) {
+  let repository = self.repository.compare(other.repository)
+  if repository != 0 {
+    repository
+  } else {
+    let plugin = self.plugin.compare(other.plugin)
+    if plugin != 0 {
+      plugin
+    } else {
+      self.skill.compare(other.skill)
+    }
+  }
+}
+
+///|
 pub enum OwnershipSource {
   GitHub(GitHubOwnershipSource)
   Local(LocalOwnershipSource)
 } derive(Eq)
+
+///|
+pub impl Compare for OwnershipSource with fn compare(self, other) {
+  match (self, other) {
+    (GitHub(left), GitHub(right)) => left.compare(right)
+    (GitHub(_), Local(_)) => -1
+    (Local(_), GitHub(_)) => 1
+    (Local(left), Local(right)) => left.compare(right)
+  }
+}
 
 ///|
 pub fn OwnershipSource::from_github(
@@ -62,6 +102,11 @@ pub fn OwnershipLink::OwnershipLink(path : @path.Path) -> OwnershipLink raise {
 }
 
 ///|
+pub impl Compare for OwnershipLink with fn compare(self, other) {
+  self.path.to_string().lexical_compare(other.path.to_string())
+}
+
+///|
 pub struct OwnershipResolvedTarget {
   path : @path.Path
 } derive(Eq)
@@ -77,6 +122,11 @@ pub fn OwnershipResolvedTarget::OwnershipResolvedTarget(
 }
 
 ///|
+pub impl Compare for OwnershipResolvedTarget with fn compare(self, other) {
+  self.path.to_string().lexical_compare(other.path.to_string())
+}
+
+///|
 pub struct OwnershipManagedRoot {
   path : @path.Path
 } derive(Eq)
@@ -89,6 +139,11 @@ pub fn OwnershipManagedRoot::OwnershipManagedRoot(
     fail("ownership managed root must be absolute")
   }
   { path: path.normalize() }
+}
+
+///|
+pub impl Compare for OwnershipManagedRoot with fn compare(self, other) {
+  self.path.to_string().lexical_compare(other.path.to_string())
 }
 
 ///|
@@ -112,6 +167,33 @@ pub fn OwnershipEntry::OwnershipEntry(
     fail("ownership link must be a direct child of its managed root")
   }
   { link, symlink_target, resolved_target, managed_root, source }
+}
+
+///|
+pub impl Compare for OwnershipEntry with fn compare(self, other) {
+  let link = self.link.compare(other.link)
+  if link != 0 {
+    link
+  } else {
+    let symlink_target = self.symlink_target
+      .to_string()
+      .lexical_compare(other.symlink_target.to_string())
+    if symlink_target != 0 {
+      symlink_target
+    } else {
+      let resolved_target = self.resolved_target.compare(other.resolved_target)
+      if resolved_target != 0 {
+        resolved_target
+      } else {
+        let managed_root = self.managed_root.compare(other.managed_root)
+        if managed_root != 0 {
+          managed_root
+        } else {
+          self.source.compare(other.source)
+        }
+      }
+    }
+  }
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
@@ -259,9 +259,8 @@ pub impl FromJson for OwnershipState with fn from_json(json, path) {
 ///|
 pub impl ToJson for OwnershipState with fn to_json(self) -> Json {
   let builder = @lens.JsonBuilder::JsonBuilder()
-  let stored_entries = self.entries.to_array()
-  stored_entries.sort_by((left, right) => left.0.compare(right.0))
-  let entries = stored_entries.map(entry => entry.1)
+  let entries = self.entries.values().collect()
+  entries.sort()
   ownership_state_version_lens.set_or_abort(
     builder,
     self.version.to_string().to_json(),

--- a/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
@@ -44,16 +44,73 @@ fn github_ownership_source() -> OwnershipSource raise {
 
 ///|
 fn ownership_entry(link : @path.Path) -> OwnershipEntry raise {
+  ownership_entry_with(
+    link,
+    "../../../cache/skills/sync",
+    "/home/alice/.cache/c-plugin/skills/sync",
+    github_ownership_source(),
+  )
+}
+
+///|
+fn ownership_entry_with(
+  link : @path.Path,
+  symlink_target : @path.Path,
+  resolved_target : @path.Path,
+  source : OwnershipSource,
+) -> OwnershipEntry raise {
   OwnershipEntry::OwnershipEntry(
     OwnershipLink::OwnershipLink(link),
-    "../../../cache/skills/sync",
-    OwnershipResolvedTarget::OwnershipResolvedTarget(
-      "/home/alice/.cache/c-plugin/skills/sync",
-    ),
+    symlink_target,
+    OwnershipResolvedTarget::OwnershipResolvedTarget(resolved_target),
     OwnershipManagedRoot::OwnershipManagedRoot(
       "/home/alice/project/.agents/skills",
     ),
-    github_ownership_source(),
+    source,
+  )
+}
+
+///|
+test "OwnershipEntry Compare::compare - uses every Eq field as a tie breaker" {
+  let link = "/home/alice/project/.agents/skills/sync"
+  let base = ownership_entry(link)
+  let changed_symlink = ownership_entry_with(
+    link,
+    "../../../other-cache/skills/sync",
+    base.resolved_target.path,
+    base.source,
+  )
+  let changed_target = ownership_entry_with(
+    link,
+    base.symlink_target,
+    "/home/alice/.cache/c-plugin/skills/other-sync",
+    base.source,
+  )
+  let changed_source = ownership_entry_with(
+    link,
+    base.symlink_target,
+    base.resolved_target.path,
+    OwnershipSource::from_local(
+      LocalOwnershipSource::LocalOwnershipSource(
+        RelativeSourcePath::RelativeSourcePath("vendor/c-plugin"),
+        PluginName::PluginName("c-plugin"),
+        SkillName::SkillName("sync"),
+      ),
+    ),
+  )
+  inspect(base.compare(base), content="0")
+  inspect(base.compare(changed_symlink) != 0, content="true")
+  inspect(base.compare(changed_target) != 0, content="true")
+  inspect(base.compare(changed_source) != 0, content="true")
+  inspect(base != changed_symlink, content="true")
+  inspect(base != changed_target, content="true")
+  inspect(base != changed_source, content="true")
+  inspect(
+    OwnershipManagedRoot::OwnershipManagedRoot("/workspace/a").compare(
+      OwnershipManagedRoot::OwnershipManagedRoot("/workspace/b"),
+    ) !=
+    0,
+    content="true",
   )
 }
 


### PR DESCRIPTION
## 概要

[TOT-103](https://linear.app/totto2727/issue/TOT-103/c-plugin-v2-f3-follow-up-ownershipentryのcanonical-ordering契約を整理する) として ownership state の順序契約をJSON出力境界へ整理します。

* `OwnershipEntry` と構成型に `Compare` を実装
* `Compare == 0` と `Eq` が一致するよう全fieldをtie-breakerに使用
* 内部の immutable HashMap は順序を保持しない
* JSON出力時だけ values をsortし、hash iterationに依存しないcanonical outputを生成

依存PR: [TOT-109](https://linear.app/totto2727/issue/TOT-109/c-plugin-v2-f3-follow-up-ownershipsource-constructor名を対称にする) のPR<br>Linear: [TOT-103](https://linear.app/totto2727/issue/TOT-103/c-plugin-v2-f3-follow-up-ownershipentry%E3%81%AEcanonical-ordering%E5%A5%91%E7%B4%84%E3%82%92%E6%95%B4%E7%90%86%E3%81%99%E3%82%8B)

## 処理フロー

```mermaid
flowchart TD
  A["immutable HashMap"] --> B["valuesを収集"]
  B --> C["OwnershipEntry::Compareでsort"]
  C --> D["canonical JSON array"]
  E["domain equality"] --> F["順序非依存"]
```

## テストケース

```mermaid
flowchart TD
  A["ordering contract"] --> B["link primary key"]
  A --> C["全Eq fieldのtie-breaker"]
  A --> D["source variant ordering"]
  A --> E["異なるmap挿入順"]
  B --> F["deterministic JSON"]
  C --> F
  D --> F
  E --> F
  E --> G["domain equalityは同一"]
```

## 検証

Exact SHA: `9cc8fcdbf696c3f86aa73e56e6feb7c44dfab8d7`

* native tests: 92/92
* check / release build / format: pass
* 5-lane review: pass