### PR TITLE
[TOT-156] repository resolution整合性を生成境界へ移行

### DIFF
--- a/mbt/app/c-plugin-v2/src/desired_links.mbt
+++ b/mbt/app/c-plugin-v2/src/desired_links.mbt
@@ -26,6 +26,40 @@ pub(all) enum RepositorySkillResolution {
 }
 
 ///|
+pub struct RepositorySkillResolutions {
+  entries : @immut_hashmap.HashMap[
+    RepositoryIdentity,
+    RepositorySkillResolution,
+  ]
+}
+
+///|
+pub(all) suberror RepositorySkillResolutionsError {
+  DuplicateRepositoryIdentity(identity~ : RepositoryIdentity)
+}
+
+///|
+pub fn RepositorySkillResolutions::RepositorySkillResolutions(
+  resolutions : Array[RepositorySkillResolution],
+) -> RepositorySkillResolutions raise RepositorySkillResolutionsError {
+  let mut entries : @immut_hashmap.HashMap[
+    RepositoryIdentity,
+    RepositorySkillResolution,
+  ] = @immut_hashmap.HashMap([])
+  for resolution in resolutions {
+    let identity = match resolution {
+      Available(repository~, skills=_) | Unavailable(repository~, reason=_) =>
+        repository.identity()
+    }
+    guard entries.get(identity) is None else {
+      raise DuplicateRepositoryIdentity(identity~)
+    }
+    entries = entries.add(identity, resolution)
+  }
+  { entries, }
+}
+
+///|
 pub(all) struct RepositoryUnavailable {
   repository : RepositoryIdentity
   reason : String
@@ -38,14 +72,6 @@ pub(all) struct DesiredLinkPlan {
     RepositoryIdentity,
     RepositoryUnavailable,
   ]
-}
-
-///|
-pub(all) suberror DesiredLinkPlanningError {
-  RepositoryIdentityMismatch(
-    expected~ : RepositoryIdentity,
-    actual~ : RepositoryIdentity
-  )
 }
 
 ///|
