### PR TITLE
c-plugin v2にpersist_and_sync mutation adapterを追加

### DIFF
--- a/mbt/app/c-plugin-v2/src/persist_and_sync.mbt
+++ b/mbt/app/c-plugin-v2/src/persist_and_sync.mbt
@@ -1,0 +1,27 @@
+///|
+/// Reports whether a lock mutation changed durable state and completed sync.
+pub(all) enum PersistAndSyncResult {
+  NoChange
+  Synced
+  PersistedButSyncFailed(cause~ : SyncError)
+} derive(Debug)
+
+///|
+/// Persists a changed lock candidate before synchronizing that same value.
+pub async fn persist_and_sync(
+  current_lock~ : Lock,
+  candidate~ : Lock?,
+  persist~ : async (Lock) -> Unit raise StateStoreError,
+  sync~ : async (Lock) -> Unit raise SyncError,
+) -> PersistAndSyncResult raise StateStoreError {
+  let changed_lock = match candidate {
+    None => return NoChange
+    Some(candidate) if candidate == current_lock => return NoChange
+    Some(candidate) => candidate
+  }
+  persist(changed_lock)
+  sync(changed_lock) catch {
+    cause => return PersistedButSyncFailed(cause~)
+  }
+  Synced
+}

--- a/mbt/app/c-plugin-v2/src/persist_and_sync_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/persist_and_sync_wbtest.mbt
@@ -1,0 +1,130 @@
+///|
+fn persist_and_sync_test_lock(targets : Array[String]) -> Lock raise {
+  Lock::Lock(targets.map(target => Target::Target(target)), [])
+}
+
+///|
+async test "PersistAndSync persist_and_sync 1 - persists before syncing the same changed candidate" {
+  let current_lock = persist_and_sync_test_lock([])
+  let candidate = persist_and_sync_test_lock([".cursor/skills"])
+  let events : Array[String] = []
+  let persisted : Array[Lock] = []
+  let synced : Array[Lock] = []
+  let persist : async (Lock) -> Unit raise StateStoreError = fn(lock) {
+    events.push("persist")
+    persisted.push(lock)
+  }
+  let sync : async (Lock) -> Unit raise SyncError = fn(lock) {
+    events.push("sync")
+    synced.push(lock)
+  }
+
+  let result = persist_and_sync(
+    current_lock~,
+    candidate=Some(candidate),
+    persist~,
+    sync~,
+  )
+
+  debug_inspect(result, content="Synced")
+  debug_inspect(events, content="[\"persist\", \"sync\"]")
+  inspect(persisted.length(), content="1")
+  inspect(synced.length(), content="1")
+  inspect(persisted[0] == candidate, content="true")
+  inspect(synced[0] == candidate, content="true")
+}
+
+///|
+async test "PersistAndSync persist_and_sync 2 - skips persistence and sync when cancelled" {
+  let current_lock = persist_and_sync_test_lock([])
+  let events : Array[String] = []
+  let persist : async (Lock) -> Unit raise StateStoreError = _lock => {
+    events.push("persist")
+  }
+  let sync : async (Lock) -> Unit raise SyncError = fn(_lock) {
+    events.push("sync")
+  }
+
+  let result = persist_and_sync(current_lock~, candidate=None, persist~, sync~)
+
+  debug_inspect(result, content="NoChange")
+  debug_inspect(events, content="[]")
+}
+
+///|
+async test "PersistAndSync persist_and_sync 3 - skips persistence and sync for an equal candidate" {
+  let current_lock = persist_and_sync_test_lock([".cursor/skills"])
+  let events : Array[String] = []
+  let persist : async (Lock) -> Unit raise StateStoreError = fn(_lock) {
+    events.push("persist")
+  }
+  let sync : async (Lock) -> Unit raise SyncError = fn(_lock) {
+    events.push("sync")
+  }
+
+  let result = persist_and_sync(
+    current_lock~,
+    candidate=Some(current_lock),
+    persist~,
+    sync~,
+  )
+
+  debug_inspect(result, content="NoChange")
+  debug_inspect(events, content="[]")
+}
+
+///|
+async test "PersistAndSync persist_and_sync 4 - does not sync after persistence fails" {
+  let current_lock = persist_and_sync_test_lock([])
+  let candidate = persist_and_sync_test_lock([".cursor/skills"])
+  let lock_path = @path.Path("c-plugin-lock.json")
+  let synced : Array[Lock] = []
+  let persist : async (Lock) -> Unit raise StateStoreError = _lock => {
+    raise StateStoreError::IO(path=lock_path, reason="write failed")
+  }
+  let sync : async (Lock) -> Unit raise SyncError = fn(lock) {
+    synced.push(lock)
+  }
+
+  try
+    persist_and_sync(current_lock~, candidate=Some(candidate), persist~, sync~)
+    |> ignore
+  catch {
+    StateStoreError::IO(path~, reason~) => {
+      inspect(path == lock_path, content="true")
+      inspect(reason, content="write failed")
+    }
+    _ => fail("expected persistence error")
+  } noraise {
+    _ => fail("persistence failure must propagate")
+  }
+  inspect(synced.length(), content="0")
+}
+
+///|
+async test "PersistAndSync persist_and_sync 5 - reports sync failure after preserving the candidate" {
+  let current_lock = persist_and_sync_test_lock([])
+  let candidate = persist_and_sync_test_lock([".cursor/skills"])
+  let persisted : Array[Lock] = []
+  let persist : async (Lock) -> Unit raise StateStoreError = fn(lock) {
+    persisted.push(lock)
+  }
+  let sync : async (Lock) -> Unit raise SyncError = _lock => {
+    raise SyncError::Planning(reason="sync failed")
+  }
+
+  let result = persist_and_sync(
+    current_lock~,
+    candidate=Some(candidate),
+    persist~,
+    sync~,
+  )
+
+  match result {
+    PersistedButSyncFailed(cause=SyncError::Planning(reason~)) =>
+      inspect(reason, content="sync failed")
+    _ => fail("expected persisted sync failure")
+  }
+  inspect(persisted.length(), content="1")
+  inspect(persisted[0] == candidate, content="true")
+}


