### PR TITLE
TOT-155 c-plugin-v2: desired-link生成失敗をtyped errorへ置き換える

### DIFF
--- a/mbt/app/c-plugin-v2/src/desired_links.mbt
+++ b/mbt/app/c-plugin-v2/src/desired_links.mbt
@@ -75,6 +75,26 @@ pub(all) struct DesiredLinkPlan {
 }
 
 ///|
+pub(all) enum DesiredEntryConstructionStage {
+  Link
+  ResolvedTarget
+  ManagedRoot
+  Entry
+} derive(Debug, Eq)
+
+///|
+pub(all) suberror DesiredLinkPlanningError {
+  InvalidDesiredEntry(
+    stage~ : DesiredEntryConstructionStage,
+    repository~ : RepositoryIdentity,
+    managed_root~ : @path.Path,
+    skill~ : SkillName,
+    skill_path~ : @path.Path
+  )
+  InvalidOwnershipState(link~ : @path.Path)
+}
+
+///|
 struct DesiredLinkCandidate {
   repository : RepositoryIdentity
   entry : OwnershipEntry
@@ -121,24 +141,73 @@ fn desired_entry(
   root : ManagedSkillRoot,
   repository : LockRepository,
   skill : ResolvedSkill,
-) -> OwnershipEntry raise {
-  let link = OwnershipLink::OwnershipLink(
-    root.path.join(skill.skill_name.value),
-  )
+) -> OwnershipEntry raise DesiredLinkPlanningError {
+  let repository_identity = repository.identity()
+  let link_path = root.path.join(skill.skill_name.value)
+  let link = OwnershipLink::OwnershipLink(link_path) catch {
+    RelativeOwnershipLink(_) =>
+      raise InvalidDesiredEntry(
+        stage=Link,
+        repository=repository_identity,
+        managed_root=root.path,
+        skill=skill.skill_name,
+        skill_path=skill.skill_path,
+      )
+  }
+  let resolved_target = OwnershipResolvedTarget::OwnershipResolvedTarget(
+    skill.skill_path,
+  ) catch {
+    RelativeOwnershipResolvedTarget(_) =>
+      raise InvalidDesiredEntry(
+        stage=ResolvedTarget,
+        repository=repository_identity,
+        managed_root=root.path,
+        skill=skill.skill_name,
+        skill_path=skill.skill_path,
+      )
+  }
+  let managed_root = OwnershipManagedRoot::OwnershipManagedRoot(root.path) catch {
+    RelativeOwnershipManagedRoot(_) =>
+      raise InvalidDesiredEntry(
+        stage=ManagedRoot,
+        repository=repository_identity,
+        managed_root=root.path,
+        skill=skill.skill_name,
+        skill_path=skill.skill_path,
+      )
+  }
   OwnershipEntry::OwnershipEntry(
     link,
     skill.skill_path.relative(base=root.path),
-    OwnershipResolvedTarget::OwnershipResolvedTarget(skill.skill_path),
-    OwnershipManagedRoot::OwnershipManagedRoot(root.path),
+    resolved_target,
+    managed_root,
     ownership_source(repository, skill),
-  )
+  ) catch {
+    OwnershipLinkOutsideManagedRoot(..) =>
+      raise InvalidDesiredEntry(
+        stage=Entry,
+        repository=repository_identity,
+        managed_root=root.path,
+        skill=skill.skill_name,
+        skill_path=skill.skill_path,
+      )
+  }
+}
+
+///|
+fn desired_ownership_state(
+  entries : Array[OwnershipEntry],
+) -> OwnershipState raise DesiredLinkPlanningError {
+  OwnershipState::OwnershipState(entries) catch {
+    DuplicateOwnershipLink(link~) => raise InvalidOwnershipState(link~)
+  }
 }
 
 ///|
 pub fn plan_desired_skill_links(
   managed_roots : @immut_hashset.HashSet[ManagedSkillRoot],
   repositories : RepositorySkillResolutions,
-) -> DesiredLinkPlan raise {
+) -> DesiredLinkPlan raise DesiredLinkPlanningError {
   let mut candidates : @immut_hashmap.HashMap[
     OwnershipLinkIdentity,
     DesiredLinkCandidate,
@@ -181,7 +250,7 @@ pub fn plan_desired_skill_links(
   }
   let entries = candidates.to_array().map(pair => pair.1.entry)
   {
-    ownership_state: OwnershipState::OwnershipState(entries),
+    ownership_state: desired_ownership_state(entries),
     unavailable_repositories: unavailable,
   }
 }

--- a/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
@@ -331,7 +331,7 @@ test "DesiredLinks plan_desired_skill_links - empty roots or repositories produc
 }
 
 ///|
