### PR TITLE
MoonBit ActionでCI用devShellを選択可能にする

### DIFF
--- a/.github/actions/check-moonbit/action.yaml
+++ b/.github/actions/check-moonbit/action.yaml
@@ -1,5 +1,5 @@
-name: Setup MoonBit
-description: Update the MoonBit registry with the Nix-managed toolchain.
+name: Check MoonBit
+description: Check the MoonBit workspace with the Nix-managed toolchain.
 
 inputs:
   dev-shell:
@@ -10,10 +10,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Update MoonBit registry
+    - name: Check MoonBit workspace
       shell: bash
       env:
         NIX_DEV_SHELL: ${{ inputs.dev-shell }}
       run: |
         eval "$(nix print-dev-env "$GITHUB_WORKSPACE#$NIX_DEV_SHELL")"
-        moon update
+        moon fmt --check
+        moon check --deny-warn
+        moon build
+        moon test


### PR DESCRIPTION
## 概要

MoonBit用の共有Composite Actionで、利用するNix devShellを選択可能にします。入力を省略した場合は従来どおり`default`を使用し、CI専用ツールが必要なリポジトリだけ`dev-shell: ci`を指定できます。

過去に存在した`check-moonbit` Actionを復元し、`setup-moonbit`と同じdevShell選択規約へ統一します。

```mermaid
flowchart TD
  A["呼び出し側Workflow"] --> B{"dev-shell指定"}
  B -->|"省略"| C["default devShell"]
  B -->|"ci"| D["ci devShell"]
  C --> E["moon update / check / build / test"]
  D --> E
```

## 変更内容

- `setup-moonbit`へ任意の`dev-shell`入力を追加
- 入力省略時は後方互換の`default`
- `check-moonbit`を復元し、同じ`dev-shell`入力を追加
- 選択したshellを`nix print-dev-env`で現在のComposite Actionプロセスへ読み込み

## 検証

- Action YAMLの構文解析
- `git diff --check`
- `dev-shell: default`相当でNix環境を読み込み、Nix管理のMoonBit toolchainを実行

```mermaid
flowchart LR
  T1["入力省略"] --> R1["defaultを解決"] --> P1["MoonBit version取得成功"]
  T2["dev-shell指定"] --> R2["指定attributeを解決"]
```

Relates to TOT-173
