### PR TITLE
fix(c-plugin-v2): Nix registry pinをmanifestへ同期する

### DIFF
--- a/mbt/app/c-plugin-v2/package.nix
+++ b/mbt/app/c-plugin-v2/package.nix
@@ -14,7 +14,7 @@ let
     "moonbitlang/x" = "0.4.47";
     "shu-kitamura/sha256" = "0.1.1";
     "totto2727/admiral" = "0.6.2";
-    "totto2727/lens" = "0.4.0";
+    "totto2727/lens" = "0.4.2";
     "totto2727/target-file-discovery" = "0.2.1";
   };
   cachedRegistry = moonPlatform.buildCachedRegistry {

--- a/mbt/flake.lock
+++ b/mbt/flake.lock
@@ -3,11 +3,11 @@
     "moon-registry": {
       "flake": false,
       "locked": {
-        "lastModified": 1786351871,
-        "narHash": "sha256-55SgNYr7YFm134+t8RGSH02eskwOykjCOOP8SfC99B0=",
+        "lastModified": 1786419373,
+        "narHash": "sha256-r8O1ZFqQj9btE/Z9UtbRtBEUWQw8Ms8DuB0kBRQPL9M=",
         "ref": "refs/heads/main",
-        "rev": "e6d628e537263a2740f6dbb0c14f38df2e9bd2ca",
-        "revCount": 12165,
+        "rev": "4630af617b7f738f1065f0e4e50b7d6c7e3c7633",
+        "revCount": 12222,
         "type": "git",
         "url": "https://mooncakes.io/git/index"
       },


### PR DESCRIPTION
## 概要

c-plugin-v2 の isolated Nix package が使う Mooncakes registry pin を、manifest と通常 workspace の実効依存へ同期します。

`moon.mod` は Lens `0.4.2` を要求していましたが、`package.nix` は `0.4.0` を固定し、古い registry revision には `0.4.2` artifact がありませんでした。本 PR で Lens pin を `0.4.2` に揃え、公式 Mooncakes registry main revision `4630af617b7f738f1065f0e4e50b7d6c7e3c7633` を固定します。Admiral は親 PR #316 と一致する `0.6.2` を維持します。

Linear: [TOT-183](https://linear.app/totto2727/issue/TOT-183/c-plugin-v2-nix-packageのmooncakes-registry-pinをmanifestへ同期する)

## 処理フロー

```mermaid
flowchart TD
  A["c-plugin-v2 moon.mod"] --> B["Lens 0.4.2 / Admiral 0.6.2"]
  B --> C["package.nix の isolated dependency pin"]
  C --> D["Mooncakes registry rev 4630af6 を固定"]
  D --> E["cached registry に両 artifact を配置"]
  E --> F["isolated Nix package build"]
  F --> G["c-plugin-v2 0.1.0 binary"]
```

## テスト条件

```mermaid
flowchart TD
  A["pin 整合"] --> B{"検証面"}
  B --> C["registry metadata"]
  C --> C1["URL / rev / narHash 一致"]
  B --> D["Nix c-plugin-v2"]
  D --> D1["build PASS"]
  D --> D2["help / version 0.1.0 PASS"]
  B --> E["Nix v1 c-plugin"]
  E --> E1["build PASS"]
  B --> F["MoonBit"]
  F --> F1["native 172 / 172 PASS"]
  F --> F2["workspace 294 / 294 PASS"]
  B --> G["Docker E2E"]
  G --> G1["init / sync / recursive / add PASS"]
```

## 検証

- `nix flake metadata ./mbt --json --no-write-lock-file`
- `nix flake check ./mbt --no-build --no-write-lock-file`
- `nix build ./mbt#c-plugin-v2 --no-link --print-build-logs`
- Nix store binary `c-plugin-v2 --help` / `--version`: 0.1.0
- `nix build ./mbt#c-plugin --no-link`
- `moon test mbt/app/c-plugin-v2/src --target native`: 172 passed
- `vp run mbt:check`
- `vp run mbt:build`
- `vp run mbt:test`: 294 passed
- `bash mbt/app/c-plugin-v2/src/e2e/run.sh`
- exact SHA review-work 6 lanes: PASS

## Stack

#307 → #312 → #314 → #315 → #316 → 本 PR

Base: `codex/tot-184-admiral-struct-construction`

## Scope

- 1 issue = 1 commit = 1 PR
- 2 files、5 additions / 5 deletions
- v1 source/package、CLI source、test、async cancellation 処理は変更しません