### PR TITLE
MoonBitパッケージ公開用Actionを追加

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -6,5 +6,12 @@ plan_mode_reasoning_effort = "xhigh"
 command = "linear-mcp"
 args = []
 
+# Managed by LazyCodex: multi_agent_v2 is re-disabled on every Codex session start
+# because enabling it fails every turn with HTTP 400 (openai/codex#26753).
+# Opt out: LAZYCODEX_CONFIG_MIGRATION_DISABLED=1 (or OMO_CODEX_CONFIG_MIGRATION_DISABLED=1).
 [features.multi_agent_v2]
+enabled = false
 max_concurrent_threads_per_session = 16
+
+[agents]
+max_threads = 1000

--- a/.github/actions/publish-moonbit/action.yaml
+++ b/.github/actions/publish-moonbit/action.yaml
@@ -1,0 +1,86 @@
+# Based on https://github.com/cogna-dev/moonbit-actions/blob/11d02666d9a2577ab0e692ea8f9e68507d0669a5/publish/action.yml
+name: Publish MoonBit package
+description: Publish a MoonBit package to the mooncakes.io registry, skipping an already-published version.
+
+inputs:
+  token:
+    description: >
+      API token for the mooncakes.io registry. Store this as a repository
+      secret and pass it as `secrets.MOONCAKES_TOKEN`.
+    required: true
+  package-path:
+    description: >
+      Path to the package directory that contains moon.pkg.
+      Defaults to the repository root.
+    required: false
+    default: .
+  dry-run:
+    description: >
+      If true, runs `moon publish --dry-run` instead of `moon publish`.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Save credentials and publish package
+      shell: bash
+      working-directory: ${{ inputs.package-path }}
+      env:
+        MOONCAKES_TOKEN: ${{ inputs.token }}
+        PUBLISH_DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        set -euo pipefail
+
+        eval "$(nix print-dev-env "$GITHUB_WORKSPACE#default")"
+
+        mkdir -p ~/.moon
+        tmp_credentials="$(mktemp -p ~/.moon credentials.json.XXXXXX)"
+        publish_log="$(mktemp)"
+        trap 'rm -f ~/.moon/credentials.json "$tmp_credentials" "$publish_log"' EXIT
+
+        chmod 600 "$tmp_credentials"
+        printf '%s' "$MOONCAKES_TOKEN" | base64 -d > "$tmp_credentials" || { echo "Failed to decode MOONCAKES_TOKEN (expected base64-encoded credentials)" >&2; exit 1; }
+        test -s "$tmp_credentials" || { echo "Decoded credentials file is empty" >&2; exit 1; }
+        mv -f "$tmp_credentials" ~/.moon/credentials.json
+
+        moon whoami
+        moon update
+
+        publish_args=()
+        case "${PUBLISH_DRY_RUN,,}" in
+          true|1|yes)
+            publish_args+=(--dry-run)
+            ;;
+          false|0|no|'')
+            ;;
+          *)
+            echo "Invalid dry-run value: '$PUBLISH_DRY_RUN'. Use true/false." >&2
+            exit 1
+            ;;
+        esac
+
+        set +e
+        moon publish "${publish_args[@]}" 2>&1 | tee "$publish_log"
+        pipeline_status=("${PIPESTATUS[@]}")
+        set -e
+
+        moon_status="${pipeline_status[0]}"
+        tee_status="${pipeline_status[1]}"
+
+        if [[ "$tee_status" -ne 0 ]]; then
+          exit "$tee_status"
+        fi
+
+        if [[ "$moon_status" -eq 0 ]]; then
+          exit 0
+        fi
+
+        if grep -Fq "409 Conflict" "$publish_log" &&
+          grep -Fq "Version Error:" "$publish_log" &&
+          grep -Fq "is duplicated with an existing version" "$publish_log"; then
+          echo "MoonBit module version is already published; continuing."
+          exit 0
+        fi
+
+        exit "$moon_status"

--- a/.github/actions/publish-moonbit/action.yaml
+++ b/.github/actions/publish-moonbit/action.yaml
@@ -18,7 +18,7 @@ inputs:
     description: >
       If true, runs `moon publish --dry-run` instead of `moon publish`.
     required: false
-    default: "false"
+    default: 'false'
 
 runs:
   using: composite


### PR DESCRIPTION
## 概要

- MoonBitパッケージをmooncakes.ioへ公開するComposite Actionを追加します。
- 認証情報を安全に配置し、`moon whoami`で確認した後、連続公開に必要な`moon update`を必ず実行します。
- `dry-run`をサポートし、同一バージョンが公開済みの場合だけ成功として継続します。
- その他のpublish失敗とログ出力失敗は元の終了コードを維持します。

## 参照元

- [cogna-dev/moonbit-actions publish Action](https://github.com/cogna-dev/moonbit-actions/blob/11d02666d9a2577ab0e692ea8f9e68507d0669a5/publish/action.yml)

## 処理フロー

```mermaid
flowchart TD
  A[Action開始] --> B[Nix開発環境を読み込む]
  B --> C[認証情報をデコードして配置する]
  C --> D[moon whoamiで認証を確認する]
  D --> E[moon updateを実行する]
  E --> F{dry-run値は有効か}
  F -- いいえ --> G[失敗]
  F -- はい --> H[moon publishを実行する]
  H --> I{publishは成功したか}
  I -- はい --> J[成功]
  I -- 公開済みバージョン --> J
  I -- その他の失敗 --> G
```

## 検証

- `vp fmt .github/actions/publish-moonbit/action.yaml --check`
- ActionメタデータのYAML読み込みと埋め込みBashの構文確認
- 通常成功、公開済みバージョン、通常失敗、dry-runの4経路をモック実行し、`moon update`がpublishより前に呼ばれることを確認

## CI status

- 最新コミット: `d64b71abda6af734dcb43fda838e3e70dd637a62`
- 最新`check`ジョブ: success ([run 31353267851](https://github.com/totto2727-org/monorepo/actions/runs/31353267851))
- 再試行履歴: 初回commit `825eeaaf`はYAMLフォーマット違反でfailure、修正commit `d64b71ab`でsuccess
