### PR TITLE
[TOT-154] marketplace codecとfile readの責務を分離

### DIFF
--- a/mbt/app/c-plugin-v2/src/marketplace.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace.mbt
@@ -76,6 +76,18 @@ impl @json.FromJson for ClaudeMarketplace with fn from_json(json, path) {
 }
 
 ///|
+/// Encode the canonical minimal Claude/Cursor marketplace shape. Plugin declaration order is preserved and unmodeled input metadata is omitted.
+pub impl ToJson for ClaudeMarketplace with fn to_json(self) {
+  let builder = @lens.JsonBuilder::JsonBuilder()
+  marketplace_name_lens.set_or_abort(builder, self.name.to_json())
+  marketplace_plugins_lens.set_or_abort(
+    builder,
+    self.plugins.iter().to_array().to_json(),
+  )
+  builder.to_json()
+}
+
+///|
 #alias(CursorMarketplacePlugin)
 struct ClaudeMarketplacePlugin {
   name : PluginName
@@ -91,6 +103,14 @@ impl @json.FromJson for ClaudeMarketplacePlugin with fn from_json(json, path) {
     json, path,
   )
   { name, source }
+}
+
+///|
+pub impl ToJson for ClaudeMarketplacePlugin with fn to_json(self) {
+  let builder = @lens.JsonBuilder::JsonBuilder()
+  marketplace_plugin_name_lens.set_or_abort(builder, self.name.to_json())
+  marketplace_plugin_source_lens.set_or_abort(builder, self.source.to_json())
+  builder.to_json()
 }
 
 ///|
@@ -118,6 +138,18 @@ impl @json.FromJson for CodexMarketplace with fn from_json(json, path) {
 }
 
 ///|
+/// Encode the canonical minimal Codex marketplace shape. Plugin declaration order is preserved and unmodeled input metadata is omitted.
+pub impl ToJson for CodexMarketplace with fn to_json(self) {
+  let builder = @lens.JsonBuilder::JsonBuilder()
+  marketplace_name_lens.set_or_abort(builder, self.name.to_json())
+  marketplace_plugins_lens.set_or_abort(
+    builder,
+    self.plugins.iter().to_array().to_json(),
+  )
+  builder.to_json()
+}
+
+///|
 struct CodexMarketplacePlugin {
   name : PluginName
   source : CodexMarketplaceSource
@@ -132,6 +164,17 @@ impl @json.FromJson for CodexMarketplacePlugin with fn from_json(json, path) {
     json, path,
   )
   { name, source }
+}
+
+///|
+pub impl ToJson for CodexMarketplacePlugin with fn to_json(self) {
+  let builder = @lens.JsonBuilder::JsonBuilder()
+  marketplace_plugin_name_lens.set_or_abort(builder, self.name.to_json())
+  marketplace_plugin_source_lens.set_or_abort(
+    builder,
+    ToJson::to_json(self.source),
+  )
+  builder.to_json()
 }
 
 ///|
@@ -158,6 +201,13 @@ impl @json.FromJson for CodexMarketplaceSourceKind with fn from_json(json, path)
 }
 
 ///|
