### PR TITLE
[TOT-153] repository root検証をValue Objectへ移行

### DIFF
--- a/mbt/app/c-plugin-v2/src/marketplace_resolution.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace_resolution.mbt
@@ -1,4 +1,25 @@
 ///|
+pub(all) suberror RepositoryRootError {
+  RelativeRepositoryRoot(path~ : @path.Path)
+} derive(Debug, Eq)
+
+///|
+pub struct RepositoryRoot {
+  path : @path.Path
+} derive(Eq)
+
+///|
+pub fn RepositoryRoot::RepositoryRoot(
+  path : @path.Path,
+) -> RepositoryRoot raise RepositoryRootError {
+  let normalized = path.normalize()
+  guard normalized.is_absolute() else {
+    raise RelativeRepositoryRoot(path=normalized)
+  }
+  { path: normalized }
+}
+
+///|
 pub struct ResolvedSkill {
   plugin_name : PluginName
   plugin_path : RelativePluginPath
@@ -8,23 +29,18 @@ pub struct ResolvedSkill {
 
 ///|
 pub(all) suberror SkillResolutionError {
-  RelativeRepositoryRoot(path~ : @path.Path)
   IO(path~ : @path.Path, reason~ : String)
   InvalidSkillName(path~ : @path.Path, reason~ : String)
 } derive(Debug, Eq)
 
 ///|
 pub async fn resolve_marketplace_skills(
-  repository_root : @path.Path,
+  repository_root : RepositoryRoot,
   marketplace : Marketplace,
 ) -> ReadOnlyArray[ResolvedSkill] raise SkillResolutionError {
-  guard repository_root.is_absolute() else {
-    raise RelativeRepositoryRoot(path=repository_root)
-  }
-  let normalized_root = repository_root.normalize()
   let resolved = []
   for plugin in marketplace.plugins {
-    let plugin_skills = resolve_plugin_skills(normalized_root, plugin)
+    let plugin_skills = resolve_plugin_skills(repository_root, plugin)
     resolved.push_iter(plugin_skills.iter())
   }
   ReadOnlyArray::from_array(resolved)
@@ -32,10 +48,12 @@ pub async fn resolve_marketplace_skills(
 
 ///|
 async fn resolve_plugin_skills(
-  repository_root : @path.Path,
+  repository_root : RepositoryRoot,
   plugin : MarketplacePlugin,
 ) -> Array[ResolvedSkill] raise SkillResolutionError {
-  let skills_directory = repository_root.join(plugin.path.path).join("skills")
+  let skills_directory = repository_root.path
+    .join(plugin.path.path)
+    .join("skills")
   let entries = @fs.readdir(
     skills_directory.to_string(),
     include_hidden=false,

--- a/mbt/app/c-plugin-v2/src/marketplace_resolution_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace_resolution_wbtest.mbt
@@ -27,6 +27,25 @@ fn test_marketplace(plugins : Array[(String, String)]) -> Marketplace raise {
 }
 
 ///|
+test "RepositoryRoot RepositoryRoot - normalizes an absolute path" {
+  let root = RepositoryRoot::RepositoryRoot(
+    @path.Path("/synthetic/repository/./plugins/.."),
+  )
+  inspect(root.path.to_string(), content="/synthetic/repository")
+}
+
+///|
+test "RepositoryRoot RepositoryRoot - reports a normalized relative path" {
+  let relative = @path.Path("repository/../relative")
+  try RepositoryRoot::RepositoryRoot(relative) catch {
+    RepositoryRootError::RelativeRepositoryRoot(path~) =>
+      inspect(path.to_string(), content="relative")
+  } noraise {
+    _ => fail("relative repository root must fail")
+  }
+}
+
+///|
 async test "MarketplaceResolution resolve_marketplace_skills - preserves plugin and sorted skill order" {
   @async.with_task_group() <| group => {
     let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-resolution-")
@@ -38,7 +57,10 @@ async test "MarketplaceResolution resolve_marketplace_skills - preserves plugin 
       ("plugin-b", "plugins/b"),
       ("plugin-a", "plugins/a"),
     ])
-    let resolved = resolve_marketplace_skills(root, marketplace)
+    let resolved = resolve_marketplace_skills(
+      RepositoryRoot::RepositoryRoot(root),
+      marketplace,
+    )
     debug_inspect(
       resolved.map(skill => {
         "\{skill.plugin_name.value}|\{skill.plugin_path.path.to_string()}|\{skill.skill_name.value}|\{skill.skill_path.to_string()}"
@@ -66,15 +88,15 @@ async test "MarketplaceResolution resolve_marketplace_skills - consumes every M0
     let codex =
       #|{"name":"test","plugins":[{"name":"plugin","source":{"source":"local","path":"plugins/p"}}]}
     let claude = resolve_marketplace_skills(
-      root,
+      RepositoryRoot::RepositoryRoot(root),
       Marketplace::from_json(MarketplaceKind::claude(), @json.parse(strings)),
     )
     let cursor = resolve_marketplace_skills(
-      root,
+      RepositoryRoot::RepositoryRoot(root),
       Marketplace::from_json(MarketplaceKind::cursor(), @json.parse(strings)),
     )
     let codex_result = resolve_marketplace_skills(
-      root,
+      RepositoryRoot::RepositoryRoot(root),
       Marketplace::from_json(MarketplaceKind::codex(), @json.parse(codex)),
     )
     inspect(claude == cursor && cursor == codex_result, content="true")
@@ -88,7 +110,7 @@ async test "MarketplaceResolution resolve_marketplace_skills - missing skills di
     group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
     create_test_skill(root, "plugins/later", "valid")
     let resolved = resolve_marketplace_skills(
-      root,
+      RepositoryRoot::RepositoryRoot(root),
       test_marketplace([
         ("missing", "plugins/missing"),
         ("later", "plugins/later"),
@@ -114,7 +136,7 @@ async test "MarketplaceResolution resolve_marketplace_skills - filters non-skill
       create_mode=CreateNew,
     )
     let resolved = resolve_marketplace_skills(
-      root,
+      RepositoryRoot::RepositoryRoot(root),
       test_marketplace([("plugin", "plugins/p")]),
     )
     inspect(resolved.length(), content="1")
@@ -130,7 +152,7 @@ async test "MarketplaceResolution resolve_marketplace_skills - shared names acro
     create_test_skill(root, "plugins/a", "shared")
     create_test_skill(root, "plugins/b", "shared")
     let resolved = resolve_marketplace_skills(
-      root,
+      RepositoryRoot::RepositoryRoot(root),
       test_marketplace([("a", "plugins/a"), ("b", "plugins/b")]),
     )
     debug_inspect(
@@ -149,7 +171,7 @@ async test "MarketplaceResolution resolve_marketplace_skills - invalid discovere
     let candidate = root.join("plugins/p/skills").join("bad\\name")
     try
       resolve_marketplace_skills(
-        root,
+        RepositoryRoot::RepositoryRoot(root),
         test_marketplace([("plugin", "plugins/p")]),
       )
     catch {
@@ -172,7 +194,7 @@ async test "MarketplaceResolution resolve_marketplace_skills - file at skills pa
     @fs.write_file(skills.to_string(), "file", create_mode=CreateNew)
     try
       resolve_marketplace_skills(
-        root,
+        RepositoryRoot::RepositoryRoot(root),
         test_marketplace([("plugin", "plugins/p")]),
       )
     catch {
@@ -198,7 +220,10 @@ async test "MarketplaceResolution resolve_marketplace_skills - input and output 
       ),
     ]
     let marketplace = Marketplace::Marketplace("test", caller)
-    let resolved = resolve_marketplace_skills(root, marketplace)
+    let resolved = resolve_marketplace_skills(
+      RepositoryRoot::RepositoryRoot(root),
+      marketplace,
+    )
     caller.clear()
     inspect(marketplace.plugins.length(), content="1")
     inspect(resolved.length(), content="1")
@@ -214,8 +239,14 @@ async test "MarketplaceResolution resolve_marketplace_skills - normalizes dotted
     create_test_skill(root, "plugins/p", "stable")
     let marketplace = test_marketplace([("plugin", "plugins/p")])
     inspect(
-      resolve_marketplace_skills(root, marketplace) ==
-      resolve_marketplace_skills(root.join("."), marketplace),
+      resolve_marketplace_skills(
+        RepositoryRoot::RepositoryRoot(root),
+        marketplace,
+      ) ==
+      resolve_marketplace_skills(
+        RepositoryRoot::RepositoryRoot(root.join(".")),
+        marketplace,
+      ),
       content="true",
     )
   }
@@ -232,7 +263,7 @@ async test "MarketplaceResolution resolve_marketplace_skills - does not suppress
     @fs.write_file(invalid.to_string(), "file", create_mode=CreateNew)
     try
       resolve_marketplace_skills(
-        root,
+        RepositoryRoot::RepositoryRoot(root),
         test_marketplace([("good", "plugins/good"), ("bad", "plugins/bad")]),
       )
     catch {
@@ -242,17 +273,5 @@ async test "MarketplaceResolution resolve_marketplace_skills - does not suppress
     } noraise {
       _ => fail("IO must not become partial success")
     }
-  }
-}
-
-///|
-async test "MarketplaceResolution resolve_marketplace_skills - rejects relative repository root" {
-  let relative = @path.Path("relative/repository")
-  try resolve_marketplace_skills(relative, test_marketplace([])) catch {
-    SkillResolutionError::RelativeRepositoryRoot(path~) =>
-      inspect(path == relative, content="true")
-    _ => fail("expected RelativeRepositoryRoot")
-  } noraise {
-    _ => fail("relative root must fail")
   }
 }


### PR DESCRIPTION
## 概要

[TOT-153](https://linear.app/totto2727/issue/TOT-153/c-plugin-v2-m3-m1-follow-up-repository-root検証をvalue-objectへ委譲する)として、repository rootの絶対パス・正規化不変条件を`RepositoryRoot`へ移します。

## 方針

- `RepositoryRoot` constructorでnormalize後にabsoluteを検証します。
- 相対パスは`RepositoryRootError::RelativeRepositoryRoot`として拒否します。
- resolverは検証済み型を受け取り、`is_absolute`や`normalize`を再実行しません。
- 不要な`priv`や単純accessor、互換shimは追加しません。

```mermaid
flowchart LR
  A["@path.Path"] --> B["RepositoryRoot constructor"]
  B --> C["normalize"]
  C --> D{"absolute?"}
  D -->|yes| E["RepositoryRoot"]
  D -->|no| F["RelativeRepositoryRoot"]
  E --> G["resolve_marketplace_skills"]
```

## テストケース

```mermaid
flowchart TD
  A["RepositoryRoot"] --> B["Dotted absolute path"]
  A --> C["Relative path"]
  A --> D["Marketplace resolution"]
  B --> E["Normalized value"]
  C --> F["Typed error"]
  D --> G["Ordering / ENOENT / IO unchanged"]
```

- focused tests: 12/12 PASS
- full native tests: 146/146 PASS
- format / deny-warn check / release build / diff check: PASS
- exact SHA review: 5/5 PASS

## 依存関係

TOT-101はmainへmerge済みです。TOT-154とは関連のみで機能依存がないため、独立した`main`向けPRです。

## 参考資料

- [moonbitlang/x path](https://github.com/moonbitlang/x/tree/c549d324ee3a5b3de7da4f3c1ea4572e8cfc3cba/path)
- [MoonBit error handling](https://docs.moonbitlang.com/en/latest/language/error-handling.html)

## CI

- Latest commit: `4ccfc791cba5c1088aa9898bc13d137ffc54aa69`
- Status: PENDING