### PR TITLE
fix(c-plugin-v2): Admiral manifestを実効版0.6.2へ同期する

### DIFF
--- a/mbt/app/c-plugin-v2/moon.mod
+++ b/mbt/app/c-plugin-v2/moon.mod
@@ -22,7 +22,7 @@ import {
   "mizchi/tui@0.10.0",
   "moonbitlang/async@0.20.3",
   "moonbitlang/x@0.4.47",
-  "totto2727/admiral@0.6.1",
+  "totto2727/admiral@0.6.2",
   "totto2727/lens@0.4.2",
   "totto2727/target-file-discovery@0.2.1",
 }


### PR DESCRIPTION
## 概要

c-plugin-v2 自身の manifest が要求する Admiral を `0.6.1` から、現行 source API と isolated package 定義が使用する `0.6.2` へ同期します。

通常の MoonBit workspace では別 member の `0.6.2` 要求により不整合が隠れていましたが、isolated Nix build では `0.6.1` が選ばれ、`CommandDef::CommandDef` / `CliApp::CliApp` が解決できませんでした。本 PR は source を変更せず manifest だけを正します。

Linear: [TOT-184](https://linear.app/totto2727/issue/TOT-184/c-plugin-v2-manifestのadmiral依存を実効版062へ同期する)

## 処理フロー

```mermaid
flowchart TD
  A["c-plugin-v2 moon.mod"] --> B["Admiral 0.6.2 を明示要求"]
  B --> C["現行 custom constructor API と一致"]
  C --> D["workspace と isolated build の解決結果を統一"]
  D --> E["後続 TOT-183 の Nix registry pin を適用可能"]
```

## テスト条件

```mermaid
flowchart TD
  A["Admiral manifest 0.6.2"] --> B{"検証面"}
  B --> C["native package"]
  C --> C1["check PASS"]
  C --> C2["172 / 172 tests PASS"]
  B --> D["workspace"]
  D --> D1["check / build PASS"]
  D --> D2["294 / 294 tests PASS"]
  B --> E["real CLI"]
  E --> E1["help PASS"]
  E --> E2["version 0.1.0"]
  B --> F["Docker E2E"]
  F --> F1["init / sync / recursive / add PASS"]
  B --> G["future stacked Nix"]
  G --> G1["Admiral 0.6.2 + Lens 0.4.2 resolve"]
  G --> G2["nix build PASS"]
```

## 検証

- `moon check mbt/app/c-plugin-v2/src --target native`
- `moon test mbt/app/c-plugin-v2/src --target native`: 172 passed
- `vp run mbt:check`
- `vp run mbt:build`
- `vp run mbt:test`: 294 passed
- `bash mbt/app/c-plugin-v2/src/e2e/run.sh`
- 後続 TOT-183 の変更を重ねた `nix build ./mbt#c-plugin-v2 --no-link --print-build-logs`
- Nix store binary の `--help` / `--version`: 0.1.0
- exact SHA review-work 6 lanes: PASS

## Stack

#307 → #312 → #314 → #315 → 本 PR

Base: `codex/tot-121-add-local`

## Scope

- 1 issue = 1 commit = 1 PR
- 1 file、1 addition / 1 deletion
- source、test、async cancellation 処理は変更しません