### PR TITLE
feat(c-plugin-v2): skill target addを実装する

### DIFF
--- a/mbt/app/c-plugin-v2/src/command_target_add.mbt
+++ b/mbt/app/c-plugin-v2/src/command_target_add.mbt
@@ -1,0 +1,149 @@
+///|
+let target_add_global_option : @admiral.OptionDef[Bool] = @admiral.bool(
+  "global",
+  short='g',
+  description="Use the user-level lock file",
+)
+
+///|
+let target_add_path_argument : @admiral.PositionDef[String] = @admiral.position_string(
+  "path",
+  description="Additional skill-link root relative to the lock file",
+)
+
+///|
+struct TargetAddOptions {
+  global : Bool
+  target : Target
+}
+
+///|
+enum TargetAddResult {
+  Added(target~ : Target, sync_result~ : SyncLockResult)
+  AlreadyPresent(target~ : Target, lock_path~ : @path.Path)
+}
+
+///|
+pub(all) suberror TargetAddError {
+  Discovery(cause~ : LockDiscoveryError)
+  Store(cause~ : StateStoreError)
+  InvalidInput(reason~ : String)
+  SyncAfterPersist(cause~ : SyncError)
+} derive(Debug)
+
+///|
+fn target_add_options(context : @admiral.Context) -> TargetAddOptions raise {
+  let path : @path.Path = context.get_string_required(target_add_path_argument)
+  let target = Target::Target(path) catch {
+    error => raise TargetAddError::InvalidInput(reason=error.to_string())
+  }
+  { global: context.get_bool(target_add_global_option), target }
+}
+
+///|
+fn target_add_discovery_options(global : Bool) -> LockDiscoveryOptions {
+  if global {
+    LockDiscoveryOptions::Global
+  } else {
+    LockDiscoveryOptions::Project(recursive=false)
+  }
+}
+
+///|
+fn build_target_add_candidate(
+  current_lock : Lock,
+  target : Target,
+) -> Lock raise TargetAddError {
+  let targets = current_lock.targets.add(target).iter().to_array()
+  let repositories = current_lock.repositories.to_array().map(entry => entry.1)
+  Lock::Lock(targets, repositories) catch {
+    error => raise InvalidInput(reason=error.to_string())
+  }
+}
+
+///|
+async fn target_add(
+  runtime : Runtime,
+  options : TargetAddOptions,
+) -> TargetAddResult raise TargetAddError {
+  let lock_paths = runtime.discover_locks(
+    target_add_discovery_options(options.global),
+  ) catch {
+    error => raise Discovery(cause=error)
+  }
+  guard lock_paths.length() == 1 else {
+    raise InvalidInput(reason="target add requires exactly one lock file")
+  }
+  let lock_path = lock_paths[0]
+  let current_lock = runtime.load_lock(lock_path) catch {
+    error => raise Store(cause=error)
+  }
+  let candidate = build_target_add_candidate(current_lock, options.target)
+  let mut sync_result : SyncLockResult? = None
+  let result = persist_and_sync(
+    current_lock~,
+    candidate=Some(candidate),
+    persist=lock => runtime.write_lock_atomic(lock_path, lock),
+    sync=lock => {
+      try {
+        sync_result = Some(sync_loaded_lock(runtime, lock_path, lock))
+      } catch {
+        SyncError::Store(cause~) => raise SyncError::Store(cause~)
+        SyncError::InvalidPath(path~, reason~) =>
+          raise SyncError::InvalidPath(path~, reason~)
+        SyncError::Planning(reason~) => raise SyncError::Planning(reason~)
+        error => raise SyncError::Planning(reason=error.to_string())
+      }
+    },
+  ) catch {
+    error => raise Store(cause=error)
+  }
+  match result {
+    NoChange => AlreadyPresent(target=options.target, lock_path~)
+    PersistedButSyncFailed(cause~) => raise SyncAfterPersist(cause~)
+    Synced =>
+      match sync_result {
+        Some(sync_result) => Added(target=options.target, sync_result~)
+        None =>
+          raise InvalidInput(
+            reason="target add sync completed without a result",
+          )
+      }
+  }
+}
+
+///|
+async fn run_target_add(runtime : Runtime, context : @admiral.Context) -> Unit {
+  match target_add(runtime, target_add_options(context)) {
+    AlreadyPresent(target~, lock_path~) =>
+      println("Target \{target.path} already registered in \{lock_path}")
+    Added(target~, sync_result~) =>
+      println(
+        "Added target \{target.path} to \{sync_result.lock_path}: \{sync_status_text(sync_result.reconciliation.status)} (\{sync_result.reconciliation.notices.length()} notices, \{sync_result.unavailable_repositories.length()} unavailable repositories)",
+      )
+  }
+}
+
+///|
+fn target_add_command_def(
+  run : async (@admiral.Context) -> Unit,
+) -> @admiral.CommandDef {
+  @admiral.CommandDef::CommandDef(
+    name="add",
+    description="Add an additional skill-link root",
+    positionals=[target_add_path_argument],
+    options=[target_add_global_option],
+    run=Some(run),
+  )
+}
+
+///|
+fn target_command_def(
+  run_add : async (@admiral.Context) -> Unit,
+) -> @admiral.CommandDef {
+  @admiral.CommandDef::CommandDef(
+    name="target",
+    description="Manage additional skill-link roots",
+    subcommands=[target_add_command_def(run_add)],
+  )
+}