-test "DesiredLinks plan_desired_skill_links - propagates an invalid resolved skill path" {
+test "DesiredLinks plan_desired_skill_links - reports invalid resolved skill path context" {
   let skill_name = SkillName::SkillName("install")
   let repository = desired_links_local_repository([skill_name])
   let invalid_skill : ResolvedSkill = {
@@ -355,9 +355,41 @@ test "DesiredLinks plan_desired_skill_links - propagates an invalid resolved ski
       ]),
     )
   catch {
-    Failure::Failure(_) => ()
+    InvalidDesiredEntry(
+      stage~,
+      repository=actual_repository,
+      managed_root~,
+      skill=actual_skill,
+      skill_path~
+    ) => {
+      inspect(
+        stage == DesiredEntryConstructionStage::ResolvedTarget,
+        content="true",
+      )
+      inspect(actual_repository == repository.identity(), content="true")
+      inspect(managed_root.to_string(), content="/tmp/managed")
+      inspect(actual_skill == skill_name, content="true")
+      inspect(skill_path.to_string(), content="relative/skill")
+    }
     error => raise error
   } noraise {
     _ => fail("invalid resolved skill path must raise")
+  }
+}
+
+///|
+test "DesiredLinks desired_ownership_state - reports invalid ownership state link context" {
+  let root = ManagedSkillRoot::ManagedSkillRoot(@path.Path("/tmp/managed"))
+  let repository = desired_links_local_repository([
+    SkillName::SkillName("install"),
+  ])
+  let skill = desired_links_resolved_skill(@path.Path("/tmp"), "install")
+  let entry = desired_entry(root, repository, skill)
+  try desired_ownership_state([entry, entry]) catch {
+    InvalidOwnershipState(link~) =>
+      inspect(link.to_string(), content="/tmp/managed/install")
+    error => raise error
+  } noraise {
+    _ => fail("duplicate desired ownership link must raise")
   }
 }

--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -67,6 +67,34 @@ pub enum OwnershipSource {
 } derive(Eq)
 
 ///|
