### PR TITLE
c-plugin v2のrecursive syncを実装する

### DIFF
--- a/mbt/app/c-plugin-v2/src/command_sync.mbt
+++ b/mbt/app/c-plugin-v2/src/command_sync.mbt
@@ -6,15 +6,26 @@ let sync_global_option : @admiral.OptionDef[Bool] = @admiral.bool(
 )
 
 ///|
+let sync_recursive_option : @admiral.OptionDef[Bool] = @admiral.bool(
+  "recursive",
+  short='r',
+  description="Sync the nearest project lock and visible descendants",
+)
+
+///|
 struct SyncOptions {
   global : Bool
+  recursive : Bool
 }
 
 ///|
 fn sync_options(
   context : @admiral.Context,
 ) -> SyncOptions raise @json.JsonDecodeError {
-  { global: context.get_bool(sync_global_option) }
+  {
+    global: context.get_bool(sync_global_option),
+    recursive: context.get_bool(sync_recursive_option),
+  }
 }
 
 ///|
@@ -100,10 +111,15 @@ async fn sync_locks(
   runtime : Runtime,
   options : SyncOptions,
 ) -> ReadOnlyArray[SyncLockResult] {
+  guard !(options.global && options.recursive) else {
+    raise SyncError::Planning(
+      reason="--global cannot be combined with --recursive",
+    )
+  }
   let discovery_options = if options.global {
     LockDiscoveryOptions::Global
   } else {
-    LockDiscoveryOptions::Project(recursive=false)
+    LockDiscoveryOptions::Project(recursive=options.recursive)
   }
   let lock_paths = runtime.discover_locks(discovery_options)
   let results = []
@@ -138,7 +154,7 @@ fn sync_command_def(
   @admiral.CommandDef::CommandDef(
     name="sync",
     description="Reconcile managed skill links from the lock file",
-    options=[sync_global_option],
+    options=[sync_global_option, sync_recursive_option],
     run=Some(run),
   )
 }

--- a/mbt/app/c-plugin-v2/src/command_sync_recursive_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/command_sync_recursive_wbtest.mbt
@@ -1,0 +1,144 @@
+///|
+fn recursive_sync_test_cli(runtime : Runtime) -> @admiral.CliApp {
+  @admiral.CliApp::CliApp(name="c-plugin", version="test", description="test", commands=[
+    @admiral.CommandDef::CommandDef(name="skill", subcommands=[
+      sync_command_def(async fn(context) { run_sync(runtime, context) }),
+    ]),
+  ])
+}
+
+///|
+async test "Sync command recursive 1 - routes the short recursive option to recursive project discovery" {
+  with_sync_test_runtime(async fn(_fixture_runtime, root) {
+    let paths = RuntimePaths::RuntimePaths(
+      root.join("home"),
+      root.join("project"),
+      root.join("cache"),
+    )
+    let empty_lock = Lock::Lock([], [])
+    let project_lock = paths.project_lock_path(paths.cwd)
+    let mut discovered_options = None
+    let runtime = Runtime::Runtime(
+      paths~,
+      discover_locks_api=(_paths, options) => {
+        discovered_options = Some(options)
+        ReadOnlyArray::from_array([project_lock])
+      },
+      load_lock=_path => empty_lock,
+      create_lock_exclusive~,
+      write_lock_atomic~,
+      load_ownership_state=path => raise StateStoreError::NotFound(path~),
+      write_ownership_state_atomic~,
+    )
+
+    recursive_sync_test_cli(runtime).run(
+      argv=Some(["skill", "sync", "-r"]),
+      env=Map([]),
+    )
+
+    debug_inspect(discovered_options, content="Some(Project(recursive=true))")
+  })
+}
+
+///|
+async test "Sync command recursive 2 - rejects global recursive sync before discovery" {
+  with_sync_test_runtime(async fn(_fixture_runtime, root) {
+    let paths = RuntimePaths::RuntimePaths(
+      root.join("home"),
+      root.join("project"),
+      root.join("cache"),
+    )
+    let mut discovery_called = false
+    let runtime = Runtime::Runtime(
+      paths~,
+      discover_locks_api=(_paths, _options) => {
+        discovery_called = true
+        ReadOnlyArray::from_array([])
+      },
+      load_lock~,
+      create_lock_exclusive~,
+      write_lock_atomic~,
+      load_ownership_state~,
+      write_ownership_state_atomic~,
+    )
+
+    try
+      recursive_sync_test_cli(runtime).run(
+        argv=Some(["skill", "sync", "-g", "-r"]),
+        env=Map([]),
+      )
+    catch {
+      SyncError::Planning(reason~) =>
+        inspect(reason, content="--global cannot be combined with --recursive")
+      _ => fail("expected recursive global validation error")
+    } noraise {
+      _ => fail("recursive global sync must fail")
+    }
+    inspect(discovery_called, content="false")
+  })
+}
+
+///|
+async test "Sync command recursive 3 - keeps completed lock ownership isolated when a later lock fails" {
+  with_sync_test_runtime(async fn(_fixture_runtime, root) {
+    let paths = RuntimePaths::RuntimePaths(
+      root.join("home"),
+      root.join("project"),
+      root.join("cache"),
+    )
+    let project = paths.cwd
+    create_sync_marketplace(project.join("marketplace"))
+    let parent_lock_path = project.join("c-plugin-lock.json")
+    let child_lock_path = project.join("child").join("c-plugin-lock.json")
+    create_lock_exclusive(parent_lock_path, sync_test_lock(["alpha"]))
+    let parent_state_path = project.join(".agents").join("c-plugin-state.json")
+    let child_state_path = child_lock_path
+      .dirname()
+      .join(".agents")
+      .join("c-plugin-state.json")
+    let foreign = project.join(".agents").join("skills").join("foreign")
+    @fs.mkdir(foreign.dirname().to_string(), recursive=true)
+    @fs.write_file(foreign.to_string(), "foreign\n", create_mode=CreateNew)
+    let mut discovered_options = None
+    let runtime = Runtime::Runtime(
+      paths~,
+      discover_locks_api=(_paths, options) => {
+        discovered_options = Some(options)
+        ReadOnlyArray::from_array([parent_lock_path, child_lock_path])
+      },
+      load_lock=path => {
+        if path == child_lock_path {
+          raise StateStoreError::Decode(path~, reason="invalid child lock")
+        }
+        load_lock(path)
+      },
+      create_lock_exclusive~,
+      write_lock_atomic~,
+      load_ownership_state~,
+      write_ownership_state_atomic~,
+    )
+
+    try
+      sync_locks(runtime, { global: false, recursive: true }) |> ignore
+    catch {
+      SyncError::Store(
+        cause=StateStoreError::Decode(path~, reason="invalid child lock")
+      ) => inspect(path == child_lock_path, content="true")
+      _ => fail("expected child lock decode failure")
+    } noraise {
+      _ => fail("recursive sync must report the child failure")
+    }
+
+    debug_inspect(discovered_options, content="Some(Project(recursive=true))")
+    inspect(@fs.exists(parent_state_path.to_string()), content="true")
+    inspect(@fs.exists(child_state_path.to_string()), content="false")
+    inspect(@fs.read_file(foreign.to_string()).text(), content="foreign\n")
+    debug_inspect(
+      @fs.kind(
+        project.join(".agents").join("skills").join("alpha").to_string(),
+        follow_symlink=false,
+      ),
+      content="SymLink",
+    )
+  })
+}

--- a/mbt/app/c-plugin-v2/src/e2e/Dockerfile
+++ b/mbt/app/c-plugin-v2/src/e2e/Dockerfile
@@ -41,8 +41,9 @@ WORKDIR /sandbox
 COPY --from=builder --chown=sandbox:sandbox /sandbox/.local/bin/c-plugin-v2 /sandbox/.local/bin/c-plugin-v2
 COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/init.sh /sandbox/e2e/init.sh
 COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/sync.sh /sandbox/e2e/sync.sh
+COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/sync_recursive.sh /sandbox/e2e/sync_recursive.sh
 
-RUN chmod +x /sandbox/.local/bin/c-plugin-v2 /sandbox/e2e/init.sh /sandbox/e2e/sync.sh && \
+RUN chmod +x /sandbox/.local/bin/c-plugin-v2 /sandbox/e2e/init.sh /sandbox/e2e/sync.sh /sandbox/e2e/sync_recursive.sh && \
     ln -s /sandbox/.local/bin/c-plugin-v2 /sandbox/.local/bin/c-plugin
 
 ENTRYPOINT ["/sandbox/e2e/init.sh"]

--- a/mbt/app/c-plugin-v2/src/e2e/run.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/run.sh
@@ -65,6 +65,9 @@ docker run --rm "${platform_args[@]}" "$image" global
 docker run --rm "${platform_args[@]}" \
   --entrypoint /sandbox/e2e/sync.sh \
   "$image"
+docker run --rm "${platform_args[@]}" \
+  --entrypoint /sandbox/e2e/sync_recursive.sh \
+  "$image"
 
 snapshot_host_state >"$after_state"
 if ! cmp -s "$before_state" "$after_state"; then

--- a/mbt/app/c-plugin-v2/src/e2e/sync_recursive.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/sync_recursive.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root=/tmp/c-plugin-v2-sync-recursive-e2e
+test_home=$test_root/home
+project_root=$test_home/project
+child_root=$project_root/child
+ignored_root=$project_root/ignored
+initial_stdout=$test_root/initial.stdout
+initial_stderr=$test_root/initial.stderr
+edited_stdout=$test_root/edited.stdout
+edited_stderr=$test_root/edited.stderr
+
+write_marketplace() {
+  local root=$1
+  local skill=$2
+  local repository=$root/marketplace
+  mkdir -p "$repository/.claude-plugin" "$repository/plugins/demo/skills/$skill"
+  printf '%s\n' \
+    '{"name":"fixture","plugins":[{"name":"demo","source":"plugins/demo"}]}' \
+    >"$repository/.claude-plugin/marketplace.json"
+  printf '# %s\n' "$skill" >"$repository/plugins/demo/skills/$skill/SKILL.md"
+}
+
+write_lock() {
+  local root=$1
+  local enabled_skill=$2
+  printf '%s\n' \
+    '{' \
+    '  "version": "2",' \
+    '  "targets": [],' \
+    '  "repositories": [' \
+    '    {' \
+    '      "type": "local",' \
+    '      "path": "marketplace",' \
+    '      "marketplaceKind": "claude",' \
+    '      "plugins": [' \
+    '        {' \
+    '          "name": "demo",' \
+    '          "path": "plugins/demo",' \
+    "          \"enabledSkills\": [$enabled_skill]" \
+    '        }' \
+    '      ]' \
+    '    }' \
+    '  ]' \
+    '}' >"$root/c-plugin-lock.json"
+}
+
+mkdir -p "$project_root" "$child_root" "$ignored_root"
+write_marketplace "$project_root" alpha
+write_marketplace "$child_root" beta
+write_lock "$project_root" '"alpha"'
+write_lock "$child_root" '"beta"'
+printf 'ignored/\n' >"$project_root/.gitignore"
+printf '{invalid\n' >"$ignored_root/c-plugin-lock.json"
+mkdir -p "$project_root/.agents/skills"
+printf 'foreign\n' >"$project_root/.agents/skills/foreign"
+cp "$project_root/c-plugin-lock.json" "$test_root/parent-initial.json"
+cp "$child_root/c-plugin-lock.json" "$test_root/child-initial.json"
+cd "$project_root"
+
+env HOME="$test_home" c-plugin skill sync -r >"$initial_stdout" 2>"$initial_stderr"
+
+[[ ! -s $initial_stderr ]]
+[[ $(grep -c '^Synced ' "$initial_stdout") -eq 2 ]]
+grep -F "Synced $project_root/c-plugin-lock.json:" "$initial_stdout" >/dev/null
+grep -F "Synced $child_root/c-plugin-lock.json:" "$initial_stdout" >/dev/null
+! grep -F "$ignored_root/c-plugin-lock.json" "$initial_stdout" >/dev/null
+[[ $(realpath "$project_root/.agents/skills/alpha") == "$project_root/marketplace/plugins/demo/skills/alpha" ]]
+[[ $(realpath "$child_root/.agents/skills/beta") == "$child_root/marketplace/plugins/demo/skills/beta" ]]
+[[ -f $project_root/.agents/c-plugin-state.json ]]
+[[ -f $child_root/.agents/c-plugin-state.json ]]
+grep -Fx 'foreign' "$project_root/.agents/skills/foreign" >/dev/null
+cmp -s "$test_root/parent-initial.json" "$project_root/c-plugin-lock.json"
+cmp -s "$test_root/child-initial.json" "$child_root/c-plugin-lock.json"
+
+write_lock "$project_root" ''
+cp "$project_root/c-plugin-lock.json" "$test_root/parent-edited.json"
+env HOME="$test_home" c-plugin skill sync --recursive >"$edited_stdout" 2>"$edited_stderr"
+
+[[ ! -s $edited_stderr ]]
+[[ $(grep -c '^Synced ' "$edited_stdout") -eq 2 ]]
+[[ ! -e $project_root/.agents/skills/alpha ]]
+[[ -L $child_root/.agents/skills/beta ]]
+grep -F '"skill": "beta"' "$child_root/.agents/c-plugin-state.json" >/dev/null
+grep -Fx 'foreign' "$project_root/.agents/skills/foreign" >/dev/null
+cmp -s "$test_root/parent-edited.json" "$project_root/c-plugin-lock.json"
+cmp -s "$test_root/child-initial.json" "$child_root/c-plugin-lock.json"
+
+set +e
+env HOME="$test_home" c-plugin skill sync -g -r >"$test_root/invalid.stdout" 2>"$test_root/invalid.stderr"
+invalid_status=$?
+set -e
+[[ $invalid_status -ne 0 ]]
+grep -F 'totto2727/c-plugin-v2.SyncError.Planning' "$test_root/invalid.stdout" >/dev/null
+
+printf 'PASS: recursive sync isolates descendant lock ownership\n'


### PR DESCRIPTION
## 概要

Linear: https://linear.app/totto2727/issue/TOT-120
親PR: #312
Stack: #307 → #312 → 本PR

c-plugin v2 の `skill sync` に `-r` / `--recursive` を追加し、最寄りのproject lockからHOME境界内の子project lockを順に同期します。既存のtarget-file-discovery経路を利用するため、gitignore対象は探索から除外されます。`--global` と `--recursive` の併用は探索前にtyped planning errorで拒否します。

## 処理フロー

```mermaid
flowchart TD
  A["c-plugin skill sync"] --> B{"global && recursive"}
  B -- Yes --> C["SyncError.Planning"]
  B -- No --> D{"global"}
  D -- Yes --> E["Global lock discovery"]
  D -- No --> F{"recursive"}
  F -- No --> G["Nearest project lock"]
  F -- Yes --> H["Nearest project lock + visible descendants"]
  E --> I["Process locks sequentially"]
  G --> I
  H --> I
  I --> J["Derive managed root and ownership state per lock"]
  J --> K["Reconcile links and checkpoint state"]
```

## テストケース

```mermaid
flowchart LR
  A["CLI routing"] --> A1["-r → Project recursive true"]
  A --> A2["-g -r → reject before discovery"]
  B["Failure isolation"] --> B1["Parent succeeds"]
  B1 --> B2["Child decode fails"]
  B2 --> B3["Parent link and state remain"]
  B2 --> B4["Foreign path remains"]
  C["Container E2E"] --> C1["Parent and child links/states"]
  C --> C2["Ignored invalid lock excluded"]
  C --> C3["Parent stale cleanup preserves child"]
  C --> C4["Lock bytes unchanged"]
```

## 検証

- `vp run mbt:check`
- `moon test mbt/app/c-plugin-v2/src --target native` 169/169 PASS
- `vp run mbt:build`
- workspace MoonBit tests 291/291 PASS
- `bash mbt/app/c-plugin-v2/src/e2e/run.sh` PASS
- 5 files、266 additions / 4 deletions、合計270行
- exact SHA: `abc9212d415e3c2332d37df458a10d353ecd932e`

## 依存関係

本PRは #312 のpersist-and-sync adapterにstackしています。#312は #307 にstackしています。