### PR TITLE
c-plugin v2にlocal marketplace addを実装する

### DIFF
--- a/mbt/app/c-plugin-v2/src/command_add_local.mbt
+++ b/mbt/app/c-plugin-v2/src/command_add_local.mbt
@@ -1,0 +1,271 @@
+///|
+let add_global_option : @admiral.OptionDef[Bool] = @admiral.bool(
+  "global",
+  short='g',
+  description="Use the user-level lock file",
+)
+
+///|
+let add_local_option : @admiral.OptionDef[String] = @admiral.string(
+  "local",
+  description="Local marketplace root beginning with ./",
+  required=true,
+)
+
+///|
+let add_kind_option : @admiral.OptionDef[String] = @admiral.string(
+  "kind",
+  description="Marketplace kind: claude, cursor, or codex",
+  required=true,
+)
+
+///|
+let add_skill_option : @admiral.OptionDef[Array[String]] = @admiral.strings(
+  "skill",
+  description="Plugin and skill selection as plugin/skill",
+  required=true,
+)
+
+///|
+struct AddLocalOptions {
+  global : Bool
+  source : RelativeSourcePath
+  kind : MarketplaceKind
+  selections : ReadOnlyArray[String]
+}
+
+///|
+struct AddLocalResult {
+  repository_root : RepositoryRoot
+  sync_result : SyncLockResult
+}
+
+///|
+struct AddSkillSelection {
+  plugin_name : PluginName
+  skill_name : SkillName
+}
+
+///|
+pub(all) suberror AddLocalError {
+  Discovery(cause~ : LockDiscoveryError)
+  Store(cause~ : StateStoreError)
+  InvalidInput(reason~ : String)
+  SyncAfterPersist(cause~ : SyncError)
+} derive(Debug)
+
+///|
+fn add_marketplace_kind(value : String) -> MarketplaceKind raise AddLocalError {
+  match value {
+    "claude" => MarketplaceKind::claude()
+    "cursor" => MarketplaceKind::cursor()
+    "codex" => MarketplaceKind::codex()
+    _ => raise InvalidInput(reason="unsupported marketplace kind: " + value)
+  }
+}
+
+///|
+fn add_local_options(context : @admiral.Context) -> AddLocalOptions raise {
+  let source = context.get_string_required(add_local_option)
+  guard source.has_prefix("./") else {
+    raise AddLocalError::InvalidInput(reason="--local path must begin with ./")
+  }
+  let source_path = RelativeSourcePath::RelativeSourcePath(
+    @path.Path(source).normalize(),
+  ) catch {
+    error => raise AddLocalError::InvalidInput(reason=error.to_string())
+  }
+  {
+    global: context.get_bool(add_global_option),
+    source: source_path,
+    kind: add_marketplace_kind(context.get_string_required(add_kind_option)),
+    selections: context.get_strings_required(add_skill_option).all,
+  }
+}
+
+///|
+fn resolve_add_repository_root(
+  lock_path : @path.Path,
+  source : RelativeSourcePath,
+) -> RepositoryRoot raise AddLocalError {
+  RepositoryRoot::RepositoryRoot(lock_path.dirname().join(source.path)) catch {
+    error =>
+      raise AddLocalError::InvalidInput(
+        reason=repository_root_error_reason(error),
+      )
+  }
+}
+
+///|
+fn parse_add_skill_selection(
+  value : String,
+) -> AddSkillSelection raise AddLocalError {
+  let parts : Array[String] = value
+    .split("/")
+    .map(part => part.to_owned())
+    .collect()
+  guard parts.length() == 2 else {
+    raise InvalidInput(reason="skill selection must be plugin/skill: " + value)
+  }
+  {
+    plugin_name: PluginName::PluginName(parts[0]) catch {
+      error => raise InvalidInput(reason=error.to_string())
+    },
+    skill_name: SkillName::SkillName(parts[1]) catch {
+      error => raise InvalidInput(reason=error.to_string())
+    },
+  }
+}
+
+///|
+fn build_local_add_candidate(
+  current_lock : Lock,
+  source : RelativeSourcePath,
+  kind : MarketplaceKind,
+  marketplace : Marketplace,
+  resolved_skills : ReadOnlyArray[ResolvedSkill],
+  selections : ReadOnlyArray[String],
+) -> Lock raise AddLocalError {
+  let selected = selections.map(parse_add_skill_selection)
+  for selection in selected {
+    guard resolved_skills.any(skill => {
+      skill.plugin_name == selection.plugin_name &&
+      skill.skill_name == selection.skill_name
+    }) else {
+      raise InvalidInput(
+        reason="unknown marketplace skill: {selection.plugin_name.value}/{selection.skill_name.value}",
+      )
+    }
+  }
+  let plugins : Array[Plugin] = []
+  for marketplace_plugin in marketplace.plugins {
+    let enabled = selected
+      .filter(selection => selection.plugin_name == marketplace_plugin.name)
+      .map(selection => selection.skill_name)
+      .iter()
+      .to_array()
+    if enabled.length() > 0 {
+      plugins.push(
+        Plugin::Plugin(
+          marketplace_plugin.name,
+          marketplace_plugin.path,
+          enabled,
+        ) catch {
+          error => raise InvalidInput(reason=error.to_string())
+        },
+      )
+    }
+  }
+  let repository = LocalLockRepository::LocalLockRepository(
+    source, kind, plugins,
+  ) catch {
+    error => raise InvalidInput(reason=error.to_string())
+  }
+  let repositories = current_lock.repositories.to_array().map(entry => entry.1)
+  repositories.push(LockRepository::from_local(repository))
+  Lock::Lock(current_lock.targets.iter().to_array(), repositories) catch {
+    error => raise InvalidInput(reason=error.to_string())
+  }
+}
+
+///|
+async fn add_local(
+  runtime : Runtime,
+  options : AddLocalOptions,
+) -> AddLocalResult raise AddLocalError {
+  let discovery_options = if options.global {
+    LockDiscoveryOptions::Global
+  } else {
+    LockDiscoveryOptions::Project(recursive=false)
+  }
+  let lock_paths = runtime.discover_locks(discovery_options) catch {
+    error => raise Discovery(cause=error)
+  }
+  guard lock_paths.length() == 1 else {
+    raise InvalidInput(reason="add requires exactly one lock file")
+  }
+  let lock_path = lock_paths[0]
+  let current_lock = runtime.load_lock(lock_path) catch {
+    error => raise Store(cause=error)
+  }
+  let repository_root = resolve_add_repository_root(lock_path, options.source)
+  let marketplace = read_marketplace_file(
+    repository_root.path.join(marketplace_manifest_path(options.kind)),
+    options.kind,
+  ) catch {
+    error => raise InvalidInput(reason=marketplace_read_error_reason(error))
+  }
+  let resolved_skills = resolve_marketplace_skills(repository_root, marketplace) catch {
+    error => raise InvalidInput(reason=skill_resolution_error_reason(error))
+  }
+  let candidate = build_local_add_candidate(
+    current_lock,
+    options.source,
+    options.kind,
+    marketplace,
+    resolved_skills,
+    options.selections,
+  )
+  let mut sync_result : SyncLockResult? = None
+  let result = persist_and_sync(
+    current_lock~,
+    candidate=Some(candidate),
+    persist=lock => runtime.write_lock_atomic(lock_path, lock),
+    sync=lock => {
+      try {
+        sync_result = Some(sync_loaded_lock(runtime, lock_path, lock))
+      } catch {
+        SyncError::Store(cause~) => raise SyncError::Store(cause~)
+        SyncError::InvalidPath(path~, reason~) =>
+          raise SyncError::InvalidPath(path~, reason~)
+        SyncError::Planning(reason~) => raise SyncError::Planning(reason~)
+        error => raise SyncError::Planning(reason=error.to_string())
+      }
+    },
+  ) catch {
+    error => raise Store(cause=error)
+  }
+  match result {
+    PersistedButSyncFailed(cause~) => raise SyncAfterPersist(cause~)
+    NoChange =>
+      raise InvalidInput(reason="add candidate did not change the lock")
+    Synced => ()
+  }
+  let synchronized = match sync_result {
+    Some(result) => result
+    None => raise InvalidInput(reason="add sync completed without a result")
+  }
+  { repository_root, sync_result: synchronized }
+}
+
+///|
+async fn run_add_local(runtime : Runtime, context : @admiral.Context) -> Unit {
+  let result = add_local(runtime, add_local_options(context))
+  println(
+    "Added " +
+    result.repository_root.path.to_string() +
+    " to " +
+    result.sync_result.lock_path.to_string() +
+    ": " +
+    sync_status_text(result.sync_result.reconciliation.status) +
+    " (" +
+    result.sync_result.reconciliation.notices.length().to_string() +
+    " notices, " +
+    result.sync_result.unavailable_repositories.length().to_string() +
+    " unavailable repositories)",
+  )
+}
+
+///|
+fn add_local_command_def(
+  run : async (@admiral.Context) -> Unit,
+) -> @admiral.CommandDef {
+  @admiral.CommandDef::CommandDef(
+    name="add",
+    description="Add a local plugin marketplace",
+    options=[
+      add_global_option, add_local_option, add_kind_option, add_skill_option,
+    ],
+    run=Some(run),
+  )
+}