+pub(all) suberror OwnershipLinkError {
+  RelativeOwnershipLink(path~ : @path.Path)
+}
+
+///|
+pub(all) suberror OwnershipResolvedTargetError {
+  RelativeOwnershipResolvedTarget(path~ : @path.Path)
+}
+
+///|
+pub(all) suberror OwnershipManagedRootError {
+  RelativeOwnershipManagedRoot(path~ : @path.Path)
+}
+
+///|
+pub(all) suberror OwnershipEntryError {
+  OwnershipLinkOutsideManagedRoot(
+    link~ : @path.Path,
+    managed_root~ : @path.Path
+  )
+}
+
+///|
+pub(all) suberror OwnershipStateError {
+  DuplicateOwnershipLink(link~ : @path.Path)
+}
+
+///|
 pub impl Compare for OwnershipSource with fn compare(self, other) {
   match (self, other) {
     (GitHub(left), GitHub(right)) => left.compare(right)
@@ -111,8 +139,10 @@ pub struct OwnershipLink {
 } derive(Eq)
 
 ///|
-pub fn OwnershipLink::OwnershipLink(path : @path.Path) -> OwnershipLink raise {
-  guard path.is_absolute() else { fail("ownership link must be absolute") }
+pub fn OwnershipLink::OwnershipLink(
+  path : @path.Path,
+) -> OwnershipLink raise OwnershipLinkError {
+  guard path.is_absolute() else { raise RelativeOwnershipLink(path~) }
   { path: path.normalize() }
 }
 
@@ -129,10 +159,8 @@ pub struct OwnershipResolvedTarget {
 ///|
 pub fn OwnershipResolvedTarget::OwnershipResolvedTarget(
   path : @path.Path,
-) -> OwnershipResolvedTarget raise {
-  guard path.is_absolute() else {
-    fail("ownership resolved target must be absolute")
-  }
+) -> OwnershipResolvedTarget raise OwnershipResolvedTargetError {
+  guard path.is_absolute() else { raise RelativeOwnershipResolvedTarget(path~) }
   { path: path.normalize() }
 }
 
@@ -149,10 +177,8 @@ pub struct OwnershipManagedRoot {
 ///|
 pub fn OwnershipManagedRoot::OwnershipManagedRoot(
   path : @path.Path,
-) -> OwnershipManagedRoot raise {
-  guard path.is_absolute() else {
-    fail("ownership managed root must be absolute")
-  }
+) -> OwnershipManagedRoot raise OwnershipManagedRootError {
+  guard path.is_absolute() else { raise RelativeOwnershipManagedRoot(path~) }
   { path: path.normalize() }
 }
 
@@ -177,9 +203,12 @@ pub fn OwnershipEntry::OwnershipEntry(
   resolved_target : OwnershipResolvedTarget,
   managed_root : OwnershipManagedRoot,
   source : OwnershipSource,
-) -> OwnershipEntry raise {
+) -> OwnershipEntry raise OwnershipEntryError {
   guard link.path.dirname() == managed_root.path else {
-    fail("ownership link must be a direct child of its managed root")
+    raise OwnershipLinkOutsideManagedRoot(
+      link=link.path,
+      managed_root=managed_root.path,
+    )
   }
   { link, symlink_target, resolved_target, managed_root, source }
 }
@@ -242,12 +271,17 @@ pub impl Hash for OwnershipLinkIdentity with fn hash_combine(self, hasher) {
 ///|
 pub fn OwnershipState::OwnershipState(
   entries : Array[OwnershipEntry],
-) -> OwnershipState raise {
-  let stored_entries = @immut_hashmap.HashMap(
-    entries.map(entry => (OwnershipLinkIdentity(entry.link.path), entry)),
-  )
-  guard stored_entries.length() == entries.length() else {
-    fail("ownership links must be unique")
+) -> OwnershipState raise OwnershipStateError {
+  let mut stored_entries : @immut_hashmap.HashMap[
+    OwnershipLinkIdentity,
+    OwnershipEntry,
+  ] = @immut_hashmap.HashMap([])
+  for entry in entries {
+    let identity = OwnershipLinkIdentity(entry.link.path)
+    guard stored_entries.get(identity) is None else {
+      raise DuplicateOwnershipLink(link=entry.link.path)
+    }
+    stored_entries = stored_entries.add(identity, entry)
   }
   { version: 1, entries: stored_entries }
 }

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
@@ -137,7 +137,8 @@ pub impl ToJson for OwnershipSource with fn to_json(self) -> Json {
 pub impl FromJson for OwnershipLink with fn from_json(json, path) {
   let value : String = @json.from_json(json, path~)
   OwnershipLink::OwnershipLink(@path.Path(value)) catch {
-    _ => raise @json.JsonDecodeError((path, "ownership link must be absolute"))
+    RelativeOwnershipLink(_) =>
+      raise @json.JsonDecodeError((path, "ownership link must be absolute"))
   }
 }
 
@@ -150,7 +151,7 @@ pub impl ToJson for OwnershipLink with fn to_json(self) -> Json {
 pub impl FromJson for OwnershipResolvedTarget with fn from_json(json, path) {
   let value : String = @json.from_json(json, path~)
   OwnershipResolvedTarget::OwnershipResolvedTarget(@path.Path(value)) catch {
-    _ =>
+    RelativeOwnershipResolvedTarget(_) =>
       raise @json.JsonDecodeError(
         (path, "ownership resolved target must be absolute"),
       )
@@ -166,7 +167,7 @@ pub impl ToJson for OwnershipResolvedTarget with fn to_json(self) -> Json {
 pub impl FromJson for OwnershipManagedRoot with fn from_json(json, path) {
   let value : String = @json.from_json(json, path~)
   OwnershipManagedRoot::OwnershipManagedRoot(@path.Path(value)) catch {
-    _ =>
+    RelativeOwnershipManagedRoot(_) =>
       raise @json.JsonDecodeError(
         (path, "ownership managed root must be absolute"),
       )
@@ -202,7 +203,7 @@ pub impl FromJson for OwnershipEntry with fn from_json(json, path) {
     managed_root,
     source,
   ) catch {
-    _ =>
+    OwnershipLinkOutsideManagedRoot(..) =>
       raise ownership_entry_link_lens.json_decode_error(
         path, "ownership link must be a direct child of its managed root",
       )
@@ -249,7 +250,7 @@ pub impl FromJson for OwnershipState with fn from_json(json, path) {
     path=ownership_state_entries_lens.add_to_json_path(path),
   )
   OwnershipState::OwnershipState(entries) catch {
-    _ =>
+    DuplicateOwnershipLink(_) =>
       raise ownership_state_entries_lens.json_decode_error(
         path, "ownership links must be unique",
       )


### PR DESCRIPTION
## 概要

[TOT-155](https://linear.app/totto2727/issue/TOT-155) の対応です。desired-link生成で発生する所有権パスの不変条件違反を、productionの `try!` や汎用 `Failure` に依存せず、文脈を保持したtyped errorとして呼び出し元へ返します。

## 変更内容

- ownership domainの各constructorに、相対path・managed root直下制約・重複linkを表す狭いtyped errorを定義
- desired entry生成時の失敗を `DesiredLinkPlanningError` へ明示変換
- stage / repository / managed root / skill / skill pathをエラーへ保持
- codec境界の変換をcatch-allから具体的なtyped error variantの明示matchへ変更
- 無効なresolved skill pathと重複ownership linkの回帰テストを追加

## 処理フロー

```mermaid
flowchart TD
  A["Validated repository resolutions"] --> B["Build ownership link"]
  B -->|valid| C["Build resolved target"]
  B -->|relative path| E["InvalidDesiredEntry(stage: Link)"]
  C -->|valid| D["Build managed root and ownership entry"]
  C -->|relative path| F["InvalidDesiredEntry(stage: ResolvedTarget)"]
  D -->|valid| G["Build OwnershipState"]
  D -->|invalid relationship| H["InvalidDesiredEntry(stage: Entry)"]
  G -->|unique links| I["Desired link plan"]
  G -->|duplicate link| J["InvalidOwnershipState"]
```

## テストケース

```mermaid
flowchart LR
  S["Desired-link planning"] --> N["正常なrepository resolution"]
  S --> R["relative resolved skill path"]
  S --> D["duplicate ownership link"]
  N --> NP["既存の計画結果を維持"]
  R --> RP["ResolvedTarget stageと全contextを返す"]
  D --> DP["重複linkをtyped errorで返す"]
  C["Ownership-state codec"] --> CP["各constructor errorを具体variantで変換"]
```

## 検証

- `moon fmt --check mbt/app/c-plugin-v2/src`
- `moon check --deny-warn --target native mbt/app/c-plugin-v2/src`
- `moon test --target native mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt --no-parallelize` (12/12)
- `moon test --target native mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt --no-parallelize` (12/12)
- `moon test --target native mbt/app/c-plugin-v2/src --no-parallelize` (147/147)
- `moon build --release --target native mbt/app/c-plugin-v2/src`
- `git diff --check`
- exact SHA `4ce7f070b50141d95b9950fc4d1620c0023bf957` に対する5レビュー: PASS

## 依存関係

このPRはTOT-156の `RepositorySkillResolutions` を入力境界として使用するため、PR #298（`codex/tot-156-repository-resolution-domain`）上に積んでいます。PR #298のmerge後にbaseをmainへ切り替えます。

## 参考資料

- [MoonBit Error Handling](https://docs.moonbitlang.com/en/stable/language/error-handling.html)

## CI

- SUCCESS: [CI run](https://github.com/totto2727-org/monorepo/actions/runs/31359276938)