--- a/mbt/app/c-plugin-v2/src/command_target_add_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/command_target_add_wbtest.mbt
@@ -1,0 +1,51 @@
+///|
+test "Target add candidate 1 - adds one normalized unique target" {
+  let current = Lock::Lock([], [])
+  let target = Target::Target(".cursor/./skills")
+  let candidate = build_target_add_candidate(current, target)
+  inspect(candidate.targets.length(), content="1")
+  inspect(
+    candidate.targets.contains(Target::Target(".cursor/skills")),
+    content="true",
+  )
+  inspect(candidate.repositories == current.repositories, content="true")
+}
+
+///|
+test "Target add candidate 2 - duplicate normalized target is semantic no-op" {
+  let current = Lock::Lock([Target::Target(".cursor/skills")], [])
+  let candidate = build_target_add_candidate(
+    current,
+    Target::Target(".cursor/./skills"),
+  )
+  inspect(candidate == current, content="true")
+}
+
+///|
+async test "Target add command 3 - parses typed path and global scope" {
+  let mut captured : TargetAddOptions? = None
+  let cli = @admiral.CliApp::CliApp(name="c-plugin", commands=[
+    @admiral.CommandDef::CommandDef(name="skill", subcommands=[
+      target_command_def(context => captured = Some(target_add_options(context))),
+    ]),
+  ])
+  cli.run(
+    argv=Some(["skill", "target", "add", ".cursor/./skills", "--global"]),
+    env=Map([]),
+  )
+  match captured {
+    Some(options) => {
+      inspect(options.global, content="true")
+      inspect(options.target.path.to_string(), content=".cursor/skills")
+    }
+    None => fail("target add command did not run")
+  }
+  match target_add_discovery_options(false) {
+    Project(recursive~) => inspect(recursive, content="false")
+    _ => fail("project target add must use project discovery")
+  }
+  match target_add_discovery_options(true) {
+    Global => ()
+    _ => fail("global target add must use global discovery")
+  }
+}

--- a/mbt/app/c-plugin-v2/src/e2e/Dockerfile
+++ b/mbt/app/c-plugin-v2/src/e2e/Dockerfile
@@ -43,6 +43,7 @@ COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/init.sh /sandbox/e2e/in
 COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/sync.sh /sandbox/e2e/sync.sh
 COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/sync_recursive.sh /sandbox/e2e/sync_recursive.sh
 COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/add.sh /sandbox/e2e/add.sh
+COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/target_add.sh /sandbox/e2e/target_add.sh
 
 RUN chmod +x /sandbox/.local/bin/c-plugin-v2 /sandbox/e2e/*.sh && \
     ln -s /sandbox/.local/bin/c-plugin-v2 /sandbox/.local/bin/c-plugin

--- a/mbt/app/c-plugin-v2/src/e2e/run.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/run.sh
@@ -71,6 +71,9 @@ docker run --rm "${platform_args[@]}" \
 docker run --rm "${platform_args[@]}" \
   --entrypoint /sandbox/e2e/add.sh \
   "$image"
+docker run --rm "${platform_args[@]}" \
+  --entrypoint /sandbox/e2e/target_add.sh \
+  "$image"
 
 snapshot_host_state >"$after_state"
 if ! cmp -s "$before_state" "$after_state"; then

--- a/mbt/app/c-plugin-v2/src/e2e/target_add.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/target_add.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root=/tmp/c-plugin-v2-target-add-e2e
+rm -rf -- "$test_root"
+trap 'rm -rf -- "$test_root"' EXIT INT TERM
+test_home=$test_root/home
+project_root=$test_home/project
+project_repository=$project_root/marketplace
+project_plugin=$project_repository/plugins/demo
+project_lock=$project_root/c-plugin-lock.json
+project_state=$project_root/.agents/c-plugin-state.json
+
+mkdir -p "$project_repository/.claude-plugin" "$project_plugin/skills/alpha"
+printf '%s\n' '{"name":"fixture","plugins":[{"name":"demo","source":"plugins/demo"}]}' >"$project_repository/.claude-plugin/marketplace.json"
+printf '# alpha\n' >"$project_plugin/skills/alpha/SKILL.md"
+printf '%s\n' '{"version":"2","targets":[],"repositories":[{"type":"local","path":"marketplace","marketplaceKind":"claude","plugins":[{"name":"demo","path":"plugins/demo","enabledSkills":["alpha"]}]}]}' >"$project_lock"
+
+cd "$project_root"
+project_output=$(env HOME="$test_home" c-plugin skill target add .cursor/skills)
+[[ $project_output == "Added target .cursor/skills to $project_lock: partial (1 notices, 0 unavailable repositories)" ]]
+compact_project_lock=$(tr -d '[:space:]' <"$project_lock")
+[[ $compact_project_lock == '{"version":"2","targets":[".cursor/skills"],"repositories":[{"type":"local","path":"marketplace","marketplaceKind":"claude","plugins":[{"name":"demo","path":"plugins/demo","enabledSkills":["alpha"]}]}]}' ]]
+for root in "$project_root/.agents/skills" "$project_root/.cursor/skills"; do
+  [[ -L $root/alpha ]]
+  [[ $(realpath "$root/alpha") == "$project_plugin/skills/alpha" ]]
+done
+grep -F "\"managedRoot\": \"$project_root/.agents/skills\"" "$project_state" >/dev/null
+grep -F "\"managedRoot\": \"$project_root/.cursor/skills\"" "$project_state" >/dev/null
+
+project_lock_hash=$(cksum "$project_lock")
+project_state_hash=$(cksum "$project_state")
+repeat_output=$(env HOME="$test_home" c-plugin skill target add .cursor/./skills)
+[[ $repeat_output == "Target .cursor/skills already registered in $project_lock" ]]
+[[ $(cksum "$project_lock") == "$project_lock_hash" ]]
+[[ $(cksum "$project_state") == "$project_state_hash" ]]
+
+global_repository=$test_home/global-marketplace
+global_plugin=$global_repository/plugins/demo
+global_lock=$test_home/c-plugin-lock.json
+global_state=$test_home/.agents/c-plugin-state.json
+mkdir -p "$global_repository/.claude-plugin" "$global_plugin/skills/beta" "$project_root/nested"
+printf '%s\n' '{"name":"fixture","plugins":[{"name":"demo","source":"plugins/demo"}]}' >"$global_repository/.claude-plugin/marketplace.json"
+printf '# beta\n' >"$global_plugin/skills/beta/SKILL.md"
+printf '%s\n' '{"version":"2","targets":[],"repositories":[{"type":"local","path":"global-marketplace","marketplaceKind":"claude","plugins":[{"name":"demo","path":"plugins/demo","enabledSkills":["beta"]}]}]}' >"$global_lock"
+
+cd "$project_root/nested"
+global_output=$(env HOME="$test_home" c-plugin skill target add .claude/skills --global)
+[[ $global_output == "Added target .claude/skills to $global_lock: partial (1 notices, 0 unavailable repositories)" ]]
+for root in "$test_home/.agents/skills" "$test_home/.claude/skills"; do
+  [[ -L $root/beta ]]
+  [[ $(realpath "$root/beta") == "$global_plugin/skills/beta" ]]
+done
+grep -F '"targets": [' "$global_lock" >/dev/null
+grep -F '".claude/skills"' "$global_lock" >/dev/null
+grep -F "\"managedRoot\": \"$test_home/.claude/skills\"" "$global_state" >/dev/null
+
+printf 'PASS: target add project/global and repeat no-op\n'

--- a/mbt/app/c-plugin-v2/src/main.mbt
+++ b/mbt/app/c-plugin-v2/src/main.mbt
@@ -27,6 +27,9 @@ fn app(runtime : Runtime) -> @admiral.CliApp {
             run_add_local(runtime, context)
           }),
           sync_command_def(async fn(context) { run_sync(runtime, context) }),
+          target_command_def(async fn(context) {
+            run_target_add(runtime, context)
+          }),
         ],
       ),
     ],

--- a/mbt/app/c-plugin-v2/src/main_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/main_wbtest.mbt
@@ -1,5 +1,5 @@
 ///|
-test "CliApp app - exposes init and skill add and sync commands" {
+test "CliApp app - exposes init and skill leaf commands" {
   let paths = RuntimePaths::RuntimePaths(
     "/tmp/c-plugin-v2-main-home", "/tmp/c-plugin-v2-main-cwd", "/tmp/c-plugin-v2-main-cache",
   )
@@ -10,7 +10,10 @@ test "CliApp app - exposes init and skill add and sync commands" {
   inspect(cli.commands.length(), content="2")
   inspect(cli.commands[0].name, content="init")
   inspect(cli.commands[1].name, content="skill")
-  inspect(cli.commands[1].subcommands.length(), content="2")
+  inspect(cli.commands[1].subcommands.length(), content="3")
   inspect(cli.commands[1].subcommands[0].name, content="add")
   inspect(cli.commands[1].subcommands[1].name, content="sync")
+  inspect(cli.commands[1].subcommands[2].name, content="target")
+  inspect(cli.commands[1].subcommands[2].subcommands.length(), content="1")
+  inspect(cli.commands[1].subcommands[2].subcommands[0].name, content="add")
 }


### PR DESCRIPTION
## 概要

`c-plugin skill target add <path> [-g]` を追加し、既存 lock に追加の skill-link root を登録して、同じ candidate を即時同期します。

target は lock 基準の typed relative `Path` として正規化し、immutable set で一意性を保証します。正規化後に既存 target と一致する再実行は成功 no-op とし、lock/state の書き込みも sync も行いません。

Linear: [TOT-122](https://linear.app/totto2727/issue/TOT-122/c-plugin-v2-m3-c-target-add-target-add-commandを実装する)

## 処理フロー

```mermaid
flowchart TD
  A["skill target add path"] --> B["Targetでrelative pathを検証・正規化"]
  B --> C{"project / global"}
  C --> D["既存lockを1件取得"]
  D --> E["immutable target setへ追加"]
  E --> F{"candidate == current"}
  F -->|yes| G["AlreadyPresent: write/syncなし"]
  F -->|no| H["candidateをatomic persist"]
  H --> I["同じcandidateをsync_loaded_lockへ渡す"]
  I --> J["primary + additional rootをreconcile"]
  J --> K["status / notice / unavailableを表示"]
```

## テスト条件

```mermaid
flowchart TD
  A["target add"] --> B{"ケース"}
  B --> C["project .cursor/skills"]
  C --> C1["canonical lock"]
  C --> C2["primary + cursor link/state"]
  B --> D["global .claude/skills"]
  D --> D1["nested CWDからHOME lock"]
  D --> D2["primary + claude link/state"]
  B --> E["normalized repeat"]
  E --> E1["exit 0 AlreadyPresent"]
  E --> E2["lock/state hash不変"]
  B --> F["invalid path"]
  F --> F1["absolute/traversalを拒否"]
  F --> F2["lock無変更"]
  B --> G["post-persist sync failure"]
  G --> G1["persist済みcandidateを保持"]
  G --> G2["成功表示なし"]
```

## 検証

- `moon test mbt/app/c-plugin-v2/src/command_target_add_wbtest.mbt --target native`: 3 passed
- `moon check mbt/app/c-plugin-v2/src --target native`
- `moon test mbt/app/c-plugin-v2/src --target native`: 175 passed
- `vp run mbt:check`
- `vp run mbt:build`
- `vp run mbt:test`: 297 passed
- `bash mbt/app/c-plugin-v2/src/e2e/run.sh`
- real CLI project/global/repeat/invalid/post-persist failure
- exact SHA review-work 6 lanes: PASS

## Stack

#307 → #312 → #314 → #315 → #316 → #317 → 本 PR

Base: `codex/tot-183-nix-registry-pin`

## Scope

- 1 issue = 1 commit = 1 PR
- 7 files、271 additions / 2 deletions = 273 changed lines
- dependency変更なし
- async cancellation固有の処理は追加しません