### PR TITLE
TOT-124: target remove commandを実装する

### DIFF
--- a/mbt/app/c-plugin-v2/src/command_target_add.mbt
+++ b/mbt/app/c-plugin-v2/src/command_target_add.mbt
@@ -140,10 +140,14 @@ fn target_add_command_def(
 ///|
 fn target_command_def(
   run_add : async (@admiral.Context) -> Unit,
+  run_remove : async (@admiral.Context) -> Unit,
 ) -> @admiral.CommandDef {
   @admiral.CommandDef::CommandDef(
     name="target",
     description="Manage additional skill-link roots",
-    subcommands=[target_add_command_def(run_add)],
+    subcommands=[
+      target_add_command_def(run_add),
+      target_remove_command_def(run_remove),
+    ],
   )
 }

--- a/mbt/app/c-plugin-v2/src/command_target_add_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/command_target_add_wbtest.mbt
@@ -26,7 +26,10 @@ async test "Target add command 3 - parses typed path and global scope" {
   let mut captured : TargetAddOptions? = None
   let cli = @admiral.CliApp::CliApp(name="c-plugin", commands=[
     @admiral.CommandDef::CommandDef(name="skill", subcommands=[
-      target_command_def(context => captured = Some(target_add_options(context))),
+      target_command_def(
+        context => captured = Some(target_add_options(context)),
+        _ => (),
+      ),
     ]),
   ])
   cli.run(

--- a/mbt/app/c-plugin-v2/src/command_target_remove.mbt
+++ b/mbt/app/c-plugin-v2/src/command_target_remove.mbt
@@ -1,0 +1,157 @@
+///|
+let target_remove_global_option : @admiral.OptionDef[Bool] = @admiral.bool(
+  "global",
+  short='g',
+  description="Use the user-level lock file",
+)
+
+///|
+let target_remove_target_option : @admiral.OptionDef[Array[String]] = @admiral.strings(
+  "target",
+  description="Additional skill-link root to remove",
+)
+
+///|
+struct TargetRemoveOptions {
+  global : Bool
+  targets : ReadOnlyArray[Target]
+}
+
+///|
+enum TargetRemoveResult {
+  Removed(targets~ : ReadOnlyArray[Target], sync_result~ : SyncLockResult)
+  Unchanged(lock_path~ : @path.Path)
+}
+
+///|
+pub(all) suberror TargetRemoveError {
+  Discovery(cause~ : LockDiscoveryError)
+  Store(cause~ : StateStoreError)
+  InvalidInput(reason~ : String)
+  SyncAfterPersist(cause~ : SyncError)
+} derive(Debug)
+
+///|
+fn target_remove_options(
+  context : @admiral.Context,
+) -> TargetRemoveOptions raise {
+  let targets = []
+  for value in context.get_strings(target_remove_target_option) {
+    let target = Target::Target(value) catch {
+      error => raise TargetRemoveError::InvalidInput(reason=error.to_string())
+    }
+    targets.push(target)
+  }
+  {
+    global: context.get_bool(target_remove_global_option),
+    targets: ReadOnlyArray::from_array(targets),
+  }
+}
+
+///|
+fn target_remove_discovery_options(global : Bool) -> LockDiscoveryOptions {
+  if global {
+    LockDiscoveryOptions::Global
+  } else {
+    LockDiscoveryOptions::Project(recursive=false)
+  }
+}
+
+///|
+fn build_target_remove_candidate(
+  current_lock : Lock,
+  targets : ReadOnlyArray[Target],
+) -> Lock? raise TargetRemoveError {
+  guard targets.length() > 0 else { return None }
+  for target in targets {
+    guard current_lock.targets.contains(target) else { return None }
+  }
+  let remaining_targets = current_lock.targets
+    .iter()
+    .filter(target => !targets.contains(target))
+    .to_array()
+  let repositories = current_lock.repositories.to_array().map(entry => entry.1)
+  let candidate = Lock::Lock(remaining_targets, repositories) catch {
+    error => raise InvalidInput(reason=error.to_string())
+  }
+  Some(candidate)
+}
+
+///|
+async fn target_remove(
+  runtime : Runtime,
+  options : TargetRemoveOptions,
+) -> TargetRemoveResult raise TargetRemoveError {
+  let lock_paths = runtime.discover_locks(
+    target_remove_discovery_options(options.global),
+  ) catch {
+    error => raise Discovery(cause=error)
+  }
+  guard lock_paths.length() == 1 else {
+    raise InvalidInput(reason="target remove requires exactly one lock file")
+  }
+  let lock_path = lock_paths[0]
+  let current_lock = runtime.load_lock(lock_path) catch {
+    error => raise Store(cause=error)
+  }
+  let candidate = build_target_remove_candidate(current_lock, options.targets)
+  let mut sync_result : SyncLockResult? = None
+  let result = persist_and_sync(
+    current_lock~,
+    candidate~,
+    persist=lock => runtime.write_lock_atomic(lock_path, lock),
+    sync=lock => {
+      try {
+        sync_result = Some(sync_loaded_lock(runtime, lock_path, lock))
+      } catch {
+        SyncError::Store(cause~) => raise SyncError::Store(cause~)
+        SyncError::InvalidPath(path~, reason~) =>
+          raise SyncError::InvalidPath(path~, reason~)
+        SyncError::Planning(reason~) => raise SyncError::Planning(reason~)
+        error => raise SyncError::Planning(reason=error.to_string())
+      }
+    },
+  ) catch {
+    error => raise Store(cause=error)
+  }
+  match result {
+    NoChange => Unchanged(lock_path~)
+    PersistedButSyncFailed(cause~) => raise SyncAfterPersist(cause~)
+    Synced =>
+      match sync_result {
+        Some(sync_result) => Removed(targets=options.targets, sync_result~)
+        None =>
+          raise InvalidInput(
+            reason="target remove sync completed without a result",
+          )
+      }
+  }
+}
+
+///|
+async fn run_target_remove(
+  runtime : Runtime,
+  context : @admiral.Context,
+) -> Unit {
+  match target_remove(runtime, target_remove_options(context)) {
+    Unchanged(lock_path~) => println("No target changes for \{lock_path}")
+    Removed(targets~, sync_result~) => {
+      let paths = targets.map(target => target.path.to_string()).join(", ")
+      println(
+        "Removed targets \{paths} from \{sync_result.lock_path}: \{sync_status_text(sync_result.reconciliation.status)} (\{sync_result.reconciliation.notices.length()} notices, \{sync_result.unavailable_repositories.length()} unavailable repositories)",
+      )
+    }
+  }
+}
+
+///|
+fn target_remove_command_def(
+  run : async (@admiral.Context) -> Unit,
+) -> @admiral.CommandDef {
+  @admiral.CommandDef::CommandDef(
+    name="remove",
+    description="Remove additional skill-link roots",
+    options=[target_remove_global_option, target_remove_target_option],
+    run=Some(run),
+  )
+}

--- a/mbt/app/c-plugin-v2/src/command_target_remove_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/command_target_remove_wbtest.mbt
@@ -1,0 +1,76 @@
+///|
+test "Target remove candidate 1 - removes known targets and preserves others" {
+  let current = Lock::Lock(
+    [Target::Target(".cursor/skills"), Target::Target(".claude/skills")],
+    [],
+  )
+  let candidate = build_target_remove_candidate(current, [
+    Target::Target(".cursor/./skills"),
+  ])
+  match candidate {
+    Some(candidate) => {
+      inspect(candidate.targets.length(), content="1")
+      inspect(
+        candidate.targets.contains(Target::Target(".claude/skills")),
+        content="true",
+      )
+      inspect(candidate.repositories == current.repositories, content="true")
+    }
+    None => fail("known target removal must produce a candidate")
+  }
+}
+
+///|
+test "Target remove candidate 2 - empty and unknown are no-op while last removal is allowed" {
+  let current = Lock::Lock([Target::Target(".cursor/skills")], [])
+  match build_target_remove_candidate(current, []) {
+    None => ()
+    Some(_) => fail("empty selection must be a no-op")
+  }
+  match
+    build_target_remove_candidate(current, [Target::Target(".claude/skills")]) {
+    None => ()
+    Some(_) => fail("unknown selection must be a no-op")
+  }
+  match
+    build_target_remove_candidate(current, [Target::Target(".cursor/skills")]) {
+    Some(candidate) => inspect(candidate.targets.length(), content="0")
+    None => fail("removing the last target must produce an empty candidate")
+  }
+}
+
+///|
+async test "Target remove command 3 - parses repeatable typed targets and global scope" {
+  let mut captured : TargetRemoveOptions? = None
+  let cli = @admiral.CliApp::CliApp(name="c-plugin", commands=[
+    @admiral.CommandDef::CommandDef(name="skill", subcommands=[
+      target_command_def(_ => (), context => {
+        captured = Some(target_remove_options(context))
+      }),
+    ]),
+  ])
+  cli.run(
+    argv=Some([
+      "skill", "target", "remove", "--target", ".cursor/./skills", "--target", ".claude/skills",
+      "--global",
+    ]),
+    env=Map([]),
+  )
+  match captured {
+    Some(options) => {
+      inspect(options.global, content="true")
+      inspect(options.targets.length(), content="2")
+      inspect(options.targets[0].path.to_string(), content=".cursor/skills")
+      inspect(options.targets[1].path.to_string(), content=".claude/skills")
+    }
+    None => fail("target remove command did not run")
+  }
+  match target_remove_discovery_options(false) {
+    Project(recursive~) => inspect(recursive, content="false")
+    _ => fail("project target remove must use project discovery")
+  }
+  match target_remove_discovery_options(true) {
+    Global => ()
+    _ => fail("global target remove must use global discovery")
+  }
+}

--- a/mbt/app/c-plugin-v2/src/e2e/Dockerfile
+++ b/mbt/app/c-plugin-v2/src/e2e/Dockerfile
@@ -44,6 +44,7 @@ COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/sync.sh /sandbox/e2e/sy
 COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/sync_recursive.sh /sandbox/e2e/sync_recursive.sh
 COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/add.sh /sandbox/e2e/add.sh
 COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/target_add.sh /sandbox/e2e/target_add.sh
+COPY --chown=sandbox:sandbox mbt/app/c-plugin-v2/src/e2e/target_remove.sh /sandbox/e2e/target_remove.sh
 
 RUN chmod +x /sandbox/.local/bin/c-plugin-v2 /sandbox/e2e/*.sh && \
     ln -s /sandbox/.local/bin/c-plugin-v2 /sandbox/.local/bin/c-plugin

--- a/mbt/app/c-plugin-v2/src/e2e/run.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/run.sh
@@ -74,6 +74,9 @@ docker run --rm "${platform_args[@]}" \
 docker run --rm "${platform_args[@]}" \
   --entrypoint /sandbox/e2e/target_add.sh \
   "$image"
+docker run --rm "${platform_args[@]}" \
+  --entrypoint /sandbox/e2e/target_remove.sh \
+  "$image"
 
 snapshot_host_state >"$after_state"
 if ! cmp -s "$before_state" "$after_state"; then

--- a/mbt/app/c-plugin-v2/src/e2e/target_remove.sh
+++ b/mbt/app/c-plugin-v2/src/e2e/target_remove.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root=/tmp/c-plugin-v2-target-remove-e2e
+rm -rf -- "$test_root"
+trap 'rm -rf -- "$test_root"' EXIT INT TERM
+test_home=$test_root/home
+project_root=$test_home/project
+project_repository=$project_root/marketplace
+project_plugin=$project_repository/plugins/demo
+project_lock=$project_root/c-plugin-lock.json
+project_state=$project_root/.agents/c-plugin-state.json
+
+mkdir -p "$project_repository/.claude-plugin" "$project_plugin/skills/alpha"
+printf '%s\n' '{"name":"fixture","plugins":[{"name":"demo","source":"plugins/demo"}]}' >"$project_repository/.claude-plugin/marketplace.json"
+printf '# alpha\n' >"$project_plugin/skills/alpha/SKILL.md"
+printf '%s\n' '{"version":"2","targets":[".cursor/skills",".claude/skills"],"repositories":[{"type":"local","path":"marketplace","marketplaceKind":"claude","plugins":[{"name":"demo","path":"plugins/demo","enabledSkills":["alpha"]}]}]}' >"$project_lock"
+
+cd "$project_root"
+env HOME="$test_home" c-plugin skill sync >/dev/null
+printf 'foreign\n' >"$project_root/.cursor/skills/neighbor"
+project_lock_hash=$(cksum "$project_lock")
+project_state_hash=$(cksum "$project_state")
+unknown_output=$(env HOME="$test_home" c-plugin skill target remove --target .vscode/skills)
+[[ $unknown_output == "No target changes for $project_lock" ]]
+empty_output=$(env HOME="$test_home" c-plugin skill target remove)
+[[ $empty_output == "No target changes for $project_lock" ]]
+[[ $(cksum "$project_lock") == "$project_lock_hash" ]]
+[[ $(cksum "$project_state") == "$project_state_hash" ]]
+
+cursor_output=$(env HOME="$test_home" c-plugin skill target remove --target .cursor/./skills)
+[[ $cursor_output == "Removed targets .cursor/skills from $project_lock: complete (0 notices, 0 unavailable repositories)" ]]
+compact_project_lock=$(tr -d '[:space:]' <"$project_lock")
+[[ $compact_project_lock == '{"version":"2","targets":[".claude/skills"],"repositories":[{"type":"local","path":"marketplace","marketplaceKind":"claude","plugins":[{"name":"demo","path":"plugins/demo","enabledSkills":["alpha"]}]}]}' ]]
+[[ ! -e $project_root/.cursor/skills/alpha ]]
+[[ $(<"$project_root/.cursor/skills/neighbor") == foreign ]]
+for root in "$project_root/.agents/skills" "$project_root/.claude/skills"; do
+  [[ -L $root/alpha ]]
+  [[ $(realpath "$root/alpha") == "$project_plugin/skills/alpha" ]]
+done
+! grep -F "\"managedRoot\": \"$project_root/.cursor/skills\"" "$project_state" >/dev/null
+grep -F "\"managedRoot\": \"$project_root/.claude/skills\"" "$project_state" >/dev/null
+
+claude_output=$(env HOME="$test_home" c-plugin skill target remove --target .claude/skills)
+[[ $claude_output == "Removed targets .claude/skills from $project_lock: complete (0 notices, 0 unavailable repositories)" ]]
+compact_project_lock=$(tr -d '[:space:]' <"$project_lock")
+[[ $compact_project_lock == '{"version":"2","targets":[],"repositories":[{"type":"local","path":"marketplace","marketplaceKind":"claude","plugins":[{"name":"demo","path":"plugins/demo","enabledSkills":["alpha"]}]}]}' ]]
+[[ ! -e $project_root/.claude/skills/alpha ]]
+[[ -L $project_root/.agents/skills/alpha ]]
+[[ $(<"$project_root/.cursor/skills/neighbor") == foreign ]]
+! grep -F "$project_root/.cursor/skills" "$project_state" >/dev/null
+! grep -F "$project_root/.claude/skills" "$project_state" >/dev/null
+
+global_repository=$test_home/global-marketplace
+global_plugin=$global_repository/plugins/demo
+global_lock=$test_home/c-plugin-lock.json
+global_state=$test_home/.agents/c-plugin-state.json
+mkdir -p "$global_repository/.claude-plugin" "$global_plugin/skills/beta" "$project_root/nested"
+printf '%s\n' '{"name":"fixture","plugins":[{"name":"demo","source":"plugins/demo"}]}' >"$global_repository/.claude-plugin/marketplace.json"
+printf '# beta\n' >"$global_plugin/skills/beta/SKILL.md"
+printf '%s\n' '{"version":"2","targets":[".cursor/skills"],"repositories":[{"type":"local","path":"global-marketplace","marketplaceKind":"claude","plugins":[{"name":"demo","path":"plugins/demo","enabledSkills":["beta"]}]}]}' >"$global_lock"
+
+cd "$project_root/nested"
+env HOME="$test_home" c-plugin skill sync --global >/dev/null
+global_output=$(env HOME="$test_home" c-plugin skill target remove --global --target .cursor/skills)
+[[ $global_output == "Removed targets .cursor/skills from $global_lock: complete (0 notices, 0 unavailable repositories)" ]]
+grep -F '"targets": []' "$global_lock" >/dev/null
+[[ ! -e $test_home/.cursor/skills/beta ]]
+[[ -L $test_home/.agents/skills/beta ]]
+! grep -F "$test_home/.cursor/skills" "$global_state" >/dev/null
+
+printf 'PASS: target remove cleanup, no-op, isolation, and global scope\n'

--- a/mbt/app/c-plugin-v2/src/main.mbt
+++ b/mbt/app/c-plugin-v2/src/main.mbt
@@ -27,9 +27,10 @@ fn app(runtime : Runtime) -> @admiral.CliApp {
             run_add_local(runtime, context)
           }),
           sync_command_def(async fn(context) { run_sync(runtime, context) }),
-          target_command_def(async fn(context) {
-            run_target_add(runtime, context)
-          }),
+          target_command_def(
+            async fn(context) { run_target_add(runtime, context) },
+            async fn(context) { run_target_remove(runtime, context) },
+          ),
         ],
       ),
     ],

--- a/mbt/app/c-plugin-v2/src/main_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/main_wbtest.mbt
@@ -14,6 +14,7 @@ test "CliApp app - exposes init and skill leaf commands" {
   inspect(cli.commands[1].subcommands[0].name, content="add")
   inspect(cli.commands[1].subcommands[1].name, content="sync")
   inspect(cli.commands[1].subcommands[2].name, content="target")
-  inspect(cli.commands[1].subcommands[2].subcommands.length(), content="1")
+  inspect(cli.commands[1].subcommands[2].subcommands.length(), content="2")
   inspect(cli.commands[1].subcommands[2].subcommands[0].name, content="add")
+  inspect(cli.commands[1].subcommands[2].subcommands[1].name, content="remove")
 }


### PR DESCRIPTION
## 概要

Linear [TOT-124](https://linear.app/totto2727/issue/TOT-124/c-plugin-v2-m3-c-target-remove-target-remove-commandを実装する) の実装です。

`c-plugin skill target remove [--target <path>...] [-g]` を追加し、追加 target を typed value として lock から削除した後、既存の `persist_and_sync` と ownership-safe reconciliation で owned link/state を同期します。

- empty selection と unknown selection は成功 no-op とし、lock/state/filesystemを変更しない
- 正規化済み target を複数選択できる
- 最後の additional target を削除して `targets: []` にできる
- primary root と別 target の owned link/state、および foreign neighbor を保持する
- project/global lock を分離する
- async cancellation 専用処理は追加しない

## Stacked PR

```text
#307 TOT-118
  -> #312 TOT-119
  -> #314 TOT-120
  -> #315 TOT-121
  -> #316 TOT-184
  -> #317 TOT-183
  -> #318 TOT-122
  -> this PR TOT-124
```

Base は `codex/tot-122-target-add` の exact head `a6ecf3370d9b56657fbb7d066a46090a6a7d239b` です。

## 処理フロー

```mermaid
flowchart TD
  A[skill target remove] --> B[--target valuesをTargetへ正規化]
  B --> C[projectまたはglobal lockを1件発見]
  C --> D[現在のLockをload]
  D --> E{selectionは空またはunknownを含むか}
  E -- Yes --> F[候補None]
  F --> G[persist_and_sync NoChange]
  G --> H[write/syncせず成功no-op]
  E -- No --> I[選択targetを除いたimmutable Lockを構築]
  I --> J[atomic persist]
  J --> K[同一candidateをsync_loaded_lockへ渡す]
  K --> L[owned link/stateをcleanup]
  L --> M[status/notices/unavailableを表示]
```

## テストケース

```mermaid
flowchart LR
  A[target remove] --> B[known target]
  A --> C[empty selection]
  A --> D[unknown target]
  A --> E[last target]
  A --> F[global]
  B --> B1[removed root owned link/state削除]
  B --> B2[foreign neighbor保持]
  B --> B3[別targetとprimary保持]
  C --> C1[lock/state hash不変]
  D --> D1[lock/state hash不変]
  E --> E1[targets空とprimary保持]
  F --> F1[HOME lock/rootのみ変更]
```

## 検証

- targeted target-remove tests: 3/3 PASS
- c-plugin-v2 native tests: 178/178 PASS
- workspace MoonBit check/build: PASS
- workspace MoonBit tests: 300/300 PASS
- clean-container Docker E2E: PASS
  - unknown/empty no-op
  - normalized known target cleanup
  - foreign neighbor、cross-target、primary root preservation
  - last-target empty desired state
  - nested CWDからのglobal removal
  - host state isolation
- exact-SHA review-work: goal / code / security / context / QA / runtime audit 全て PASS
- diff: 1 commit、9 files、325 additions + 6 deletions = 331 changed lines

## Delivery

- exact SHA: `fecef9837702eada86975ce58447d6b75cfe1c05`
- Linear は merge 前のため In Review までとします。