+pub impl ToJson for CodexMarketplaceSourceKind with fn to_json(self) {
+  match self {
+    CodexMarketplaceSourceKind::Local => "local".to_json()
+  }
+}
+
+///|
 impl @json.FromJson for CodexMarketplaceSource with fn from_json(json, path) {
   let source : CodexMarketplaceSourceKind = codex_source_kind_lens.decode_from_json(
     json, path,
@@ -166,6 +216,14 @@ impl @json.FromJson for CodexMarketplaceSource with fn from_json(json, path) {
     json, path,
   )
   { source, path: plugin_path }
+}
+
+///|
+pub impl ToJson for CodexMarketplaceSource with fn to_json(self) {
+  let builder = @lens.JsonBuilder::JsonBuilder()
+  codex_source_kind_lens.set_or_abort(builder, ToJson::to_json(self.source))
+  codex_source_path_lens.set_or_abort(builder, self.path.to_json())
+  builder.to_json()
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/marketplace_file.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace_file.mbt
@@ -1,0 +1,24 @@
+///|
+/// Typed failures from the marketplace file-read boundary.
+pub(all) suberror MarketplaceReadError {
+  IO(path~ : @path.Path, reason~ : String)
+  Syntax(path~ : @path.Path, cause~ : @json.ParseError)
+  Validation(path~ : @path.Path, cause~ : @json.JsonDecodeError)
+} derive(Debug)
+
+///|
+/// Read and decode a marketplace without performing property-level decoding at the I/O boundary.
+pub async fn read_marketplace_file(
+  path : @path.Path,
+  kind : MarketplaceKind,
+) -> Marketplace raise MarketplaceReadError {
+  let text = @fs.read_file(path.to_string()).text() catch {
+    error => raise IO(path~, reason=error.to_string())
+  }
+  let json = @json.parse(text) catch {
+    error => raise Syntax(path~, cause=error)
+  }
+  Marketplace::from_json(kind, json) catch {
+    error => raise Validation(path~, cause=error)
+  }
+}

--- a/mbt/app/c-plugin-v2/src/marketplace_file_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace_file_wbtest.mbt
@@ -1,0 +1,68 @@
+///|
+async test "read_marketplace_file - reads parses and decodes a marketplace" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-marketplace-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let path = root.join("marketplace.json")
+    let text =
+      #|{"name":"test","plugins":[{"name":"second","source":"plugins/second"},{"name":"first","source":"plugins/first"}]}
+    @fs.write_file(path.to_string(), text, create_mode=CreateNew)
+    let marketplace = read_marketplace_file(path, MarketplaceKind::claude())
+    inspect(marketplace.name, content="test")
+    debug_inspect(
+      marketplace.plugins.map(plugin => plugin.name.value),
+      content="<ReadOnlyArray: [\"second\", \"first\"]>",
+    )
+  }
+}
+
+///|
+async test "read_marketplace_file - reports filesystem failure separately" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-marketplace-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let path = root.join("missing.json")
+    try read_marketplace_file(path, MarketplaceKind::cursor()) |> ignore catch {
+      MarketplaceReadError::IO(path=failed_path, reason=_) =>
+        inspect(failed_path.to_string(), content=path.to_string())
+      _ => fail("expected MarketplaceReadError::IO")
+    }
+  }
+}
+
+///|
+async test "read_marketplace_file - reports JSON syntax failure separately" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-marketplace-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let path = root.join("marketplace.json")
+    @fs.write_file(path.to_string(), "{", create_mode=CreateNew)
+    try read_marketplace_file(path, MarketplaceKind::claude()) |> ignore catch {
+      MarketplaceReadError::Syntax(path=failed_path, cause=_) =>
+        inspect(failed_path.to_string(), content=path.to_string())
+      _ => fail("expected MarketplaceReadError::Syntax")
+    }
+  }
+}
+
+///|
+async test "read_marketplace_file - preserves validation JsonPath" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-marketplace-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let path = root.join("marketplace.json")
+    let text =
+      #|{"name":"test","plugins":[{"source":"plugins/first"}]}
+    @fs.write_file(path.to_string(), text, create_mode=CreateNew)
+    try read_marketplace_file(path, MarketplaceKind::claude()) |> ignore catch {
+      MarketplaceReadError::Validation(
+        path=failed_path,
+        cause=@json.JsonDecodeError::JsonDecodeError((json_path, _))
+      ) => {
+        inspect(failed_path.to_string(), content=path.to_string())
+        inspect(json_path.to_string(), content="/plugins/0/name")
+      }
+      _ => fail("expected MarketplaceReadError::Validation")
+    }
+  }
+}

--- a/mbt/app/c-plugin-v2/src/marketplace_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace_wbtest.mbt
@@ -62,6 +62,69 @@ test "format-specific marketplace models decode complete validated values" {
 }
 
 ///|
