### PR TITLE
[TOT-159] share-codingへpath form invariantルールを追加

### DIFF
--- a/plugins/totto2727-coding/skills/share-coding/SKILL.md
+++ b/plugins/totto2727-coding/skills/share-coding/SKILL.md
@@ -15,6 +15,12 @@ description: >-
 
 Express invariants in the type system whenever possible. Preserve paths, identifiers, commands, and domain payloads as specific structural values while they cross application layers. Keep generic JSON at serialization boundaries, and convert structural values to text only when an external protocol or display requires it.
 
+## Single-value invariants
+
+When a value must satisfy a condition independently of other values, consider representing that condition with a dedicated type. Validate and normalize raw input in the type's constructor or an equivalent factory, then pass the validated value through internal layers. Examples include an integer constrained to a fixed range and a path that must always be absolute. Do not repeat the same validation in each function that consumes the value; scattered checks reduce readability and make omissions likely.
+
+Keep rules that describe a relationship between multiple values in the function or domain policy that owns that relationship. Do not force a contextual relationship into a type that represents only one value.
+
 ## Collection invariants
 
 Do not construct a unique array with manual `contains`, `filter`, `fold`, or a local deduplication helper. When uniqueness is a domain invariant, store the values in a collection whose type guarantees uniqueness. Prefer the language's `Set` or a library set such as Effect `HashSet` for TypeScript and `@immut/hashset` or `@immut/sorted_set` for MoonBit. Convert the set to an array only at a consumer or API boundary that requires a sequence, such as serialization, presentation, interoperability, or a detached public snapshot.
@@ -28,6 +34,26 @@ If a private array exists only to stop callers from mutating it, prefer a readon
 ## Strict boundary conversion
 
 Keep untrusted or weakly typed values at the boundary where they enter or leave the program. Convert an external response into a wire model, convert the wire model into a validated domain model, convert the domain model into an outbound request model, and serialize only that request model. Apply the same rule to library values whose types are too broad to preserve domain invariants. Do not pass `any`, generic JSON, stringly typed identifiers, or parser contexts through internal application layers.
+
+## Path form invariants
+
+When internal code expects a specific path form, validate and normalize external raw paths or strings in a constructor or equivalent factory before passing them into internal layers. Represent relative paths such as `./...` or `../...`, absolute paths, and URI forms such as `file://...` with types that preserve their distinct invariants. Keep filesystem paths and URIs separate; validate a URI scheme before constructing its domain type. Do not repeat checks such as `is_absolute` in terminal functions.
+
+For example, normalize a MoonBit `Path` before checking and storing its absolute-path invariant:
+
+```mbt check
+pub struct AbsolutePath {
+  path : @path.Path
+}
+
+pub fn AbsolutePath::AbsolutePath(path : @path.Path) -> AbsolutePath raise {
+  let normalized = path.normalize()
+  guard normalized.is_absolute() else {
+    fail("absolute path required")
+  }
+  { path: normalized }
+}
+```
 
 ## State models
 


### PR DESCRIPTION
## 概要

[TOT-159](https://linear.app/totto2727/issue/TOT-159/coding-plugin-path-form-invariantルールをshare-codingへ追加する)として、値単体の不変条件とpath form invariantを`share-coding`へ追加します。

## 方針

- 値単体で常に成立すべき条件は専用型とconstructor/factoryで保持します。
- 複数値の関係は、その関係を所有するdomain policyへ残します。
- relative/absolute filesystem pathとURIを区別し、URI schemeを検証します。
- MoonBitの`AbsolutePath`例だけを追加し、`mbt-coding`は変更しません。

```mermaid
flowchart LR
  A["Raw path / string"] --> B["Constructor / factory"]
  B --> C{"Validate and normalize"}
  C -->|valid| D["Invariant-preserving type"]
  C -->|invalid| E["Typed failure"]
  D --> F["Internal layers"]
```

## テストケース

```mermaid
flowchart TD
  A["share-coding skill"] --> B["Skill validator"]
  A --> C["Scope check"]
  B --> D["Skill is valid"]
  C --> E["Only SKILL.md changed"]
  A --> F["git diff --check"]
```

- skill validator: PASS
- `git diff --check`: PASS
- exact SHA review: 5/5 PASS

## 依存関係

他のc-plugin-v2実装とは独立しているため、`main`向けPRです。

## 参考資料

- [MoonBit custom constructors](https://docs.moonbitlang.com/en/latest/language/fundamentals.html#custom-constructors)
- [Path::is_absolute](https://github.com/moonbitlang/x/blob/c549d324ee3a5b3de7da4f3c1ea4572e8cfc3cba/path/path.mbt#L105-L110)
- [Path::normalize](https://github.com/moonbitlang/x/blob/c549d324ee3a5b3de7da4f3c1ea4572e8cfc3cba/path/path.mbt#L138-L144)

## CI

- Latest commit: `a56358cdd350dbeffc62062f7841f6b7e5384b5e`
- Status: PENDING