### PR TITLE
共有MoonBitテストを既存CI契約に合わせる

### DIFF
--- a/.github/actions/check-moonbit/action.yaml
+++ b/.github/actions/check-moonbit/action.yaml
@@ -19,4 +19,4 @@ runs:
         moon fmt --check
         moon check --deny-warn
         moon build
-        moon test
+        LD_LIBRARY_PATH="${MOONBIT_OPENSSL_LIBRARY_PATH:-}" moon test --no-parallelize


### PR DESCRIPTION
## 概要

共有`check-moonbit` Actionのテスト実行を、monorepo本体の`mbt:test`契約と揃えます。LinuxではNix由来のOpenSSL pathをMoonBitテストのみに設定し、テストbackendを直列化します。

```mermaid
flowchart TD
  A["選択したdevShellを読み込む"] --> B["moon fmt --check"]
  B --> C["moon check --deny-warn"]
  C --> D["moon build"]
  D --> E["OpenSSL pathをtestだけに設定"]
  E --> F["moon test --no-parallelize"]
```

## 変更内容

- `LD_LIBRARY_PATH`をMoonBit testコマンドだけに限定
- `moon test --no-parallelize`で既存のCI安定化契約を共有Actionにも適用
- `setup-moonbit`およびdevShell選択仕様は変更なし

## 検証

- Action YAML構文解析
- `git diff --check`
- monorepoの既存`mbt:test`設定および履歴との一致確認

```mermaid
flowchart LR
  T1["MOONBIT_OPENSSL_LIBRARY_PATHあり"] --> R1["testのLD_LIBRARY_PATHへ設定"]
  T2["変数なし"] --> R2["空値でtestを実行"]
  R1 --> P["非並列MoonBit test"]
  R2 --> P
```

Relates to TOT-173