+test "ClaudeMarketplace ToJson - emits canonical minimal JSON and roundtrips in declaration order" {
+  let text =
+    #|{"plugins":[{"source":"./plugins/first","name":"first"},{"source":"plugins/second","name":"second"}],"name":"test","description":"ignored"}
+  let marketplace : ClaudeMarketplace = @json.from_json(@json.parse(text))
+  let encoded = ToJson::to_json(marketplace)
+  @json.json_inspect(encoded, content={
+    "name": "test",
+    "plugins": [
+      { "name": "first", "source": "plugins/first" },
+      { "name": "second", "source": "plugins/second" },
+    ],
+  })
+  let decoded : ClaudeMarketplace = @json.from_json(encoded)
+  @json.json_inspect(ToJson::to_json(decoded), content={
+    "name": "test",
+    "plugins": [
+      { "name": "first", "source": "plugins/first" },
+      { "name": "second", "source": "plugins/second" },
+    ],
+  })
+}
+
+///|
+test "CursorMarketplace ToJson - emits canonical minimal JSON and roundtrips" {
+  let text =
+    #|{"name":"test","plugins":[{"name":"first","source":"plugins/first"}]}
+  let marketplace : CursorMarketplace = @json.from_json(@json.parse(text))
+  let encoded = ToJson::to_json(marketplace)
+  let decoded : CursorMarketplace = @json.from_json(encoded)
+  @json.json_inspect(ToJson::to_json(decoded), content={
+    "name": "test",
+    "plugins": [{ "name": "first", "source": "plugins/first" }],
+  })
+}
+
+///|
+test "CodexMarketplace ToJson - emits canonical minimal JSON and roundtrips" {
+  let text =
+    #|{"plugins":[{"source":{"path":"./plugins/first","source":"local"},"name":"first","category":"ignored"}],"name":"test"}
+  let marketplace : CodexMarketplace = @json.from_json(@json.parse(text))
+  let encoded = ToJson::to_json(marketplace)
+  @json.json_inspect(encoded, content={
+    "name": "test",
+    "plugins": [
+      {
+        "name": "first",
+        "source": { "source": "local", "path": "plugins/first" },
+      },
+    ],
+  })
+  let decoded : CodexMarketplace = @json.from_json(encoded)
+  @json.json_inspect(ToJson::to_json(decoded), content={
+    "name": "test",
+    "plugins": [
+      {
+        "name": "first",
+        "source": { "source": "local", "path": "plugins/first" },
+      },
+    ],
+  })
+}
+
+///|
 test "Marketplace FromJson - malformed required field preserves JSON path" {
   let text =
     #|{"name":"test","plugins":[{"source":"./plugins/first"}]}


### PR DESCRIPTION
## 概要

[TOT-154](https://linear.app/totto2727/issue/TOT-154/c-plugin-v2-m3-m1-follow-up-codecとfile-readの責務を分離する)として、marketplace codecとfilesystem readの責務を分離します。

## 方針

- 形式別modelと`FromJson`/`ToJson`を同じdomain fileへ配置します。
- `read_marketplace_file`はread、JSON parse、標準decodeへの委譲だけを担当します。
- I/O、syntax、validationをtyped errorで区別し、元の`JsonPath`を保持します。
- canonical outputは宣言順を維持し、未model metadataを出力しません。

```mermaid
flowchart LR
  A["File Path"] --> B["read_marketplace_file"]
  B --> C["Read text"]
  C --> D["JSON parse"]
  D --> E["Marketplace::from_json"]
  E --> F["Typed Marketplace"]
  B --> G["IO error"]
  D --> H["Syntax error"]
  E --> I["Validation error + JsonPath"]
```

## テストケース

```mermaid
flowchart TD
  A["Marketplace"] --> B["Claude/Cursor canonical round trip"]
  A --> C["Codex canonical round trip"]
  D["File read"] --> E["Success + declaration order"]
  D --> F["Missing file"]
  D --> G["Malformed JSON"]
  D --> H["Nested validation error"]
```

- native tests: 152/152 PASS
- format / deny-warn check / release build / diff check: PASS
- exact SHA review: 5/5 PASS

## 依存関係

TOT-101とTOT-117はmainへmerge済みです。TOT-153とは機能・ファイル依存がないため、独立した`main`向けPRです。

## 参考資料

- [MoonBit error handling](https://docs.moonbitlang.com/en/stable/language/error-handling.html)

## CI

- Latest commit: `e0d112f04a80a6b5ded8eb36ee8a994b63ee5bac`
- Status: PENDING