@@ -111,20 +137,8 @@ fn desired_entry(
 ///|
 pub fn plan_desired_skill_links(
   managed_roots : @immut_hashset.HashSet[ManagedSkillRoot],
-  repositories : @immut_hashmap.HashMap[
-    RepositoryIdentity,
-    RepositorySkillResolution,
-  ],
+  repositories : RepositorySkillResolutions,
 ) -> DesiredLinkPlan raise {
-  for pair in repositories.to_array() {
-    let actual = match pair.1 {
-      Available(repository~, skills=_) | Unavailable(repository~, reason=_) =>
-        repository.identity()
-    }
-    guard pair.0 == actual else {
-      raise RepositoryIdentityMismatch(expected=pair.0, actual~)
-    }
-  }
   let mut candidates : @immut_hashmap.HashMap[
     OwnershipLinkIdentity,
     DesiredLinkCandidate,
@@ -133,7 +147,7 @@ pub fn plan_desired_skill_links(
     RepositoryIdentity,
     RepositoryUnavailable,
   ] = @immut_hashmap.HashMap([])
-  for pair in repositories.to_array() {
+  for pair in repositories.entries.to_array() {
     match pair.1 {
       Unavailable(repository~, reason~) => {
         let identity = repository.identity()

--- a/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
@@ -84,6 +84,47 @@ test "ManagedSkillRoot::ManagedSkillRoot - normalizes absolute path and rejects 
 }
 
 ///|
+test "RepositorySkillResolutions RepositorySkillResolutions - stores available and unavailable repositories" {
+  let available = desired_links_local_repository_at("vendor/available", [])
+  let unavailable = desired_links_local_repository_at("vendor/unavailable", [])
+  let resolutions = RepositorySkillResolutions::RepositorySkillResolutions([
+    Available(repository=available, skills=ReadOnlyArray::from_array([])),
+    Unavailable(repository=unavailable, reason="offline"),
+  ])
+  inspect(resolutions.entries.length(), content="2")
+  match resolutions.entries.get(available.identity()) {
+    Some(Available(repository~, skills~)) => {
+      inspect(repository.identity() == available.identity(), content="true")
+      inspect(skills.length(), content="0")
+    }
+    _ => fail("expected available repository resolution")
+  }
+  match resolutions.entries.get(unavailable.identity()) {
+    Some(Unavailable(repository~, reason~)) => {
+      inspect(repository.identity() == unavailable.identity(), content="true")
+      inspect(reason, content="offline")
+    }
+    _ => fail("expected unavailable repository resolution")
+  }
+}
+
+///|
+test "RepositorySkillResolutions RepositorySkillResolutions - rejects duplicate repository identities" {
+  let repository = desired_links_local_repository([])
+  try
+    RepositorySkillResolutions::RepositorySkillResolutions([
+      Available(repository~, skills=ReadOnlyArray::from_array([])),
+      Unavailable(repository~, reason="offline"),
+    ])
+  catch {
+    DuplicateRepositoryIdentity(identity~) =>
+      inspect(identity == repository.identity(), content="true")
+  } noraise {
+    _ => fail("duplicate repository identity must fail")
+  }
+}
+
+///|
 async test "DesiredLinks plan_desired_skill_links - expands one enabled skill" {
   @async.with_task_group() <| group => {
     let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-desired-links-")
@@ -96,15 +137,12 @@ async test "DesiredLinks plan_desired_skill_links - expands one enabled skill" {
         ManagedSkillRoot::ManagedSkillRoot(root.join(".agents/skills")),
         ManagedSkillRoot::ManagedSkillRoot(root.join(".cursor/skills")),
       ]),
-      @immut_hashmap.HashMap([
-        (
-          repository.identity(),
-          RepositorySkillResolution::Available(
-            repository~,
-            skills=ReadOnlyArray::from_array([
-              desired_links_resolved_skill(root, "install"),
-            ]),
-          ),
+      RepositorySkillResolutions::RepositorySkillResolutions([
+        RepositorySkillResolution::Available(
+          repository~,
+          skills=ReadOnlyArray::from_array([
+            desired_links_resolved_skill(root, "install"),
+          ]),
         ),
       ]),
     )
@@ -131,15 +169,12 @@ test "DesiredLinks plan_desired_skill_links - excludes disabled skill" {
     @immut_hashset.HashSet([
       ManagedSkillRoot::ManagedSkillRoot(@path.Path("/tmp/managed")),
     ]),
-    @immut_hashmap.HashMap([
-      (
-        repository.identity(),
-        Available(
-          repository~,
-          skills=ReadOnlyArray::from_array([
-            desired_links_resolved_skill(@path.Path("/tmp"), "disabled"),
-          ]),
-        ),
+    RepositorySkillResolutions::RepositorySkillResolutions([
+      Available(
+        repository~,
+        skills=ReadOnlyArray::from_array([
+          desired_links_resolved_skill(@path.Path("/tmp"), "disabled"),
+        ]),
       ),
     ]),
   )
@@ -159,16 +194,16 @@ test "DesiredLinks plan_desired_skill_links - canonical repository wins independ
   ])
   let forward = plan_desired_skill_links(
     roots,
-    @immut_hashmap.HashMap([
-      (first.identity(), Available(repository=first, skills=resolved)),
-      (last.identity(), Available(repository=last, skills=resolved)),
+    RepositorySkillResolutions::RepositorySkillResolutions([
+      Available(repository=first, skills=resolved),
+      Available(repository=last, skills=resolved),
     ]),
   )
   let reverse = plan_desired_skill_links(
     roots,
-    @immut_hashmap.HashMap([
-      (last.identity(), Available(repository=last, skills=resolved)),
-      (first.identity(), Available(repository=first, skills=resolved)),
+    RepositorySkillResolutions::RepositorySkillResolutions([
+      Available(repository=last, skills=resolved),
+      Available(repository=first, skills=resolved),
     ]),
   )
   inspect(forward.ownership_state == reverse.ownership_state, content="true")
@@ -190,11 +225,8 @@ test "DesiredLinks plan_desired_skill_links - later candidate in one repository 
     @immut_hashset.HashSet([
       ManagedSkillRoot::ManagedSkillRoot(@path.Path("/tmp/managed")),
     ]),
-    @immut_hashmap.HashMap([
-      (
-        repository.identity(),
-        Available(repository~, skills=ReadOnlyArray::from_array([first, last])),
-      ),
+    RepositorySkillResolutions::RepositorySkillResolutions([
+      Available(repository~, skills=ReadOnlyArray::from_array([first, last])),
     ]),
   )
   inspect(
@@ -212,20 +244,14 @@ test "DesiredLinks plan_desired_skill_links - unavailable repository reports wit
     @immut_hashset.HashSet([
       ManagedSkillRoot::ManagedSkillRoot(@path.Path("/tmp/managed")),
     ]),
-    @immut_hashmap.HashMap([
-      (
-        available.identity(),
-        Available(
-          repository=available,
-          skills=ReadOnlyArray::from_array([
-            desired_links_resolved_skill(@path.Path("/tmp"), "shared"),
-          ]),
-        ),
+    RepositorySkillResolutions::RepositorySkillResolutions([
+      Available(
+        repository=available,
+        skills=ReadOnlyArray::from_array([
+          desired_links_resolved_skill(@path.Path("/tmp"), "shared"),
+        ]),
       ),
-      (
-        unavailable.identity(),
-        Unavailable(repository=unavailable, reason="offline"),
-      ),
+      Unavailable(repository=unavailable, reason="offline"),
     ]),
   )
   inspect(plan.ownership_state.entries.length(), content="1")
@@ -246,24 +272,18 @@ test "DesiredLinks plan_desired_skill_links - preserves GitHub and local provena
     @immut_hashset.HashSet([
       ManagedSkillRoot::ManagedSkillRoot(@path.Path("/tmp/managed")),
     ]),
-    @immut_hashmap.HashMap([
-      (
-        github.identity(),
-        Available(
-          repository=github,
-          skills=ReadOnlyArray::from_array([
-            desired_links_resolved_skill(@path.Path("/tmp"), "github"),
-          ]),
-        ),
+    RepositorySkillResolutions::RepositorySkillResolutions([
+      Available(
+        repository=github,
+        skills=ReadOnlyArray::from_array([
+          desired_links_resolved_skill(@path.Path("/tmp"), "github"),
+        ]),
       ),
-      (
-        local_repository.identity(),
-        Available(
-          repository=local_repository,
-          skills=ReadOnlyArray::from_array([
-            desired_links_resolved_skill(@path.Path("/tmp"), "local"),
-          ]),
-        ),
+      Available(
+        repository=local_repository,
+        skills=ReadOnlyArray::from_array([
+          desired_links_resolved_skill(@path.Path("/tmp"), "local"),
+        ]),
       ),
     ]),
   )
@@ -289,50 +309,24 @@ test "DesiredLinks plan_desired_skill_links - preserves GitHub and local provena
 test "DesiredLinks plan_desired_skill_links - empty roots or repositories produce empty plan" {
   let empty = plan_desired_skill_links(
     @immut_hashset.HashSet([]),
-    @immut_hashmap.HashMap([]),
+    RepositorySkillResolutions::RepositorySkillResolutions([]),
   )
   let repository = desired_links_local_repository([])
   let no_roots = plan_desired_skill_links(
     @immut_hashset.HashSet([]),
-    @immut_hashmap.HashMap([
-      (
-        repository.identity(),
-        Available(repository~, skills=ReadOnlyArray::from_array([])),
-      ),
+    RepositorySkillResolutions::RepositorySkillResolutions([
+      Available(repository~, skills=ReadOnlyArray::from_array([])),
     ]),
   )
   let no_repositories = plan_desired_skill_links(
     @immut_hashset.HashSet([
       ManagedSkillRoot::ManagedSkillRoot(@path.Path("/tmp/managed")),
     ]),
-    @immut_hashmap.HashMap([]),
+    RepositorySkillResolutions::RepositorySkillResolutions([]),
   )
   for plan in [empty, no_roots, no_repositories] {
     inspect(plan.ownership_state.entries.length(), content="0")
     inspect(plan.unavailable_repositories.length(), content="0")
-  }
-}
-
-///|
-test "DesiredLinks plan_desired_skill_links - rejects repository identity mismatch" {
-  let repository = desired_links_local_repository([])
-  let expected = desired_links_local_repository_at("vendor/other", []).identity()
-  try
-    plan_desired_skill_links(
-      @immut_hashset.HashSet([]),
-      @immut_hashmap.HashMap([
-        (expected, Available(repository~, skills=ReadOnlyArray::from_array([]))),
-      ]),
-    )
-  catch {
-    RepositoryIdentityMismatch(expected=error_expected, actual=error_actual) =>
-      inspect(
-        error_expected == expected && error_actual == repository.identity(),
-        content="true",
-      )
-    error => raise error
-  } noraise {
-    _ => fail("identity mismatch must fail")
   }
 }
 
@@ -353,13 +347,10 @@ test "DesiredLinks plan_desired_skill_links - propagates an invalid resolved ski
       @immut_hashset.HashSet([
         ManagedSkillRoot::ManagedSkillRoot(@path.Path("/tmp/managed")),
       ]),
-      @immut_hashmap.HashMap([
-        (
-          repository.identity(),
-          Available(
-            repository~,
-            skills=ReadOnlyArray::from_array([invalid_skill]),
-          ),
+      RepositorySkillResolutions::RepositorySkillResolutions([
+        Available(
+          repository~,
+          skills=ReadOnlyArray::from_array([invalid_skill]),
         ),
       ]),
     )


### PR DESCRIPTION
## 概要

[TOT-156](https://linear.app/totto2727/issue/TOT-156/c-plugin-v2-m3-r1-p-follow-up-repository-resolution整合性を生成境界で保証する)として、repository resolution集合のidentity整合性を生成境界で保証します。

## 方針

- plannerへraw `HashMap`を渡さず、`RepositorySkillResolutions`を導入します。
- keyは各resolution内のrepository identityから導出します。
- duplicate identityを生成時のtyped errorで拒否します。
- plannerのkey/value mismatch guardと`RepositoryIdentityMismatch`を削除します。
- immutable hashmapを使用し、独自unique arrayや単純accessorを追加しません。

```mermaid
flowchart LR
  A["Resolution values"] --> B["RepositorySkillResolutions constructor"]
  B --> C["Derive repository identity"]
  C --> D{"Duplicate?"}
  D -->|no| E["Immutable identity map"]
  D -->|yes| F["DuplicateRepositoryIdentity"]
  E --> G["plan_desired_skill_links"]
```

## テストケース

```mermaid
flowchart TD
  A["Collection boundary"] --> B["Available + unavailable"]
  A --> C["Duplicate identity"]
  B --> D["Planner behavior unchanged"]
  C --> E["Typed error before planning"]
  D --> F["Canonical precedence / notices / empty input"]
```

- focused tests: 11/11 PASS
- full native tests: 146/146 PASS
- format / deny-warn check / release build / diff check: PASS
- exact SHA review: 5/5 PASS

## 依存関係

TOT-106はmainへmerge済みです。本PR自体は`main`向けの独立PRで、TOT-155だけが本PRをbaseにstackします。

## 参考資料

- [MoonBit error handling](https://docs.moonbitlang.com/en/stable/language/error-handling.html)

## CI

- Latest commit: `782dd6de3aec00f1c91f8711186f4da573dcca6a`
- Status: PENDING