--- a/mbt/app/c-plugin-v2/src/command_add_local_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/command_add_local_wbtest.mbt
@@ -1,0 +1,144 @@
+///|
+fn add_local_test_marketplace() -> Marketplace raise {
+  Marketplace::Marketplace("test", [
+    MarketplacePlugin::MarketplacePlugin(
+      PluginName::PluginName("demo"),
+      RelativePluginPath::RelativePluginPath("plugins/demo"),
+    ),
+  ])
+}
+
+///|
+fn add_local_test_resolved() -> ReadOnlyArray[ResolvedSkill] raise {
+  [
+    {
+      plugin_name: PluginName::PluginName("demo"),
+      plugin_path: RelativePluginPath::RelativePluginPath("plugins/demo"),
+      skill_name: SkillName::SkillName("alpha"),
+      skill_path: "/marketplace/plugins/demo/skills/alpha",
+    },
+    {
+      plugin_name: PluginName::PluginName("demo"),
+      plugin_path: RelativePluginPath::RelativePluginPath("plugins/demo"),
+      skill_name: SkillName::SkillName("beta"),
+      skill_path: "/marketplace/plugins/demo/skills/beta",
+    },
+  ]
+}
+
+///|
+test "Add local candidate 1 - keeps only explicitly selected skills" {
+  let candidate = build_local_add_candidate(
+    Lock::Lock([], []),
+    RelativeSourcePath::RelativeSourcePath("marketplace"),
+    MarketplaceKind::claude(),
+    add_local_test_marketplace(),
+    add_local_test_resolved(),
+    ["demo/beta"],
+  )
+
+  inspect(candidate.repositories.length(), content="1")
+  let repository = candidate.repositories.to_array()[0].1
+  match repository {
+    Local(repository) => {
+      inspect(repository.plugins.length(), content="1")
+      let plugin = repository.plugins.to_array()[0].1
+      inspect(
+        plugin.enabled_skills.contains(SkillName::SkillName("beta")),
+        content="true",
+      )
+      inspect(
+        plugin.enabled_skills.contains(SkillName::SkillName("alpha")),
+        content="false",
+      )
+    }
+    _ => fail("expected local repository")
+  }
+}
+
+///|
+test "Add local candidate 2 - rejects unknown duplicate skill and repository identities" {
+  let current = Lock::Lock([], [
+    LockRepository::from_local(
+      LocalLockRepository::LocalLockRepository(
+        RelativeSourcePath::RelativeSourcePath("marketplace"),
+        MarketplaceKind::claude(),
+        [],
+      ),
+    ),
+  ])
+  let attempts : Array[(Lock, ReadOnlyArray[String], String)] = [
+    (Lock::Lock([], []), ["demo/missing"], "unknown marketplace skill"),
+    (
+      Lock::Lock([], []),
+      ["demo/alpha", "demo/alpha"],
+      "plugin enabled skills must be unique",
+    ),
+    (current, ["demo/alpha"], "lock repositories must be unique"),
+  ]
+  for attempt in attempts {
+    try
+      build_local_add_candidate(
+        attempt.0,
+        RelativeSourcePath::RelativeSourcePath("marketplace"),
+        MarketplaceKind::claude(),
+        add_local_test_marketplace(),
+        add_local_test_resolved(),
+        attempt.1,
+      )
+      |> ignore
+    catch {
+      AddLocalError::InvalidInput(reason~) =>
+        inspect(reason.contains(attempt.2), content="true")
+      _ => fail("expected add input error")
+    } noraise {
+      _ => fail("invalid add candidate must fail")
+    }
+  }
+}
+
+///|
+async test "Add local command 3 - resolves local root from project and global locks" {
+  let mut captured = None
+  let cli = @admiral.CliApp::CliApp(name="c-plugin", commands=[
+    @admiral.CommandDef::CommandDef(name="skill", subcommands=[
+      add_local_command_def(context => {
+        captured = Some(add_local_options(context))
+      }),
+    ]),
+  ])
+
+  cli.run(
+    argv=Some([
+      "skill", "add", "--local", "./fixtures/../marketplace", "--kind", "claude",
+      "--skill", "demo/alpha", "--skill", "demo/beta",
+    ]),
+    env=Map([]),
+  )
+
+  match captured {
+    Some(options) => {
+      inspect(options.source.path.to_string(), content="marketplace")
+      inspect(
+        resolve_add_repository_root(
+          "/synthetic/project/c-plugin-lock.json",
+          options.source,
+        ).path.to_string(),
+        content="/synthetic/project/marketplace",
+      )
+      inspect(
+        resolve_add_repository_root(
+          "/synthetic/home/c-plugin-lock.json",
+          options.source,
+        ).path.to_string(),
+        content="/synthetic/home/marketplace",
+      )
+      inspect(options.kind == MarketplaceKind::claude(), content="true")
+      debug_inspect(
+        options.selections,
+        content="<ReadOnlyArray: [\"demo/alpha\", \"demo/beta\"]>",
+      )
+    }
+    None => fail("add command did not run")
+  }
+}

