### PR TITLE
FlakeHub公開用の共通actionを追加

### DIFF
--- a/.github/actions/publish-flakehub/action.yaml
+++ b/.github/actions/publish-flakehub/action.yaml
@@ -1,0 +1,16 @@
+name: Publish to FlakeHub
+description: Publish the repository root flake as a public rolling release.
+
+runs:
+  using: composite
+  steps:
+    - name: Publish root flake
+      uses: DeterminateSystems/flakehub-push@abcff4fb351e63f852f5fb2b9af0ae4e69de07d4 # main
+      with:
+        name: ${{ github.repository }}
+        rolling: true
+        visibility: public
+        # Limit pre-publish evaluation to the runner system because cross-system cache inputs are unavailable.
+        my-flake-is-too-big: true
+        # Do not register individual output paths for the flake.
+        include-output-paths: false


### PR DESCRIPTION
## 概要

FlakeHubへの公開設定を各リポジトリで重複させず、組織内で共通利用できるcomposite actionとして追加します。

## 変更内容

- リポジトリ直下のflakeをpublic rolling releaseとして公開
- 公開名に呼び出し元の `github.repository` を使用
- 評価対象をrunner systemに限定
- output pathの個別登録を無効化
- 第三者の `DeterminateSystems/flakehub-push` を検証済みfull SHAへ固定

## 処理フロー

```mermaid
flowchart LR
  CALLER["consumer workflow"] --> SHARED["publish-flakehub action"]
  SHARED --> PINNED["flakehub-push pinned SHA"]
  PINNED --> ROOT["caller repository root flake"]
  ROOT --> FH["FlakeHub public rolling release"]
```

## 検証

```mermaid
flowchart TD
  SOURCE["action metadata"] --> SCHEMA{"GitHub Action schema"}
  SCHEMA -->|PASS| PIN{"upstream SHA and inputs"}
  PIN -->|PASS| REVIEW{"goal / code / security review"}
  REVIEW -->|PASS| READY["PR ready"]
```

- GitHub Action JSON schema: PASS
- upstream SHAの実在・署名・入力互換性: PASS
- goal / code quality / security / manual QA: PASS
- 実publishはmainへの反映後にconsumer側で確認

## 参考資料

- https://docs.determinate.systems/flakehub/publishing/
- https://docs.determinate.systems/guides/github-actions/
- https://docs.github.com/en/actions/reference/security/secure-use

## CI status

- Latest commit SHA: `f96381b`
- Latest `check` job: success (run id: 31452447471, attempt: 1)
- Retry history: none