### PR DESCRIPTION
## 概要

- lock変更候補を永続化してから、同じ値をsyncへ渡す共通`persist_and_sync`境界を追加しました。
- ユーザー操作上の取消（candidateなし）とsemantic no-opではwrite/syncを行いません。
- write失敗は`StateStoreError`として伝播し、write後のsync失敗は`PersistedButSyncFailed`として返します。
- [TOT-119](https://linear.app/totto2727/issue/TOT-119/c-plugin-v2-m3-a1-persist-and-sync-mutation-adapterを実装する) に対応します。
- Stacked base: #307（`codex/tot-118-sync-command`）

## 実装フロー

```mermaid
flowchart TD
  A["candidateを受け取る"] --> B{"candidateがあるか"}
  B -- "なし" --> N["NoChange"]
  B -- "あり" --> C{"current lockと同値か"}
  C -- "同値" --> N
  C -- "変更あり" --> D["candidateをatomic persist"]
  D --> E{"write成功か"}
  E -- "失敗" --> W["StateStoreErrorを伝播"]
  E -- "成功" --> F["同じcandidateでsync"]
  F --> G{"sync成功か"}
  G -- "成功" --> S["Synced"]
  G -- "失敗" --> P["PersistedButSyncFailed"]
```

## テストケース

```mermaid
flowchart TD
  T["persist_and_sync"] --> H["変更candidate"]
  T --> C["candidateなし"]
  T --> E["同値candidate"]
  T --> W["write失敗"]
  T --> F["write後sync失敗"]
  H --> HP["persist→sync順序・同一値・各1回"]
  C --> CP["NoChange・effect 0回"]
  E --> EP["NoChange・effect 0回"]
  W --> WP["StateStoreError・sync 0回"]
  F --> FP["typed failure・candidate永続化済み"]
```

## 検証

- `moon fmt --check mbt/app/c-plugin-v2/src/persist_and_sync.mbt mbt/app/c-plugin-v2/src/persist_and_sync_wbtest.mbt`
- `vp run mbt:check`
- `moon test ./mbt/app/c-plugin-v2/src --target native`（166 passed）
- `vp run mbt:build`
- `vp run mbt:test`（288 passed）
- `bash mbt/app/c-plugin-v2/src/e2e/run.sh`（project/global init + sync PASS）
- exact SHAレビュー6レーン PASS
- 差分: 2 files / 157 additions（500行以下）