--- a/mbt/app/c-plugin-v2/src/command_sync.mbt
+++ b/mbt/app/c-plugin-v2/src/command_sync.mbt
@@ -48,8 +48,17 @@ struct SyncLockResult {
 ///|
 async fn sync_lock(runtime : Runtime, lock_path : @path.Path) -> SyncLockResult {
   let lock = runtime.load_lock(lock_path) catch {
-    error => raise Store(cause=error)
+    error => raise SyncError::Store(cause=error)
   }
+  sync_loaded_lock(runtime, lock_path, lock)
+}
+
+///|
+async fn sync_loaded_lock(
+  runtime : Runtime,
+  lock_path : @path.Path,
+  lock : Lock,
+) -> SyncLockResult {
   let repositories = resolve_repositories_for_sync(lock_path, lock) catch {
     DuplicateRepositoryIdentity(_) =>
       raise Planning(reason="duplicate repository identity in lock")

--- a/mbt/app/c-plugin-v2/src/e2e/Dockerfile
+++ b/mbt/app/c-plugin-v2/src/e2e/Dockerfile
@@ -42,8 +42,9 @@ COPY --from=builder --chown=sandbox:sandbox /sandbox/.local/bin/c-plugin-v2 /san
 COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/init.sh /sandbox/e2e/init.sh
 COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/sync.sh /sandbox/e2e/sync.sh
 COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/sync_recursive.sh /sandbox/e2e/sync_recursive.sh
+COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/add.sh /sandbox/e2e/add.sh
 
-RUN chmod +x /sandbox/.local/bin/c-plugin-v2 /sandbox/e2e/init.sh /sandbox/e2e/sync.sh /sandbox/e2e/sync_recursive.sh && \
+RUN chmod +x /sandbox/.local/bin/c-plugin-v2 /sandbox/e2e/*.sh && \
     ln -s /sandbox/.local/bin/c-plugin-v2 /sandbox/.local/bin/c-plugin
 
 ENTRYPOINT ["/sandbox/e2e/init.sh"]

--- a/mbt/app/c-plugin-v2/src/e2e/add.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/add.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+test_root=/tmp/c-plugin-v2-add-e2e
+home=$test_root/home
+project=$home/project
+repository=$project/marketplace
+plugin=$repository/plugins/demo
+lock=$project/c-plugin-lock.json
+state=$project/.agents/c-plugin-state.json
+stdout=$test_root/add.stdout
+repeat_stdout=$test_root/repeat.stdout
+foreign=$project/.agents/skills/alpha
+
+mkdir -p "$repository/.claude-plugin" "$plugin/skills/alpha" "$plugin/skills/beta"
+printf '%s\n' '{"name":"fixture","plugins":[{"name":"demo","source":"plugins/demo"}]}' >"$repository/.claude-plugin/marketplace.json"
+printf '# alpha\n' >"$plugin/skills/alpha/SKILL.md"
+printf '# beta\n' >"$plugin/skills/beta/SKILL.md"
+cd "$project"
+env HOME="$home" c-plugin init >/dev/null
+mkdir -p "$(dirname -- "$foreign")"
+printf 'foreign\n' >"$foreign"
+mkdir nested
+cd nested
+env HOME="$home" c-plugin skill add \
+  --local ./marketplace \
+  --kind claude \
+  --skill demo/alpha \
+  --skill demo/beta >"$stdout"
+grep -Fx "Added $repository to $lock: partial (2 notices, 0 unavailable repositories)" "$stdout" >/dev/null
+compact_lock=$(tr -d '[:space:]' <"$lock")
+[[ $compact_lock == '{"version":"2","targets":[],"repositories":[{"type":"local","path":"marketplace","marketplaceKind":"claude","plugins":[{"name":"demo","path":"plugins/demo","enabledSkills":["alpha","beta"]}]}]}' ]]
+link=$project/.agents/skills/beta
+[[ -L $link ]]
+[[ $(realpath "$link") == "$plugin/skills/beta" ]]
+[[ -f $foreign && ! -L $foreign ]]
+grep -Fx 'foreign' "$foreign" >/dev/null
+grep -F '"skill": "beta"' "$state" >/dev/null
+! grep -F '"skill": "alpha"' "$state" >/dev/null
+cp "$lock" "$test_root/before-repeat.json"
+set +e
+env HOME="$home" c-plugin skill add \
+  --local ./marketplace \
+  --kind claude \
+  --skill demo/alpha \
+  --skill demo/beta >"$repeat_stdout" 2>/dev/null
+repeat_status=$?
+set -e
+[[ $repeat_status -ne 0 ]]
+grep -F 'totto2727/c-plugin-v2.AddLocalError.InvalidInput' "$repeat_stdout" >/dev/null
+cmp -s "$test_root/before-repeat.json" "$lock"
+[[ -L $link ]]
+grep -F '"skill": "beta"' "$state" >/dev/null
+
+printf 'PASS: add local marketplace and repeat protection\n'

--- a/mbt/app/c-plugin-v2/src/e2e/run.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/run.sh
@@ -68,6 +68,9 @@ docker run --rm "${platform_args[@]}" \
 docker run --rm "${platform_args[@]}" \
   --entrypoint /sandbox/e2e/sync_recursive.sh \
   "$image"
+docker run --rm "${platform_args[@]}" \
+  --entrypoint /sandbox/e2e/add.sh \
+  "$image"
 
 snapshot_host_state >"$after_state"
 if ! cmp -s "$before_state" "$after_state"; then

--- a/mbt/app/c-plugin-v2/src/main.mbt
+++ b/mbt/app/c-plugin-v2/src/main.mbt
@@ -23,6 +23,9 @@ fn app(runtime : Runtime) -> @admiral.CliApp {
         name="skill",
         description="Manage skills from plugin repositories",
         subcommands=[
+          add_local_command_def(async fn(context) {
+            run_add_local(runtime, context)
+          }),
           sync_command_def(async fn(context) { run_sync(runtime, context) }),
         ],
       ),

--- a/mbt/app/c-plugin-v2/src/main_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/main_wbtest.mbt
@@ -1,5 +1,5 @@
 ///|
-test "CliApp app - exposes init and skill sync commands" {
+test "CliApp app - exposes init and skill add and sync commands" {
   let paths = RuntimePaths::RuntimePaths(
     "/tmp/c-plugin-v2-main-home", "/tmp/c-plugin-v2-main-cwd", "/tmp/c-plugin-v2-main-cache",
   )
@@ -10,6 +10,7 @@ test "CliApp app - exposes init and skill sync commands" {
   inspect(cli.commands.length(), content="2")
   inspect(cli.commands[0].name, content="init")
   inspect(cli.commands[1].name, content="skill")
-  inspect(cli.commands[1].subcommands.length(), content="1")
-  inspect(cli.commands[1].subcommands[0].name, content="sync")
+  inspect(cli.commands[1].subcommands.length(), content="2")
+  inspect(cli.commands[1].subcommands[0].name, content="add")
+  inspect(cli.commands[1].subcommands[1].name, content="sync")
 }


### PR DESCRIPTION
## 概要

Linear: https://linear.app/totto2727/issue/TOT-121
親PR: #314
Stack: #307 → #312 → #314 → 本PR

c-plugin v2 に非対話の `skill add --local` を追加します。discovered lock rootを基準にlocal marketplaceを解決し、`--kind` と反復可能な `--skill` で選択したskillだけをcanonical lockへ追加します。変更候補は `persist_and_sync` で永続化した後、同じ候補を同期します。foreign path衝突は保持し、同期結果をcomplete/partial、notice数、unavailable repository数として表示します。

## 処理フロー

```mermaid
flowchart TD
  A["c-plugin skill add --local"] --> B{"project / global"}
  B --> C["Authoritative lockを1件discover"]
  C --> D["lock root基準でlocal pathを正規化"]
  D --> E["marketplaceをdecode"]
  E --> F["--kind / --skillを決定論的に選択"]
  F --> G["domain boundaryで重複を拒否"]
  G --> H["Lock candidateを構築"]
  H --> I["candidateをatomic persist"]
  I --> J["同じcandidateでsync"]
  J --> K{"reconciliation status"}
  K --> L["complete / partial と件数を出力"]
  J -- "失敗" --> M["SyncAfterPersist"]
```

## テストケース

```mermaid
flowchart LR
  A["Candidate"] --> A1["選択skillのみ保存"]
  A --> A2["unknown / duplicate skill拒否"]
  A --> A3["duplicate repository拒否"]
  B["Path authority"] --> B1["nested project → project lock root"]
  B --> B2["global → HOME lock root"]
  C["Reconciliation"] --> C1["foreign alphaを保持・非所有"]
  C --> C2["beta link/stateを所有"]
  C --> C3["partial 2 noticesを完全一致"]
  D["Repeat"] --> D1["非0終了"]
  D --> D2["lock/state/link無変更"]
  E["Regression"] --> E1["native 172/172"]
  E --> E2["workspace 294/294"]
  E --> E3["Docker project/global/sync/recursive/add"]
```

## 検証

- `vp run mbt:check`
- `moon test mbt/app/c-plugin-v2/src --target native` 172/172 PASS
- `vp run mbt:build`
- `vp run mbt:test` 294/294 PASS
- `bash mbt/app/c-plugin-v2/src/e2e/run.sh` PASS
- 実CLIのnested project/global add、foreign collision、repeat atomicity、post-persist failureを確認
- exact-SHA review 6レーン PASS
- 8 files、491 additions / 5 deletions、合計496行
- exact SHA: `464e3fc8c2732ab148c742153a28ede22559c93b`

## 依存関係

本PRは #314 のrecursive syncにstackしています。#314は #312、#312は #307 にstackしています。

既存のNix isolated registry pin不整合は本差分では変更せず、別issue [TOT-183](https://linear.app/totto2727/issue/TOT-183/c-plugin-v2-nix-packageのmooncakes-registry-pinをmanifestへ同期する) で修正します。