### PR TITLE
c-plugin v2: MoonBit toolchainを0.10.5へ更新する

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784541274,
-        "narHash": "sha256-jtOcz5r6V/7U89ySbicd+0SWD+LqlWrWP9Qd+GZRQuI=",
+        "lastModified": 1786182444,
+        "narHash": "sha256-sFX4ibSK6w5PyFQjU7tEp4brSG2G7Au0FGzf0M/49Ac=",
         "owner": "totto2727",
         "repo": "moonbit-overlay",
-        "rev": "bdae408fa509726dd819c962c4e712cc0d0380af",
+        "rev": "43ec4416e8d2c818cbb70d2d3e2b33c6cd9cf000",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要

TOT-149 として、monorepoが使用するmoonbit-overlayをMoonBit 0.10.5を含むrevisionへ更新します。

- `flake.lock` の `moonbit-overlay` revisionだけを更新
- `flake.nix` は既存どおり `pkgs.moonbit-bin.moonbit.latest` を参照
- production source・MoonBit dependency・package manifestは変更しない
- overlay側の前提PR: [totto2727/moonbit-overlay#2](https://github.com/totto2727/moonbit-overlay/pull/2)
- 前提Linear: [TOT-150](https://linear.app/totto2727/issue/TOT-150/moonbit-overlay-moonbit-0105-toolchain-recordを追加する)

Linear: [TOT-149](https://linear.app/totto2727/issue/TOT-149/c-plugin-v2-prerequisite-moonbit-toolchainをmoonbitlangx0448対応版へ更新する)

## 処理フロー

```mermaid
flowchart LR
  A["moonbit-overlay #2"] --> B["flake.lock revision"]
  B --> C["Nix devShell"]
  C --> D["moonbit_latest"]
  D --> E["moonc v0.10.5"]
  E --> F["moonbitlang/x@0.4.48"]
```

## テストケース

```mermaid
flowchart TD
  A["更新済みflake.lock"] --> B["nix flake check --no-build"]
  A --> C["nix develop --command moon version"]
  C --> D["moonc v0.10.5"]
  A --> E["x@0.4.48 c-plugin-v2"]
  E --> F["check"]
  E --> G["native tests 88/88"]
  E --> H["release build"]
```

## 検証

Exact SHA: `34017417ae74b84061d4161d6dc98a38cd5fbe8a`

- `nix flake check --no-build`: pass on aarch64-darwin
- `nix develop --command moon version --all`: `moonc v0.10.5+5e7afb0c0`
- `moonbitlang/x@0.4.48` c-plugin-v2 check: pass
- native tests: 88/88
- release build: pass
- Vite+ wrapper: pre-existing unresolved `@totto2727/fp/vite` because this isolated worktree has not run workspace setup; direct MoonBit gates were used
