### PR TITLE
TOT-187: c-plugin-v2のpath値型をtotto2727/xへ統一する

### DIFF
--- a/c-plugin-v2/README.ja.md
+++ b/c-plugin-v2/README.ja.md
@@ -25,14 +25,14 @@
 | CLI解析          | `totto2727/admiral`                                                                                                                    |
 | 対話入力         | `mizchi/tui`                                                                                                                           |
 | Git              | `mizchi/bit`モジュールをライブラリとして使用し、主に`mizchi/bit_lib`などのライブラリパッケージを利用する。`git`や`bit` CLIは起動しない |
-| パス             | `moonbitlang/x/path.Path`                                                                                                              |
+| パス             | filesystem境界では`moonbitlang/x/path.Path`、検証済みdomain値では`totto2727/x@0.3.0/path.AbsolutePath`と`RelativePath`                 |
 | ロック探索       | `totto2727/target-file-discovery`                                                                                                      |
 | JSON             | `totto2727/lens`と標準の`FromJson`、`ToJson`トレイト                                                                                   |
 | 非同期I/O        | `moonbitlang/async`                                                                                                                    |
 | 単体テスト       | テストごとの一時ルートを使用するMoonBitブラックボックス・ホワイトボックステスト                                                        |
 | E2Eテスト        | `src/e2e/`以下のShell駆動Dockerテスト                                                                                                  |
 
-すべての依存関係は、互換性を確認した正確なバージョンに固定します。最初の実装ゲートでは、Admiral、TUI、bit、Lens、target-file-discovery、async、`moonbitlang/x/path`を同時にimportする最小構成のnativeビルドを行います。未検証の依存関係の組み合わせでは実装を進めません。
+すべての依存関係は、互換性を確認した正確なバージョンに固定します。最初の実装ゲートでは、Admiral、TUI、bit、Lens、target-file-discovery、async、`moonbitlang/x/path`、`totto2727/x@0.3.0/path`を同時にimportする最小構成のnativeビルドを行います。未検証の依存関係の組み合わせでは実装を進めません。
 
 `mizchi/bit`は現在、自身を実験的実装と説明し、リポジトリ破損の可能性を警告しています。そのため、c-pluginではキャッシュしたcloneを破棄可能なデータとして扱い、依存バージョンを固定し、使用するclone、fetch、checkout、HEAD解決APIを正確にテストします。
 
@@ -446,6 +446,7 @@ Milestone 0は完了済みの本設計契約です。Milestone 1から7では、
 
 - MoonBit toolchainと`moon install`: https://docs.moonbitlang.com/en/latest/toolchain/moon/commands.html
 - `moonbitlang/x/path.Path` public API: https://github.com/moonbitlang/x/blob/main/path/pkg.generated.mbti
+- `totto2727/x@0.3.0/path`の検証済みpath値: https://mooncakes.io/docs/totto2727/x@0.3.0/path
 - Admiral: https://github.com/totto2727/admiral
 - mizchi/tui: https://github.com/mizchi/tui.mbt
 - mizchi/bit: https://github.com/bit-vcs/bit

--- a/c-plugin-v2/README.md
+++ b/c-plugin-v2/README.md
@@ -25,14 +25,14 @@ Functional equivalence includes preserving the public `c-plugin skill` namespace
 | CLI parsing         | `totto2727/admiral`                                                                                                                            |
 | Interactive input   | `mizchi/tui`                                                                                                                                   |
 | Git                 | The `mizchi/bit` module used as a library, primarily through its library packages such as `mizchi/bit_lib`; never spawn `git` or the `bit` CLI |
-| Paths               | `moonbitlang/x/path.Path`                                                                                                                      |
+| Paths               | `moonbitlang/x/path.Path` at filesystem boundaries, with `totto2727/x@0.3.0/path.AbsolutePath` and `RelativePath` for validated domain values  |
 | Lock discovery      | `totto2727/target-file-discovery`                                                                                                              |
 | JSON                | `totto2727/lens` plus the standard `FromJson` and `ToJson` traits                                                                              |
 | Async I/O           | `moonbitlang/async`                                                                                                                            |
 | Unit tests          | MoonBit black-box and white-box tests using per-test temporary roots                                                                           |
 | E2E tests           | Shell-driven Docker tests under `src/e2e/`                                                                                                     |
 
-All dependencies must be pinned to exact compatible versions. The first implementation gate is a minimal native build importing Admiral, TUI, bit, Lens, target-file-discovery, async, and `moonbitlang/x/path` together. Implementation must not proceed on an unverified dependency combination.
+All dependencies must be pinned to exact compatible versions. The first implementation gate is a minimal native build importing Admiral, TUI, bit, Lens, target-file-discovery, async, `moonbitlang/x/path`, and `totto2727/x@0.3.0/path` together. Implementation must not proceed on an unverified dependency combination.
 
 `mizchi/bit` currently describes itself as experimental and warns about possible repository corruption. c-plugin therefore treats cached clones as disposable data, pins the dependency, and tests the exact clone, fetch, checkout, and HEAD-resolution APIs it uses.
 
@@ -446,6 +446,7 @@ The report must state that work stopped at the milestone boundary. It must not d
 
 - MoonBit toolchain and `moon install`: https://docs.moonbitlang.com/en/latest/toolchain/moon/commands.html
 - `moonbitlang/x/path.Path` public API: https://github.com/moonbitlang/x/blob/main/path/pkg.generated.mbti
+- `totto2727/x@0.3.0/path` validated path values: https://mooncakes.io/docs/totto2727/x@0.3.0/path
 - Admiral: https://github.com/totto2727/admiral
 - mizchi/tui: https://github.com/mizchi/tui.mbt
 - mizchi/bit: https://github.com/bit-vcs/bit

--- a/mbt/app/c-plugin-v2/moon.mod
+++ b/mbt/app/c-plugin-v2/moon.mod
@@ -25,4 +25,5 @@ import {
   "totto2727/admiral@0.6.2",
   "totto2727/lens@0.4.2",
   "totto2727/target-file-discovery@0.2.1",
+  "totto2727/x@0.3.0",
 }

--- a/mbt/app/c-plugin-v2/package.nix
+++ b/mbt/app/c-plugin-v2/package.nix
@@ -16,6 +16,7 @@ let
     "totto2727/admiral" = "0.6.2";
     "totto2727/lens" = "0.4.2";
     "totto2727/target-file-discovery" = "0.2.1";
+    "totto2727/x" = "0.3.0";
   };
   cachedRegistry = moonPlatform.buildCachedRegistry {
     moonModDepsSet = dependencies;

--- a/mbt/app/c-plugin-v2/src/cache_identity.mbt
+++ b/mbt/app/c-plugin-v2/src/cache_identity.mbt
@@ -10,14 +10,14 @@ let cache_scope_metadata_version_lens : @lens.Lens[Int] = @lens.root().int(
 )
 
 ///|
-let cache_scope_metadata_lock_path_lens : @lens.Lens[String] = @lens.root().string(
+let cache_scope_metadata_lock_path_lens : @lens.Lens[@x_path.AbsolutePath] = @lens.root().custom(
   "lockPath",
 )
 
 ///|
 pub struct CacheScopeMetadata {
   version : Int
-  lock_path : @path.Path
+  lock_path : @x_path.AbsolutePath
 } derive(Eq, Debug)
 
 ///|
@@ -34,18 +34,13 @@ pub impl FromJson for CacheScopeMetadata with fn from_json(json, path) {
   let version = cache_scope_metadata_version_lens.get_or_json_decode_error(
     json, path,
   )
-  guard version == 1 else {
-    raise cache_scope_metadata_version_lens.json_decode_error(
-      path, "unsupported cache scope metadata version",
-    )
-  }
   let lock_path = cache_scope_metadata_lock_path_lens.get_or_json_decode_error(
     json, path,
   )
-  CacheScopeMetadata(version, @path.Path(lock_path)) catch {
+  CacheScopeMetadata::CacheScopeMetadata(version, lock_path.path) catch {
     _ =>
-      raise cache_scope_metadata_lock_path_lens.json_decode_error(
-        path, "cache scope lock path must be absolute",
+      raise cache_scope_metadata_version_lens.json_decode_error(
+        path, "unsupported cache scope metadata version",
       )
   }
 }
@@ -54,16 +49,13 @@ pub impl FromJson for CacheScopeMetadata with fn from_json(json, path) {
 pub impl ToJson for CacheScopeMetadata with fn to_json(self) -> Json {
   let builder = @lens.JsonBuilder::JsonBuilder()
   cache_scope_metadata_version_lens.set_or_abort(builder, self.version)
-  cache_scope_metadata_lock_path_lens.set_or_abort(
-    builder,
-    self.lock_path.to_string(),
-  )
+  cache_scope_metadata_lock_path_lens.set_or_abort(builder, self.lock_path)
   builder.to_json()
 }
 
 ///|
 pub struct CacheScope {
-  lock_path : @path.Path
+  lock_path : @x_path.AbsolutePath
   scope_key : String
 } derive(Eq)
 
@@ -74,7 +66,9 @@ pub fn CacheScope::CacheScope(
   let normalized_lock_path = normalized_absolute_path("lock path", lock_path)
   let scope_key = @crypto.bytes_to_hex_string(
     @crypto.sha256(
-      @utf8.encode("lock\u{0000}\{normalized_lock_path.to_string()}"),
+      @utf8.encode(
+        "lock\u{0000}\{@x_path.Path::to_string(normalized_lock_path)}",
+      ),
     ),
   )
   { lock_path: normalized_lock_path, scope_key }
@@ -86,7 +80,7 @@ pub fn CacheScope::cache_path(
   cache_root : @path.Path,
   repository : GitHubRepository,
 ) -> @path.Path raise CacheIdentityError {
-  normalized_absolute_path("cache root", cache_root)
+  normalized_absolute_path("cache root", cache_root).path
   .join(self.scope_key)
   .join(repository.owner.value)
   .join(repository.name.value)
@@ -96,14 +90,15 @@ pub fn CacheScope::cache_path(
 pub fn CacheScope::metadata(
   self : CacheScope,
 ) -> CacheScopeMetadata raise CacheIdentityError {
-  CacheScopeMetadata::CacheScopeMetadata(1, self.lock_path)
+  CacheScopeMetadata::CacheScopeMetadata(1, self.lock_path.path)
 }
 
 ///|
 fn normalized_absolute_path(
   name : String,
   path : @path.Path,
-) -> @path.Path raise CacheIdentityError {
-  guard path.is_absolute() else { raise RelativePath(name~, path~) }
-  path.normalize()
+) -> @x_path.AbsolutePath raise CacheIdentityError {
+  @x_path.AbsolutePath::AbsolutePath(path) catch {
+    _ => raise RelativePath(name~, path~)
+  }
 }

--- a/mbt/app/c-plugin-v2/src/command_add_local.mbt
+++ b/mbt/app/c-plugin-v2/src/command_add_local.mbt
@@ -78,8 +78,11 @@ fn add_local_options(context : @admiral.Context) -> AddLocalOptions raise {
   guard source.has_prefix("./") else {
     raise AddLocalError::InvalidInput(reason="--local path must begin with ./")
   }
+  let normalized_source = @x_path.RelativePath::from_string(source) catch {
+    error => raise AddLocalError::InvalidInput(reason=error.to_string())
+  }
   let source_path = RelativeSourcePath::RelativeSourcePath(
-    @path.Path(source).normalize(),
+    normalized_source.path,
   ) catch {
     error => raise AddLocalError::InvalidInput(reason=error.to_string())
   }
@@ -97,7 +100,7 @@ fn resolve_add_repository_root(
   lock_path : @path.Path,
   source : RelativeSourcePath,
 ) -> RepositoryRoot raise AddLocalError {
-  RepositoryRoot::RepositoryRoot(lock_path.dirname().join(source.path)) catch {
+  RepositoryRoot::RepositoryRoot(lock_path.dirname().join(source.path.path)) catch {
     error =>
       raise AddLocalError::InvalidInput(
         reason=repository_root_error_reason(error),
@@ -199,7 +202,7 @@ async fn add_local(
   }
   let repository_root = resolve_add_repository_root(lock_path, options.source)
   let marketplace = read_marketplace_file(
-    repository_root.path.join(marketplace_manifest_path(options.kind)),
+    repository_root.path.path.join(marketplace_manifest_path(options.kind)),
     options.kind,
   ) catch {
     error => raise InvalidInput(reason=marketplace_read_error_reason(error))

--- a/mbt/app/c-plugin-v2/src/command_add_local_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/command_add_local_wbtest.mbt
@@ -15,13 +15,17 @@ fn add_local_test_resolved() -> ReadOnlyArray[ResolvedSkill] raise {
       plugin_name: PluginName::PluginName("demo"),
       plugin_path: RelativePluginPath::RelativePluginPath("plugins/demo"),
       skill_name: SkillName::SkillName("alpha"),
-      skill_path: "/marketplace/plugins/demo/skills/alpha",
+      skill_path: @x_path.AbsolutePath::AbsolutePath(
+        "/marketplace/plugins/demo/skills/alpha",
+      ),
     },
     {
       plugin_name: PluginName::PluginName("demo"),
       plugin_path: RelativePluginPath::RelativePluginPath("plugins/demo"),
       skill_name: SkillName::SkillName("beta"),
-      skill_path: "/marketplace/plugins/demo/skills/beta",
+      skill_path: @x_path.AbsolutePath::AbsolutePath(
+        "/marketplace/plugins/demo/skills/beta",
+      ),
     },
   ]
 }

--- a/mbt/app/c-plugin-v2/src/command_remove.mbt
+++ b/mbt/app/c-plugin-v2/src/command_remove.mbt
@@ -75,7 +75,7 @@ fn parse_remove_skill_selection(
 fn remove_skill_selection_text(selection : RemoveSkillSelection) -> String {
   match selection.repository {
     LocalIdentity(source) =>
-      "\{source.path}/\{selection.plugin_name.value}/\{selection.skill_name.value}"
+      "\{@x_path.Path::to_string(source.path)}/\{selection.plugin_name.value}/\{selection.skill_name.value}"
     GitHubIdentity(repository) =>
       "\{repository.route()}/\{selection.plugin_name.value}/\{selection.skill_name.value}"
   }

--- a/mbt/app/c-plugin-v2/src/command_sync_recursive_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/command_sync_recursive_wbtest.mbt
@@ -16,7 +16,7 @@ async test "Sync command recursive 1 - routes the short recursive option to recu
       root.join("cache"),
     )
     let empty_lock = Lock::Lock([], [])
-    let project_lock = paths.project_lock_path(paths.cwd)
+    let project_lock = paths.project_lock_path(paths.cwd.path)
     let mut discovered_options = None
     let runtime = Runtime::Runtime(
       paths~,
@@ -86,7 +86,7 @@ async test "Sync command recursive 3 - keeps completed lock ownership isolated w
       root.join("project"),
       root.join("cache"),
     )
-    let project = paths.cwd
+    let project = paths.cwd.path
     create_sync_marketplace(project.join("marketplace"))
     let parent_lock_path = project.join("c-plugin-lock.json")
     let child_lock_path = project.join("child").join("c-plugin-lock.json")

--- a/mbt/app/c-plugin-v2/src/command_sync_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/command_sync_wbtest.mbt
@@ -157,7 +157,7 @@ async test "Sync sync_lock 2 - rebuilds ownership conservatively from corrupt st
     inspect(result.reconciliation.notices.length(), content="1")
     match result.reconciliation.notices[0] {
       PreviousOwnershipCorrupt(path~, reason=_) =>
-        inspect(path.path == state_path, content="true")
+        inspect(path.path.path == state_path, content="true")
       _ => fail("expected PreviousOwnershipCorrupt")
     }
     inspect(result.reconciliation.durable_state.entries.length(), content="2")
@@ -302,7 +302,7 @@ async test "Sync sync_lock 5 - distrusts ownership roots outside the lock scope"
     debug_inspect(result.reconciliation.status, content="Partial")
     match result.reconciliation.notices[0] {
       PreviousOwnershipCorrupt(path~, reason=_) =>
-        inspect(path.path == state_path, content="true")
+        inspect(path.path.path == state_path, content="true")
       _ => fail("expected unsafe ownership to become corrupt")
     }
     debug_inspect(

--- a/mbt/app/c-plugin-v2/src/command_target_add.mbt
+++ b/mbt/app/c-plugin-v2/src/command_target_add.mbt
@@ -116,10 +116,12 @@ async fn target_add(
 async fn run_target_add(runtime : Runtime, context : @admiral.Context) -> Unit {
   match target_add(runtime, target_add_options(context)) {
     AlreadyPresent(target~, lock_path~) =>
-      println("Target \{target.path} already registered in \{lock_path}")
+      println(
+        "Target \{@x_path.Path::to_string(target.path)} already registered in \{lock_path}",
+      )
     Added(target~, sync_result~) =>
       println(
-        "Added target \{target.path} to \{sync_result.lock_path}: \{sync_status_text(sync_result.reconciliation.status)} (\{sync_result.reconciliation.notices.length()} notices, \{sync_result.unavailable_repositories.length()} unavailable repositories)",
+        "Added target \{@x_path.Path::to_string(target.path)} to \{sync_result.lock_path}: \{sync_status_text(sync_result.reconciliation.status)} (\{sync_result.reconciliation.notices.length()} notices, \{sync_result.unavailable_repositories.length()} unavailable repositories)",
       )
   }
 }

--- a/mbt/app/c-plugin-v2/src/desired_links.mbt
+++ b/mbt/app/c-plugin-v2/src/desired_links.mbt
@@ -1,19 +1,21 @@
 ///|
 pub struct ManagedSkillRoot {
-  path : @path.Path
+  path : @x_path.AbsolutePath
 } derive(Eq)
 
 ///|
 pub impl Hash for ManagedSkillRoot with fn hash_combine(self, hasher) {
-  self.path.to_string().hash_combine(hasher)
+  Hash::hash_combine(@x_path.Path::to_string(self.path), hasher)
 }
 
 ///|
 pub fn ManagedSkillRoot::ManagedSkillRoot(
   path : @path.Path,
 ) -> ManagedSkillRoot raise {
-  guard path.is_absolute() else { fail("managed skill root must be absolute") }
-  { path: path.normalize() }
+  let absolute = @x_path.AbsolutePath::AbsolutePath(path) catch {
+    _ => fail("managed skill root must be absolute")
+  }
+  { path: absolute }
 }
 
 ///|
@@ -123,13 +125,13 @@ fn desired_entry(
   skill : ResolvedSkill,
 ) -> OwnershipEntry raise {
   let link = OwnershipLink::OwnershipLink(
-    root.path.join(skill.skill_name.value),
+    root.path.path.join(skill.skill_name.value),
   )
   OwnershipEntry::OwnershipEntry(
     link,
-    skill.skill_path.relative(base=root.path),
-    OwnershipResolvedTarget::OwnershipResolvedTarget(skill.skill_path),
-    OwnershipManagedRoot::OwnershipManagedRoot(root.path),
+    skill.skill_path.path.relative(base=root.path.path),
+    OwnershipResolvedTarget::OwnershipResolvedTarget(skill.skill_path.path),
+    OwnershipManagedRoot::OwnershipManagedRoot(root.path.path),
     ownership_source(repository, skill),
   )
 }

--- a/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/desired_links_wbtest.mbt
@@ -56,7 +56,9 @@ fn desired_links_resolved_skill(
       @path.Path("plugins/plugin"),
     ),
     skill_name: SkillName::SkillName(name),
-    skill_path: root.join("repository/plugins/plugin/skills").join(name),
+    skill_path: @x_path.AbsolutePath::AbsolutePath(
+      root.join("repository/plugins/plugin/skills").join(name),
+    ),
   }
 }
 
@@ -64,9 +66,13 @@ fn desired_links_resolved_skill(
 fn desired_links_entry(
   plan : DesiredLinkPlan,
   link : @path.Path,
-) -> OwnershipEntry {
+) -> OwnershipEntry raise {
   plan.ownership_state.entries
-  .get(OwnershipLinkIdentity::OwnershipLinkIdentity(link))
+  .get(
+    OwnershipLinkIdentity::OwnershipLinkIdentity(
+      OwnershipLink::OwnershipLink(link).path,
+    ),
+  )
   .unwrap()
 }
 
@@ -151,12 +157,12 @@ async test "DesiredLinks plan_desired_skill_links - expands one enabled skill" {
       managed_root in [root.join(".agents/skills"), root.join(".cursor/skills")] {
       let entry = desired_links_entry(plan, managed_root.join("install"))
       inspect(
-        entry.link.path.to_string(),
+        entry.link.path.path.to_string(),
         content=managed_root.join("install").to_string(),
       )
       inspect(
         managed_root.join(entry.symlink_target).normalize().to_string(),
-        content=entry.resolved_target.path.to_string(),
+        content=entry.resolved_target.path.path.to_string(),
       )
     }
   }
@@ -230,8 +236,8 @@ test "DesiredLinks plan_desired_skill_links - later candidate in one repository 
     ]),
   )
   inspect(
-    desired_links_entry(plan, @path.Path("/tmp/managed/shared")).resolved_target.path.to_string(),
-    content=last.skill_path.to_string(),
+    desired_links_entry(plan, @path.Path("/tmp/managed/shared")).resolved_target.path.path.to_string(),
+    content=last.skill_path.path.to_string(),
   )
 }
 
@@ -331,33 +337,3 @@ test "DesiredLinks plan_desired_skill_links - empty roots or repositories produc
 }
 
 ///|
-test "DesiredLinks plan_desired_skill_links - propagates an invalid resolved skill path" {
-  let skill_name = SkillName::SkillName("install")
-  let repository = desired_links_local_repository([skill_name])
-  let invalid_skill : ResolvedSkill = {
-    plugin_name: PluginName::PluginName("plugin"),
-    plugin_path: RelativePluginPath::RelativePluginPath(
-      @path.Path("plugins/plugin"),
-    ),
-    skill_name,
-    skill_path: @path.Path("relative/skill"),
-  }
-  try
-    plan_desired_skill_links(
-      @immut_hashset.HashSet([
-        ManagedSkillRoot::ManagedSkillRoot(@path.Path("/tmp/managed")),
-      ]),
-      RepositorySkillResolutions::RepositorySkillResolutions([
-        Available(
-          repository~,
-          skills=ReadOnlyArray::from_array([invalid_skill]),
-        ),
-      ]),
-    )
-  catch {
-    Failure::Failure(_) => ()
-    error => raise error
-  } noraise {
-    _ => fail("invalid resolved skill path must raise")
-  }
-}

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_create.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_create.mbt
@@ -13,16 +13,16 @@ async fn create_desired_link(
   desired_entry : OwnershipEntry,
   notices : Array[LinkReconciliationNotice],
 ) -> DesiredLinkCreationResult {
-  (io.symlink)(desired_entry.symlink_target, desired_entry.link.path) catch {
+  (io.symlink)(desired_entry.symlink_target, desired_entry.link.path.path) catch {
     @os_error.OSError(_) as error if error.is_EEXIST() => {
-      notices.push(UnmanagedPathPreserved(path=desired_entry.link.path))
+      notices.push(UnmanagedPathPreserved(path=desired_entry.link.path.path))
       return Skipped
     }
     error => {
       notices.push(
         OperationFailed(
           operation=CreateLink,
-          path=desired_entry.link.path,
+          path=desired_entry.link.path.path,
           reason=error.to_string(),
         ),
       )
@@ -30,11 +30,11 @@ async fn create_desired_link(
     }
   }
   let verified = try {
-    let live_kind = (io.kind)(desired_entry.link.path)
-    let live_target = (io.realpath)(desired_entry.link.path).normalize()
+    let live_kind = (io.kind)(desired_entry.link.path.path)
+    let live_target = (io.realpath)(desired_entry.link.path.path).normalize()
     let still_contained = is_physically_contained(io, desired_entry)
     live_kind == @fs.FileKind::SymLink &&
-    live_target == desired_entry.resolved_target.path &&
+    live_target == desired_entry.resolved_target.path.path &&
     still_contained
   } catch {
     _ => false
@@ -45,7 +45,7 @@ async fn create_desired_link(
     notices.push(
       OperationFailed(
         operation=VerifyCreatedLink,
-        path=desired_entry.link.path,
+        path=desired_entry.link.path.path,
         reason="created link could not be verified",
       ),
     )
@@ -62,9 +62,9 @@ async fn create_desired_link(
     HardStop(_) => {
       let mut rollback_check_failed = false
       let rollback_verified = try
-        (io.kind)(desired_entry.link.path) == @fs.FileKind::SymLink &&
-        (io.realpath)(desired_entry.link.path).normalize() ==
-        desired_entry.resolved_target.path &&
+        (io.kind)(desired_entry.link.path.path) == @fs.FileKind::SymLink &&
+        (io.realpath)(desired_entry.link.path.path).normalize() ==
+        desired_entry.resolved_target.path.path &&
         is_physically_contained(io, desired_entry)
       catch {
         error => {
@@ -72,7 +72,7 @@ async fn create_desired_link(
           notices.push(
             OperationFailed(
               operation=VerifyCreatedLink,
-              path=desired_entry.link.path,
+              path=desired_entry.link.path.path,
               reason=error.to_string(),
             ),
           )
@@ -82,19 +82,19 @@ async fn create_desired_link(
         value => value
       }
       if rollback_verified {
-        (io.remove)(desired_entry.link.path) catch {
+        (io.remove)(desired_entry.link.path.path) catch {
           @os_error.OSError(_) as error if error.is_ENOENT() => ()
           error =>
             notices.push(
               OperationFailed(
                 operation=RemoveLink,
-                path=desired_entry.link.path,
+                path=desired_entry.link.path.path,
                 reason=error.to_string(),
               ),
             )
         }
       } else if !rollback_check_failed {
-        notices.push(UnmanagedPathPreserved(path=desired_entry.link.path))
+        notices.push(UnmanagedPathPreserved(path=desired_entry.link.path.path))
       }
       CreationHardStop({
         status: Partial,

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_create_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_create_wbtest.mbt
@@ -34,14 +34,14 @@ async test "LinkReconciliation reconcile_skill_links 10 - hard-stops after a cre
       _ => fail("expected checkpoint failure")
     }
     let first_kind = @fs.kind(
-      entry_a.link.path.to_string(),
+      entry_a.link.path.path.to_string(),
       follow_symlink=false,
     ) catch {
       _ => @fs.FileKind::Unknown
     }
     debug_inspect(first_kind, content="Unknown")
     let second_kind = @fs.kind(
-      entry_b.link.path.to_string(),
+      entry_b.link.path.path.to_string(),
       follow_symlink=false,
     ) catch {
       _ => @fs.FileKind::Unknown
@@ -59,11 +59,11 @@ async test "LinkReconciliation reconcile_skill_links 10 - hard-stops after a cre
     inspect(checkpoints.length(), content="2")
     inspect(retried.durable_state == desired_state, content="true")
     inspect(
-      @fs.realpath(entry_a.link.path.to_string()),
+      @fs.realpath(entry_a.link.path.path.to_string()),
       content=@fs.realpath(target_a.to_string()),
     )
     inspect(
-      @fs.realpath(entry_b.link.path.to_string()),
+      @fs.realpath(entry_b.link.path.path.to_string()),
       content=@fs.realpath(target_b.to_string()),
     )
   }
@@ -115,11 +115,11 @@ async test "LinkReconciliation reconcile_skill_links 12 - preserves an injected 
     inspect(checkpointed, content="false")
     match result.notices[0] {
       UnmanagedPathPreserved(path~) =>
-        inspect(path == entry.link.path, content="true")
+        inspect(path == entry.link.path.path, content="true")
       _ => fail("expected unmanaged EEXIST winner notice")
     }
     inspect(
-      @fs.realpath(entry.link.path.to_string()),
+      @fs.realpath(entry.link.path.path.to_string()),
       content=@fs.realpath(foreign_target.to_string()),
     )
   }
@@ -151,7 +151,7 @@ async test "LinkReconciliation reconcile_skill_links 17 - hard-stops after succe
       kind: async fn(path) { @fs.kind(path.to_string(), follow_symlink=false) },
       realpath: async fn(path) { @path.Path(@fs.realpath(path.to_string())) },
       symlink: async fn(target, link) {
-        if link == entry_a.link.path {
+        if link == entry_a.link.path.path {
           @fs.symlink(
             target=wrong_target.relative(base=managed_root).to_string(),
             link.to_string(),
@@ -175,15 +175,15 @@ async test "LinkReconciliation reconcile_skill_links 17 - hard-stops after succe
     inspect(checkpointed, content="false")
     match result.notices[0] {
       OperationFailed(operation=VerifyCreatedLink, path~, reason=_) =>
-        inspect(path == entry_a.link.path, content="true")
+        inspect(path == entry_a.link.path.path, content="true")
       _ => fail("expected created-link verification failure")
     }
     inspect(
-      @fs.realpath(entry_a.link.path.to_string()),
+      @fs.realpath(entry_a.link.path.path.to_string()),
       content=@fs.realpath(wrong_target.to_string()),
     )
     let later_kind = @fs.kind(
-      entry_b.link.path.to_string(),
+      entry_b.link.path.path.to_string(),
       follow_symlink=false,
     ) catch {
       _ => @fs.FileKind::Unknown

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_desired.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_desired.mbt
@@ -14,24 +14,24 @@ async fn reconcile_desired_entries(
   for pair in desired_entries {
     let identity = pair.0
     let desired_entry = pair.1
-    (io.mkdir)(desired_entry.managed_root.path) catch {
+    (io.mkdir)(desired_entry.managed_root.path.path) catch {
       error => {
         notices.push(
           OperationFailed(
             operation=EnsureManagedRoot,
-            path=desired_entry.managed_root.path,
+            path=desired_entry.managed_root.path.path,
             reason=error.to_string(),
           ),
         )
         continue
       }
     }
-    let managed_root_kind = (io.kind)(desired_entry.managed_root.path) catch {
+    let managed_root_kind = (io.kind)(desired_entry.managed_root.path.path) catch {
       error => {
         notices.push(
           OperationFailed(
             operation=VerifyContainment,
-            path=desired_entry.managed_root.path,
+            path=desired_entry.managed_root.path.path,
             reason=error.to_string(),
           ),
         )
@@ -42,7 +42,7 @@ async fn reconcile_desired_entries(
       notices.push(
         OperationFailed(
           operation=VerifyContainment,
-          path=desired_entry.managed_root.path,
+          path=desired_entry.managed_root.path.path,
           reason="managed root must be a physical directory",
         ),
       )
@@ -53,7 +53,7 @@ async fn reconcile_desired_entries(
         notices.push(
           OperationFailed(
             operation=VerifyContainment,
-            path=desired_entry.link.path,
+            path=desired_entry.link.path.path,
             reason=error.to_string(),
           ),
         )
@@ -64,18 +64,18 @@ async fn reconcile_desired_entries(
       notices.push(
         OperationFailed(
           operation=VerifyContainment,
-          path=desired_entry.link.path,
+          path=desired_entry.link.path.path,
           reason="link parent resolves outside the managed root",
         ),
       )
       continue
     }
-    let kind = classify_link(io, desired_entry.link.path) catch {
+    let kind = classify_link(io, desired_entry.link.path.path) catch {
       error => {
         notices.push(
           OperationFailed(
             operation=ClassifyLink,
-            path=desired_entry.link.path,
+            path=desired_entry.link.path.path,
             reason=error.to_string(),
           ),
         )
@@ -105,13 +105,13 @@ async fn reconcile_desired_entries(
         }
         None => ()
       }
-      (io.remove)(desired_entry.link.path) catch {
+      (io.remove)(desired_entry.link.path.path) catch {
         @os_error.OSError(_) as error if error.is_ENOENT() => ()
         error => {
           notices.push(
             OperationFailed(
               operation=RemoveLink,
-              path=desired_entry.link.path,
+              path=desired_entry.link.path.path,
               reason=error.to_string(),
             ),
           )
@@ -132,7 +132,9 @@ async fn reconcile_desired_entries(
       None =>
         match kind {
           Some(_) =>
-            notices.push(UnmanagedPathPreserved(path=desired_entry.link.path))
+            notices.push(
+              UnmanagedPathPreserved(path=desired_entry.link.path.path),
+            )
           None => should_create = true
         }
       Some(recorded_entry) =>
@@ -151,7 +153,7 @@ async fn reconcile_desired_entries(
           Some(@fs.FileKind::SymLink) => {
             let mut broken = false
             let live_target = try
-              (io.realpath)(recorded_entry.link.path)
+              (io.realpath)(recorded_entry.link.path.path)
             catch {
               @os_error.OSError(_) as error if error.is_ENOENT() => {
                 broken = true
@@ -161,7 +163,7 @@ async fn reconcile_desired_entries(
                 notices.push(
                   OperationFailed(
                     operation=ClassifyLink,
-                    path=recorded_entry.link.path,
+                    path=recorded_entry.link.path.path,
                     reason=error.to_string(),
                   ),
                 )
@@ -172,7 +174,7 @@ async fn reconcile_desired_entries(
             }
             if broken {
               notices.push(
-                BrokenOwnedLinkPreserved(path=recorded_entry.link.path),
+                BrokenOwnedLinkPreserved(path=recorded_entry.link.path.path),
               )
               let omitted = state_without_entry(durable_state, identity)
               match
@@ -184,9 +186,10 @@ async fn reconcile_desired_entries(
               }
             } else {
               match live_target {
-                Some(target) if target == recorded_entry.resolved_target.path =>
-                  if desired_entry.resolved_target.path ==
-                    recorded_entry.resolved_target.path {
+                Some(target) if target ==
+                  recorded_entry.resolved_target.path.path =>
+                  if desired_entry.resolved_target.path.path ==
+                    recorded_entry.resolved_target.path.path {
                     if desired_entry != recorded_entry {
                       let refreshed = state_with_entry(
                         durable_state, desired_entry,
@@ -202,14 +205,14 @@ async fn reconcile_desired_entries(
                   } else {
                     match recheck_stale_link(io, recorded_entry) {
                       Matching => {
-                        (io.remove)(recorded_entry.link.path) catch {
+                        (io.remove)(recorded_entry.link.path.path) catch {
                           @os_error.OSError(_) as error if error.is_ENOENT() =>
                             ()
                           error => {
                             notices.push(
                               OperationFailed(
                                 operation=RemoveLink,
-                                path=recorded_entry.link.path,
+                                path=recorded_entry.link.path.path,
                                 reason=error.to_string(),
                               ),
                             )
@@ -246,7 +249,7 @@ async fn reconcile_desired_entries(
                       Replaced => {
                         notices.push(
                           ReplacedOwnedPathPreserved(
-                            path=recorded_entry.link.path,
+                            path=recorded_entry.link.path.path,
                           ),
                         )
                         let omitted = state_without_entry(
@@ -265,7 +268,7 @@ async fn reconcile_desired_entries(
                         notices.push(
                           OperationFailed(
                             operation~,
-                            path=recorded_entry.link.path,
+                            path=recorded_entry.link.path.path,
                             reason~,
                           ),
                         )
@@ -273,7 +276,9 @@ async fn reconcile_desired_entries(
                   }
                 Some(_) => {
                   notices.push(
-                    ReplacedOwnedPathPreserved(path=recorded_entry.link.path),
+                    ReplacedOwnedPathPreserved(
+                      path=recorded_entry.link.path.path,
+                    ),
                   )
                   let omitted = state_without_entry(durable_state, identity)
                   match
@@ -290,7 +295,7 @@ async fn reconcile_desired_entries(
           }
           Some(_) => {
             notices.push(
-              ReplacedOwnedPathPreserved(path=recorded_entry.link.path),
+              ReplacedOwnedPathPreserved(path=recorded_entry.link.path.path),
             )
             let omitted = state_without_entry(durable_state, identity)
             match

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_desired_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_desired_wbtest.mbt
@@ -247,7 +247,7 @@ async test "LinkReconciliation reconcile_skill_links 4 - refreshes same-target o
     let desired = desired_owned_entry(managed_root, target, "vendor/new")
     @fs.symlink(
       target=recorded.symlink_target.to_string(),
-      recorded.link.path.to_string(),
+      recorded.link.path.path.to_string(),
     )
     let desired_state = OwnershipState::OwnershipState([desired])
     let checkpoints = []
@@ -261,11 +261,11 @@ async test "LinkReconciliation reconcile_skill_links 4 - refreshes same-target o
     inspect(checkpoints.length(), content="1")
     inspect(checkpoints[0] == desired_state, content="true")
     debug_inspect(
-      @fs.kind(desired.link.path.to_string(), follow_symlink=false),
+      @fs.kind(desired.link.path.path.to_string(), follow_symlink=false),
       content="SymLink",
     )
     inspect(
-      @fs.realpath(desired.link.path.to_string()),
+      @fs.realpath(desired.link.path.path.to_string()),
       content=@fs.realpath(target.to_string()),
     )
   }
@@ -287,7 +287,7 @@ async test "LinkReconciliation reconcile_skill_links 5 - replaces a verified own
     let desired = desired_owned_entry(managed_root, new_target, "vendor/repo")
     @fs.symlink(
       target=recorded.symlink_target.to_string(),
-      recorded.link.path.to_string(),
+      recorded.link.path.path.to_string(),
     )
     let desired_state = OwnershipState::OwnershipState([desired])
     let checkpoints = []
@@ -303,7 +303,7 @@ async test "LinkReconciliation reconcile_skill_links 5 - replaces a verified own
     inspect(checkpoints[1] == desired_state, content="true")
     inspect(result.durable_state == desired_state, content="true")
     inspect(
-      @fs.realpath(desired.link.path.to_string()),
+      @fs.realpath(desired.link.path.path.to_string()),
       content=@fs.realpath(new_target.to_string()),
     )
   }
@@ -328,10 +328,10 @@ async test "LinkReconciliation reconcile_skill_links 6 - preserves replaced and 
       if fixture == "replaced" {
         @fs.symlink(
           target=other.relative(base=managed_root).to_string(),
-          entry.link.path.to_string(),
+          entry.link.path.path.to_string(),
         )
       } else {
-        @fs.symlink(target="missing-target", entry.link.path.to_string())
+        @fs.symlink(target="missing-target", entry.link.path.path.to_string())
       }
       let desired_state = OwnershipState::OwnershipState([entry])
       let checkpoints = []
@@ -346,12 +346,12 @@ async test "LinkReconciliation reconcile_skill_links 6 - preserves replaced and 
       inspect(checkpoints.length(), content="1")
       inspect(checkpoints[0].entries.length(), content="0")
       debug_inspect(
-        @fs.kind(entry.link.path.to_string(), follow_symlink=false),
+        @fs.kind(entry.link.path.path.to_string(), follow_symlink=false),
         content="SymLink",
       )
       if fixture == "replaced" {
         inspect(
-          @fs.realpath(entry.link.path.to_string()),
+          @fs.realpath(entry.link.path.path.to_string()),
           content=@fs.realpath(other.to_string()),
         )
       }

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_io.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_io.mbt
@@ -55,8 +55,8 @@ async fn is_physically_contained(
   io : LinkReconciliationIO,
   entry : OwnershipEntry,
 ) -> Bool {
-  let physical_root = (io.realpath)(entry.managed_root.path).normalize()
-  let physical_parent = (io.realpath)(entry.link.path.dirname()).normalize()
+  let physical_root = (io.realpath)(entry.managed_root.path.path).normalize()
+  let physical_parent = (io.realpath)(entry.link.path.path.dirname()).normalize()
   physical_parent == physical_root
 }
 
@@ -65,7 +65,7 @@ async fn recheck_stale_link(
   io : LinkReconciliationIO,
   entry : OwnershipEntry,
 ) -> StaleLinkRecheck {
-  let root_kind = (io.kind)(entry.managed_root.path) catch {
+  let root_kind = (io.kind)(entry.managed_root.path.path) catch {
     error =>
       return Failed(operation=VerifyContainment, reason=error.to_string())
   }
@@ -85,18 +85,18 @@ async fn recheck_stale_link(
       reason="physical containment changed",
     )
   }
-  let kind = classify_link(io, entry.link.path) catch {
+  let kind = classify_link(io, entry.link.path.path) catch {
     error => return Failed(operation=ClassifyLink, reason=error.to_string())
   }
   match kind {
     None => Missing
     Some(@fs.FileKind::SymLink) =>
-      try (io.realpath)(entry.link.path) catch {
+      try (io.realpath)(entry.link.path.path) catch {
         @os_error.OSError(_) as error if error.is_ENOENT() => Replaced
         error => Failed(operation=ClassifyLink, reason=error.to_string())
       } noraise {
         target =>
-          if target.normalize() == entry.resolved_target.path {
+          if target.normalize() == entry.resolved_target.path.path {
             Matching
           } else {
             Replaced

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_io_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_io_wbtest.mbt
@@ -16,7 +16,7 @@ async test "LinkReconciliation reconcile_skill_links 14 - continues independent 
     let checkpoints = []
     let io : LinkReconciliationIO = {
       mkdir: async fn(path) {
-        if path == entries[0].managed_root.path {
+        if path == entries[0].managed_root.path.path {
           fail("mkdir failed")
         }
         @fs.mkdir(path.to_string(), recursive=true) catch {
@@ -25,19 +25,19 @@ async test "LinkReconciliation reconcile_skill_links 14 - continues independent 
         }
       },
       kind: async fn(path) {
-        if path == entries[2].link.path {
+        if path == entries[2].link.path.path {
           fail("kind failed")
         }
         @fs.kind(path.to_string(), follow_symlink=false)
       },
       realpath: async fn(path) {
-        if path == entries[1].managed_root.path {
+        if path == entries[1].managed_root.path.path {
           fail("realpath failed")
         }
         @path.Path(@fs.realpath(path.to_string()))
       },
       symlink: async fn(target, link) {
-        if link == entries[3].link.path {
+        if link == entries[3].link.path.path {
           fail("create failed")
         }
         @fs.symlink(target=target.to_string(), link.to_string())
@@ -64,9 +64,9 @@ async test "LinkReconciliation reconcile_skill_links 14 - continues independent 
         OperationFailed(operation~, path~, reason=_) => {
           inspect(operation == expected_operation, content="true")
           let expected_path = if index == 0 {
-            entries[index].managed_root.path
+            entries[index].managed_root.path.path
           } else {
-            entries[index].link.path
+            entries[index].link.path.path
           }
           inspect(path == expected_path, content="true")
         }
@@ -102,7 +102,7 @@ async test "LinkReconciliation reconcile_skill_links 15 - retains failed stale r
       let entry = stale_reconciliation_entry(managed_root, "install", target)
       @fs.symlink(
         target=entry.symlink_target.to_string(),
-        entry.link.path.to_string(),
+        entry.link.path.path.to_string(),
       )
       entries.push(entry)
     }
@@ -115,7 +115,7 @@ async test "LinkReconciliation reconcile_skill_links 15 - retains failed stale r
         @fs.symlink(target=target.to_string(), link.to_string())
       },
       remove: async fn(path) {
-        if path == entries[0].link.path {
+        if path == entries[0].link.path.path {
           fail("remove failed")
         }
         @fs.remove(path.to_string())
@@ -133,15 +133,15 @@ async test "LinkReconciliation reconcile_skill_links 15 - retains failed stale r
     inspect(checkpoints.length(), content="1")
     match result.notices[0] {
       OperationFailed(operation=RemoveLink, path~, reason=_) =>
-        inspect(path == entries[0].link.path, content="true")
+        inspect(path == entries[0].link.path.path, content="true")
       _ => fail("expected stale remove failure")
     }
     debug_inspect(
-      @fs.kind(entries[0].link.path.to_string(), follow_symlink=false),
+      @fs.kind(entries[0].link.path.path.to_string(), follow_symlink=false),
       content="SymLink",
     )
     let removed = @fs.kind(
-      entries[1].link.path.to_string(),
+      entries[1].link.path.path.to_string(),
       follow_symlink=false,
     ) catch {
       _ => @fs.FileKind::Unknown
@@ -165,7 +165,7 @@ async test "LinkReconciliation reconcile_skill_links 19 - reports a forced colli
     @fs.mkdir(managed_root.to_string(), recursive=true)
     @fs.mkdir(target.to_string(), recursive=true)
     @fs.write_file(
-      entry.link.path.to_string(),
+      entry.link.path.path.to_string(),
       "collision",
       create_mode=CreateNew,
     )
@@ -202,11 +202,11 @@ async test "LinkReconciliation reconcile_skill_links 19 - reports a forced colli
     inspect(result.notices.length(), content="1")
     match result.notices[0] {
       OperationFailed(operation=RemoveLink, path~, reason=_) =>
-        inspect(path == entry.link.path, content="true")
+        inspect(path == entry.link.path.path, content="true")
       _ => fail("expected forced remove failure")
     }
     inspect(
-      @fs.read_file(entry.link.path.to_string()).text(),
+      @fs.read_file(entry.link.path.path.to_string()).text(),
       content="collision",
     )
     inspect(@fs.read_file(neighbor.to_string()).text(), content="neighbor")

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_stale.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_stale.mbt
@@ -14,12 +14,15 @@ async fn reconcile_stale_entries(
   for pair in stale_entries {
     let identity = pair.0
     let recorded_entry = pair.1
-    let recorded_root_kind = classify_link(io, recorded_entry.managed_root.path) catch {
+    let recorded_root_kind = classify_link(
+      io,
+      recorded_entry.managed_root.path.path,
+    ) catch {
       error => {
         notices.push(
           OperationFailed(
             operation=VerifyContainment,
-            path=recorded_entry.managed_root.path,
+            path=recorded_entry.managed_root.path.path,
             reason=error.to_string(),
           ),
         )
@@ -29,7 +32,7 @@ async fn reconcile_stale_entries(
     match recorded_root_kind {
       None => {
         let checkpointed_state = state_without_entry(durable_state, identity)
-        (io.checkpoint)(state_path.path, checkpointed_state) catch {
+        (io.checkpoint)(state_path.path.path, checkpointed_state) catch {
           error => {
             notices.push(
               CheckpointFailed(
@@ -56,7 +59,7 @@ async fn reconcile_stale_entries(
         notices.push(
           OperationFailed(
             operation=VerifyContainment,
-            path=recorded_entry.managed_root.path,
+            path=recorded_entry.managed_root.path.path,
             reason="recorded managed root must be a physical directory",
           ),
         )
@@ -68,7 +71,7 @@ async fn reconcile_stale_entries(
         notices.push(
           OperationFailed(
             operation=VerifyContainment,
-            path=recorded_entry.link.path,
+            path=recorded_entry.link.path.path,
             reason=error.to_string(),
           ),
         )
@@ -79,18 +82,18 @@ async fn reconcile_stale_entries(
       notices.push(
         OperationFailed(
           operation=VerifyContainment,
-          path=recorded_entry.link.path,
+          path=recorded_entry.link.path.path,
           reason="link parent resolves outside the recorded managed root",
         ),
       )
       continue
     }
-    let kind = classify_link(io, recorded_entry.link.path) catch {
+    let kind = classify_link(io, recorded_entry.link.path.path) catch {
       error => {
         notices.push(
           OperationFailed(
             operation=ClassifyLink,
-            path=recorded_entry.link.path,
+            path=recorded_entry.link.path.path,
             reason=error.to_string(),
           ),
         )
@@ -101,10 +104,10 @@ async fn reconcile_stale_entries(
     match kind {
       None => omit_ownership = true
       Some(@fs.FileKind::SymLink) => {
-        let target = try (io.realpath)(recorded_entry.link.path) catch {
+        let target = try (io.realpath)(recorded_entry.link.path.path) catch {
           @os_error.OSError(_) as error if error.is_ENOENT() => {
             notices.push(
-              BrokenOwnedLinkPreserved(path=recorded_entry.link.path),
+              BrokenOwnedLinkPreserved(path=recorded_entry.link.path.path),
             )
             omit_ownership = true
             None
@@ -113,7 +116,7 @@ async fn reconcile_stale_entries(
             notices.push(
               OperationFailed(
                 operation=ClassifyLink,
-                path=recorded_entry.link.path,
+                path=recorded_entry.link.path.path,
                 reason=error.to_string(),
               ),
             )
@@ -124,16 +127,16 @@ async fn reconcile_stale_entries(
         }
         match target {
           Some(live_target) if live_target ==
-            recorded_entry.resolved_target.path =>
+            recorded_entry.resolved_target.path.path =>
             match recheck_stale_link(io, recorded_entry) {
               Matching => {
-                (io.remove)(recorded_entry.link.path) catch {
+                (io.remove)(recorded_entry.link.path.path) catch {
                   @os_error.OSError(_) as error if error.is_ENOENT() => ()
                   error => {
                     notices.push(
                       OperationFailed(
                         operation=RemoveLink,
-                        path=recorded_entry.link.path,
+                        path=recorded_entry.link.path.path,
                         reason=error.to_string(),
                       ),
                     )
@@ -145,7 +148,7 @@ async fn reconcile_stale_entries(
               Missing => omit_ownership = true
               Replaced => {
                 notices.push(
-                  ReplacedOwnedPathPreserved(path=recorded_entry.link.path),
+                  ReplacedOwnedPathPreserved(path=recorded_entry.link.path.path),
                 )
                 omit_ownership = true
               }
@@ -153,14 +156,14 @@ async fn reconcile_stale_entries(
                 notices.push(
                   OperationFailed(
                     operation~,
-                    path=recorded_entry.link.path,
+                    path=recorded_entry.link.path.path,
                     reason~,
                   ),
                 )
             }
           Some(_) => {
             notices.push(
-              ReplacedOwnedPathPreserved(path=recorded_entry.link.path),
+              ReplacedOwnedPathPreserved(path=recorded_entry.link.path.path),
             )
             omit_ownership = true
           }
@@ -168,13 +171,15 @@ async fn reconcile_stale_entries(
         }
       }
       Some(_) => {
-        notices.push(ReplacedOwnedPathPreserved(path=recorded_entry.link.path))
+        notices.push(
+          ReplacedOwnedPathPreserved(path=recorded_entry.link.path.path),
+        )
         omit_ownership = true
       }
     }
     if omit_ownership {
       let checkpointed_state = state_without_entry(durable_state, identity)
-      (io.checkpoint)(state_path.path, checkpointed_state) catch {
+      (io.checkpoint)(state_path.path.path, checkpointed_state) catch {
         error => {
           notices.push(
             CheckpointFailed(

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_stale_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_stale_wbtest.mbt
@@ -24,32 +24,32 @@ async test "LinkReconciliation reconcile_skill_links 3 - reconciles trusted stal
         "matching" =>
           @fs.symlink(
             target=entry.symlink_target.to_string(),
-            entry.link.path.to_string(),
+            entry.link.path.path.to_string(),
           )
         "removed-root" =>
-          @fs.rmdir(entry.managed_root.path.to_string(), recursive=true)
+          @fs.rmdir(entry.managed_root.path.path.to_string(), recursive=true)
         "missing" => ()
         "file" =>
           @fs.write_file(
-            entry.link.path.to_string(),
+            entry.link.path.path.to_string(),
             "foreign",
             create_mode=CreateNew,
           )
-        "directory" => @fs.mkdir(entry.link.path.to_string())
+        "directory" => @fs.mkdir(entry.link.path.path.to_string())
         "different" => {
           let other = target_root.join("different-other")
           @fs.mkdir(other.to_string())
           @fs.symlink(
-            target=other.relative(base=entry.managed_root.path).to_string(),
-            entry.link.path.to_string(),
+            target=other.relative(base=entry.managed_root.path.path).to_string(),
+            entry.link.path.path.to_string(),
           )
         }
         "broken" =>
-          @fs.symlink(target="missing-target", entry.link.path.to_string())
+          @fs.symlink(target="missing-target", entry.link.path.path.to_string())
         _ => fail("unexpected fixture")
       }
     }
-    let neighbor = entries[0].managed_root.path.join("foreign-neighbor")
+    let neighbor = entries[0].managed_root.path.path.join("foreign-neighbor")
     @fs.write_file(neighbor.to_string(), "keep", create_mode=CreateNew)
     let previous_state = OwnershipState::OwnershipState(entries)
     let desired_state = OwnershipState::OwnershipState([])
@@ -76,24 +76,24 @@ async test "LinkReconciliation reconcile_skill_links 3 - reconciles trusted stal
     inspect(result.notices.length(), content="4")
     inspect(@fs.read_file(neighbor.to_string()).text(), content="keep")
     inspect(
-      @fs.read_file(entries[2].link.path.to_string()).text(),
+      @fs.read_file(entries[2].link.path.path.to_string()).text(),
       content="foreign",
     )
     debug_inspect(
-      @fs.kind(entries[3].link.path.to_string(), follow_symlink=false),
+      @fs.kind(entries[3].link.path.path.to_string(), follow_symlink=false),
       content="Directory",
     )
     debug_inspect(
-      @fs.kind(entries[4].link.path.to_string(), follow_symlink=false),
+      @fs.kind(entries[4].link.path.path.to_string(), follow_symlink=false),
       content="SymLink",
     )
     debug_inspect(
-      @fs.kind(entries[5].link.path.to_string(), follow_symlink=false),
+      @fs.kind(entries[5].link.path.path.to_string(), follow_symlink=false),
       content="SymLink",
     )
     for index in [0, 1, 6] {
       let kind = @fs.kind(
-        entries[index].link.path.to_string(),
+        entries[index].link.path.path.to_string(),
         follow_symlink=false,
       ) catch {
         _ => @fs.FileKind::Unknown
@@ -101,7 +101,7 @@ async test "LinkReconciliation reconcile_skill_links 3 - reconciles trusted stal
       debug_inspect(kind, content="Unknown")
     }
     let removed_root_kind = @fs.kind(
-      entries[6].managed_root.path.to_string(),
+      entries[6].managed_root.path.path.to_string(),
       follow_symlink=false,
     ) catch {
       _ => @fs.FileKind::Unknown
@@ -126,11 +126,11 @@ async test "LinkReconciliation reconcile_skill_links 8 - isolates stale deletion
     let entry_b = stale_reconciliation_entry(managed_root, "b", target_b)
     @fs.symlink(
       target=entry_a.symlink_target.to_string(),
-      entry_a.link.path.to_string(),
+      entry_a.link.path.path.to_string(),
     )
     @fs.symlink(
       target=entry_b.symlink_target.to_string(),
-      entry_b.link.path.to_string(),
+      entry_b.link.path.path.to_string(),
     )
     let desired_state = OwnershipState::OwnershipState([])
     let result_a = reconcile_skill_links(
@@ -141,14 +141,14 @@ async test "LinkReconciliation reconcile_skill_links 8 - isolates stale deletion
     )
     debug_inspect(result_a.status, content="Complete")
     let removed_a = @fs.kind(
-      entry_a.link.path.to_string(),
+      entry_a.link.path.path.to_string(),
       follow_symlink=false,
     ) catch {
       _ => @fs.FileKind::Unknown
     }
     debug_inspect(removed_a, content="Unknown")
     debug_inspect(
-      @fs.kind(entry_b.link.path.to_string(), follow_symlink=false),
+      @fs.kind(entry_b.link.path.path.to_string(), follow_symlink=false),
       content="SymLink",
     )
     let result_b = reconcile_skill_links(
@@ -159,7 +159,7 @@ async test "LinkReconciliation reconcile_skill_links 8 - isolates stale deletion
     )
     debug_inspect(result_b.status, content="Complete")
     let removed_b = @fs.kind(
-      entry_b.link.path.to_string(),
+      entry_b.link.path.path.to_string(),
       follow_symlink=false,
     ) catch {
       _ => @fs.FileKind::Unknown
@@ -181,7 +181,7 @@ async test "LinkReconciliation reconcile_skill_links 11 - retries stale omission
     let entry = stale_reconciliation_entry(managed_root, "stale", target)
     @fs.symlink(
       target=entry.symlink_target.to_string(),
-      entry.link.path.to_string(),
+      entry.link.path.path.to_string(),
     )
     let previous = OwnershipState::OwnershipState([entry])
     let desired_state = OwnershipState::OwnershipState([])
@@ -205,7 +205,10 @@ async test "LinkReconciliation reconcile_skill_links 11 - retries stale omission
       }
       _ => fail("expected stale checkpoint failure")
     }
-    let removed = @fs.kind(entry.link.path.to_string(), follow_symlink=false) catch {
+    let removed = @fs.kind(
+      entry.link.path.path.to_string(),
+      follow_symlink=false,
+    ) catch {
       _ => @fs.FileKind::Unknown
     }
     debug_inspect(removed, content="Unknown")
@@ -277,7 +280,7 @@ async test "LinkReconciliation reconcile_skill_links 16 - preserves a foreign re
     )
     @fs.symlink(
       target=entry.symlink_target.to_string(),
-      entry.link.path.to_string(),
+      entry.link.path.path.to_string(),
     )
     let mut link_kind_calls = 0
     let mut remove_called = false
@@ -285,7 +288,7 @@ async test "LinkReconciliation reconcile_skill_links 16 - preserves a foreign re
     let io : LinkReconciliationIO = {
       mkdir: async fn(path) { @fs.mkdir(path.to_string(), recursive=true) },
       kind: async fn(path) {
-        if path == entry.link.path {
+        if path == entry.link.path.path {
           link_kind_calls = link_kind_calls + 1
           if link_kind_calls == 2 {
             @fs.remove(path.to_string())
@@ -320,11 +323,11 @@ async test "LinkReconciliation reconcile_skill_links 16 - preserves a foreign re
     inspect(result.durable_state.entries.length(), content="0")
     match result.notices[0] {
       ReplacedOwnedPathPreserved(path~) =>
-        inspect(path == entry.link.path, content="true")
+        inspect(path == entry.link.path.path, content="true")
       _ => fail("expected final-recheck replacement notice")
     }
     inspect(
-      @fs.realpath(entry.link.path.to_string()),
+      @fs.realpath(entry.link.path.path.to_string()),
       content=@fs.realpath(foreign_target.to_string()),
     )
   }

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_state.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_state.mbt
@@ -43,7 +43,7 @@ async fn checkpoint_ownership(
   checkpointed_state : OwnershipState,
   notices : Array[LinkReconciliationNotice],
 ) -> OwnershipCheckpointResult {
-  (io.checkpoint)(state_path.path, checkpointed_state) catch {
+  (io.checkpoint)(state_path.path.path, checkpointed_state) catch {
     error => {
       notices.push(
         CheckpointFailed(

--- a/mbt/app/c-plugin-v2/src/link_reconciliation_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/link_reconciliation_wbtest.mbt
@@ -56,7 +56,7 @@ async test "LinkReconciliation reconcile_skill_links 1 - creates a missing desir
       @fs.realpath(link.to_string()),
       content=@fs.realpath(target.to_string()),
     )
-    inspect(checkpoint_path == Some(state_path.path), content="true")
+    inspect(checkpoint_path == Some(state_path.path.path), content="true")
     inspect(checkpoint_state == Some(desired_state), content="true")
     debug_inspect(result.status, content="Complete")
     inspect(result.durable_state == desired_state, content="true")
@@ -150,7 +150,7 @@ async test "LinkReconciliation reconcile_skill_links 7 - distinguishes unavailab
       )
       @fs.symlink(
         target=foreign_target.relative(base=managed_root).to_string(),
-        collision.link.path.to_string(),
+        collision.link.path.path.to_string(),
       )
       let desired_state = OwnershipState::OwnershipState([collision, absent])
       let state_path = reconciliation_state_path(root.join("state.json"))
@@ -180,11 +180,11 @@ async test "LinkReconciliation reconcile_skill_links 7 - distinguishes unavailab
         _ => fail("expected distinct unavailable ownership notice")
       }
       inspect(
-        @fs.realpath(collision.link.path.to_string()),
+        @fs.realpath(collision.link.path.path.to_string()),
         content=@fs.realpath(foreign_target.to_string()),
       )
       inspect(
-        @fs.realpath(absent.link.path.to_string()),
+        @fs.realpath(absent.link.path.path.to_string()),
         content=@fs.realpath(absent_target.to_string()),
       )
     }

--- a/mbt/app/c-plugin-v2/src/lock_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_codec.mbt
@@ -40,40 +40,46 @@ pub impl ToJson for GitHubRepository with fn to_json(self) -> Json {
 ///|
 pub impl @json.FromJson for Target with fn from_json(json, path) {
   let value : String = @json.from_json(json, path~)
-  Target(@path.Path(value)) catch {
+  validate_restricted_relative_path_value(value, "target path") catch {
     error => raise @json.JsonDecodeError((path, error.to_string()))
   }
+  let relative : @x_path.RelativePath = @json.from_json(json, path~)
+  Target::from_relative(relative)
 }
 
 ///|
 pub impl ToJson for Target with fn to_json(self) -> Json {
-  self.path.to_string().to_json()
+  self.path.to_json()
 }
 
 ///|
 pub impl @json.FromJson for RelativeSourcePath with fn from_json(json, path) {
   let value : String = @json.from_json(json, path~)
-  RelativeSourcePath(@path.Path(value)) catch {
+  validate_restricted_relative_path_value(value, "local repository path") catch {
     error => raise @json.JsonDecodeError((path, error.to_string()))
   }
+  let relative : @x_path.RelativePath = @json.from_json(json, path~)
+  RelativeSourcePath::from_relative(relative)
 }
 
 ///|
 pub impl ToJson for RelativeSourcePath with fn to_json(self) -> Json {
-  self.path.to_string().to_json()
+  self.path.to_json()
 }
 
 ///|
 pub impl @json.FromJson for RelativePluginPath with fn from_json(json, path) {
   let value : String = @json.from_json(json, path~)
-  RelativePluginPath(@path.Path(value)) catch {
+  validate_restricted_relative_path_value(value, "plugin path") catch {
     error => raise @json.JsonDecodeError((path, error.to_string()))
   }
+  let relative : @x_path.RelativePath = @json.from_json(json, path~)
+  RelativePluginPath::from_relative(relative)
 }
 
 ///|
 pub impl ToJson for RelativePluginPath with fn to_json(self) -> Json {
-  self.path.to_string().to_json()
+  self.path.to_json()
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/lock_discovery.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_discovery.mbt
@@ -89,11 +89,11 @@ pub async fn discover_locks(
   options : LockDiscoveryOptions,
 ) -> ReadOnlyArray[@path.Path] raise LockDiscoveryError {
   match options {
-    Global => ReadOnlyArray::from_array([find_global_lock(paths.home)])
+    Global => ReadOnlyArray::from_array([find_global_lock(paths.home.path)])
     Project(recursive~) => {
-      let nearest_lock = find_project_lock(paths.home, paths.cwd)
+      let nearest_lock = find_project_lock(paths.home.path, paths.cwd.path)
       if recursive {
-        find_recursive_project_locks(paths.home, nearest_lock)
+        find_recursive_project_locks(paths.home.path, nearest_lock)
       } else {
         ReadOnlyArray::from_array([nearest_lock])
       }

--- a/mbt/app/c-plugin-v2/src/lock_discovery_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_discovery_wbtest.mbt
@@ -72,10 +72,10 @@ async fn write_lock(path : @path.Path) -> @path.Path {
 async test "discover_locks - finds the nearest project lock below the synthetic home" {
   with_lock_discovery_fixture(async fn(fixture) {
     let outer_lock = write_lock(
-      fixture.paths.home.join("workspace").join("c-plugin-lock.json"),
+      fixture.paths.home.path.join("workspace").join("c-plugin-lock.json"),
     )
     let nearest_lock = write_lock(
-      fixture.paths.home
+      fixture.paths.home.path
       .join("workspace")
       .join("package")
       .join("c-plugin-lock.json"),
@@ -92,9 +92,11 @@ async test "discover_locks - finds the nearest project lock below the synthetic 
 ///|
 async test "discover_locks - resolves the global lock exactly below the synthetic home" {
   with_lock_discovery_fixture(async fn(fixture) {
-    let global_lock = write_lock(fixture.paths.home.join("c-plugin-lock.json"))
+    let global_lock = write_lock(
+      fixture.paths.home.path.join("c-plugin-lock.json"),
+    )
     let _project_lock = write_lock(
-      fixture.paths.home
+      fixture.paths.home.path
       .join("workspace")
       .join("package")
       .join("c-plugin-lock.json"),
@@ -108,20 +110,20 @@ async test "discover_locks - resolves the global lock exactly below the syntheti
 async test "discover_locks - includes the nearest project lock and visible descendants recursively" {
   with_lock_discovery_fixture(async fn(fixture) {
     let nearest_lock = write_lock(
-      fixture.paths.home
+      fixture.paths.home.path
       .join("workspace")
       .join("package")
       .join("c-plugin-lock.json"),
     )
     let child_lock = write_lock(
-      fixture.paths.home
+      fixture.paths.home.path
       .join("workspace")
       .join("package")
       .join("child")
       .join("c-plugin-lock.json"),
     )
     let nested_lock = write_lock(
-      fixture.paths.home
+      fixture.paths.home.path
       .join("workspace")
       .join("package")
       .join("child")
@@ -141,7 +143,7 @@ async test "discover_locks - includes the nearest project lock and visible desce
 ///|
 async test "discover_locks - excludes descendants in gitignored directories" {
   with_lock_discovery_fixture(async fn(fixture) {
-    let project_root = fixture.paths.home.join("workspace").join("package")
+    let project_root = fixture.paths.home.path.join("workspace").join("package")
     let nearest_lock = write_lock(project_root.join("c-plugin-lock.json"))
     @fs.write_file(
       project_root.join(".gitignore").to_string(),
@@ -179,7 +181,7 @@ async test "discover_locks - does not search for project locks above the synthet
       LockFileNotFound(scope=Project, boundary~) => boundary.to_string()
       _ => "wrong error"
     }
-    inspect(detail, content=fixture.paths.home.to_string())
+    inspect(detail, content=fixture.paths.home.path.to_string())
     assert_true(@fs.exists(outside_lock.to_string()))
   })
 }
@@ -198,7 +200,7 @@ async test "discover_locks - reports a typed error when no project lock exists" 
       LockFileNotFound(scope=Project, boundary~) => boundary.to_string()
       _ => "wrong error"
     }
-    inspect(detail, content=fixture.paths.home.to_string())
+    inspect(detail, content=fixture.paths.home.path.to_string())
   })
 }
 
@@ -211,9 +213,9 @@ async test "discover_locks - rejects a cwd outside the synthetic home" {
     )
     @fs.mkdir(outside_cwd.to_string(), recursive=true)
     let paths = RuntimePaths::RuntimePaths(
-      fixture.paths.home,
+      fixture.paths.home.path,
       outside_cwd,
-      fixture.paths.cache_root,
+      fixture.paths.cache_root.path,
     )
     let detail = try {
       discover_locks(paths, LockDiscoveryOptions::Project(recursive=false))
@@ -223,7 +225,7 @@ async test "discover_locks - rejects a cwd outside the synthetic home" {
       LockFileNotFound(scope=Project, boundary~) => boundary.to_string()
       _ => "wrong error"
     }
-    inspect(detail, content=fixture.paths.home.to_string())
+    inspect(detail, content=fixture.paths.home.path.to_string())
     assert_true(@fs.exists(outside_lock.to_string()))
   })
 }
@@ -238,6 +240,6 @@ async test "discover_locks - reports a typed error when no global lock exists" {
       LockFileNotFound(scope=Global, boundary~) => boundary.to_string()
       _ => "wrong error"
     }
-    inspect(detail, content=fixture.paths.home.to_string())
+    inspect(detail, content=fixture.paths.home.path.to_string())
   })
 }

--- a/mbt/app/c-plugin-v2/src/lock_domain.mbt
+++ b/mbt/app/c-plugin-v2/src/lock_domain.mbt
@@ -84,70 +84,108 @@ pub fn GitHubRepository::route(self : GitHubRepository) -> String {
 
 ///|
 pub struct Target {
-  path : @path.Path
+  path : @x_path.RelativePath
 } derive(Eq)
 
 ///|
 pub impl Compare for Target with fn compare(self, other) {
-  self.path.to_string().lexical_compare(other.path.to_string())
+  @x_path.Path::to_string(self.path).lexical_compare(
+    @x_path.Path::to_string(other.path),
+  )
 }
 
 ///|
 pub impl Hash for Target with fn hash_combine(self, hasher) {
-  self.path.to_string().hash_combine(hasher)
+  Hash::hash_combine(@x_path.Path::to_string(self.path), hasher)
 }
 
 ///|
 pub fn Target::Target(path : @path.Path) -> Target raise {
-  validate_relative_path(path, "target path")
-  { path: path.normalize() }
+  Target::from_relative(restricted_relative_path(path, "target path"))
+}
+
+///|
+fn Target::from_relative(path : @x_path.RelativePath) -> Target {
+  { path, }
 }
 
 ///|
 pub struct RelativeSourcePath {
-  path : @path.Path
+  path : @x_path.RelativePath
 } derive(Eq)
 
 ///|
 pub impl Compare for RelativeSourcePath with fn compare(self, other) {
-  self.path.to_string().lexical_compare(other.path.to_string())
+  @x_path.Path::to_string(self.path).lexical_compare(
+    @x_path.Path::to_string(other.path),
+  )
 }
 
 ///|
 pub impl Hash for RelativeSourcePath with fn hash_combine(self, hasher) {
-  self.path.to_string().hash_combine(hasher)
+  Hash::hash_combine(@x_path.Path::to_string(self.path), hasher)
 }
 
 ///|
 pub fn RelativeSourcePath::RelativeSourcePath(
   path : @path.Path,
 ) -> RelativeSourcePath raise {
-  validate_relative_path(path, "local repository path")
-  { path: path.normalize() }
+  RelativeSourcePath::from_relative(
+    restricted_relative_path(path, "local repository path"),
+  )
+}
+
+///|
+fn RelativeSourcePath::from_relative(
+  path : @x_path.RelativePath,
+) -> RelativeSourcePath {
+  { path, }
 }
 
 ///|
 pub struct RelativePluginPath {
-  path : @path.Path
+  path : @x_path.RelativePath
 } derive(Eq)
 
 ///|
 pub impl Hash for RelativePluginPath with fn hash_combine(self, hasher) {
-  self.path.to_string().hash_combine(hasher)
+  Hash::hash_combine(@x_path.Path::to_string(self.path), hasher)
 }
 
 ///|
 pub fn RelativePluginPath::RelativePluginPath(
   path : @path.Path,
 ) -> RelativePluginPath raise {
-  validate_relative_path(path, "plugin path")
-  { path: path.normalize() }
+  RelativePluginPath::from_relative(
+    restricted_relative_path(path, "plugin path"),
+  )
 }
 
 ///|
-fn validate_relative_path(path : @path.Path, kind : String) -> Unit raise {
+fn RelativePluginPath::from_relative(
+  path : @x_path.RelativePath,
+) -> RelativePluginPath {
+  { path, }
+}
+
+///|
+fn restricted_relative_path(
+  path : @path.Path,
+  kind : String,
+) -> @x_path.RelativePath raise {
   let value = path.to_string()
-  guard value != "" && !path.is_absolute() && !value.contains("\\") else {
+  validate_restricted_relative_path_value(value, kind)
+  @x_path.RelativePath::RelativePath(path) catch {
+    _ => fail("\{kind} must be a relative path")
+  }
+}
+
+///|
+fn validate_restricted_relative_path_value(
+  value : String,
+  kind : String,
+) -> Unit raise {
+  guard value != "" && !value.contains("\\") else {
     fail("\{kind} must be a relative path")
   }
   let segments = value

--- a/mbt/app/c-plugin-v2/src/marketplace_resolution.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace_resolution.mbt
@@ -5,18 +5,17 @@ pub(all) suberror RepositoryRootError {
 
 ///|
 pub struct RepositoryRoot {
-  path : @path.Path
+  path : @x_path.AbsolutePath
 } derive(Eq)
 
 ///|
 pub fn RepositoryRoot::RepositoryRoot(
   path : @path.Path,
 ) -> RepositoryRoot raise RepositoryRootError {
-  let normalized = path.normalize()
-  guard normalized.is_absolute() else {
-    raise RelativeRepositoryRoot(path=normalized)
+  let absolute = @x_path.AbsolutePath::AbsolutePath(path) catch {
+    _ => raise RelativeRepositoryRoot(path=path.normalize())
   }
-  { path: normalized }
+  { path: absolute }
 }
 
 ///|
@@ -24,13 +23,14 @@ pub struct ResolvedSkill {
   plugin_name : PluginName
   plugin_path : RelativePluginPath
   skill_name : SkillName
-  skill_path : @path.Path
+  skill_path : @x_path.AbsolutePath
 } derive(Eq)
 
 ///|
 pub(all) suberror SkillResolutionError {
   IO(path~ : @path.Path, reason~ : String)
   InvalidSkillName(path~ : @path.Path, reason~ : String)
+  InvalidSkillPath(path~ : @path.Path, reason~ : String)
 } derive(Debug, Eq)
 
 ///|
@@ -51,8 +51,8 @@ async fn resolve_plugin_skills(
   repository_root : RepositoryRoot,
   plugin : MarketplacePlugin,
 ) -> Array[ResolvedSkill] raise SkillResolutionError {
-  let skills_directory = repository_root.path
-    .join(plugin.path.path)
+  let skills_directory = repository_root.path.path
+    .join(plugin.path.path.path)
     .join("skills")
   let entries = @fs.readdir(
     skills_directory.to_string(),
@@ -85,6 +85,9 @@ async fn resolve_plugin_skills(
     plugin_name: plugin.name,
     plugin_path: plugin.path,
     skill_name: candidate.0,
-    skill_path: candidate.1,
+    skill_path: @x_path.AbsolutePath::AbsolutePath(candidate.1) catch {
+      error =>
+        raise InvalidSkillPath(path=candidate.1, reason=error.to_string())
+    },
   })
 }

--- a/mbt/app/c-plugin-v2/src/marketplace_resolution_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/marketplace_resolution_wbtest.mbt
@@ -63,7 +63,7 @@ async test "MarketplaceResolution resolve_marketplace_skills - preserves plugin 
     )
     debug_inspect(
       resolved.map(skill => {
-        "\{skill.plugin_name.value}|\{skill.plugin_path.path.to_string()}|\{skill.skill_name.value}|\{skill.skill_path.to_string()}"
+        "\{skill.plugin_name.value}|\{skill.plugin_path.path.to_string()}|\{skill.skill_name.value}|\{skill.skill_path.path.to_string()}"
       }),
       content=(
         #|<ReadOnlyArray:

--- a/mbt/app/c-plugin-v2/src/moon.pkg
+++ b/mbt/app/c-plugin-v2/src/moon.pkg
@@ -12,6 +12,7 @@ import {
   "totto2727/admiral",
   "totto2727/lens",
   "totto2727/target-file-discovery" @target_file_discovery,
+  "totto2727/x/path" @x_path,
 }
 
 import {

--- a/mbt/app/c-plugin-v2/src/ownership_state.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state.mbt
@@ -92,73 +92,81 @@ pub fn OwnershipSource::from_local(
 
 ///|
 pub struct OwnershipStatePath {
-  path : @path.Path
+  path : @x_path.AbsolutePath
 } derive(Eq)
 
 ///|
 pub fn OwnershipStatePath::OwnershipStatePath(
   path : @path.Path,
 ) -> OwnershipStatePath raise {
-  guard path.is_absolute() else {
-    fail("ownership state path must be absolute")
+  let absolute = @x_path.AbsolutePath::AbsolutePath(path) catch {
+    _ => fail("ownership state path must be absolute")
   }
-  { path: path.normalize() }
+  { path: absolute }
 }
 
 ///|
 pub struct OwnershipLink {
-  path : @path.Path
+  path : @x_path.AbsolutePath
 } derive(Eq)
 
 ///|
 pub fn OwnershipLink::OwnershipLink(path : @path.Path) -> OwnershipLink raise {
-  guard path.is_absolute() else { fail("ownership link must be absolute") }
-  { path: path.normalize() }
+  let absolute = @x_path.AbsolutePath::AbsolutePath(path) catch {
+    _ => fail("ownership link must be absolute")
+  }
+  { path: absolute }
 }
 
 ///|
 pub impl Compare for OwnershipLink with fn compare(self, other) {
-  self.path.to_string().lexical_compare(other.path.to_string())
+  @x_path.Path::to_string(self.path).lexical_compare(
+    @x_path.Path::to_string(other.path),
+  )
 }
 
 ///|
 pub struct OwnershipResolvedTarget {
-  path : @path.Path
+  path : @x_path.AbsolutePath
 } derive(Eq)
 
 ///|
 pub fn OwnershipResolvedTarget::OwnershipResolvedTarget(
   path : @path.Path,
 ) -> OwnershipResolvedTarget raise {
-  guard path.is_absolute() else {
-    fail("ownership resolved target must be absolute")
+  let absolute = @x_path.AbsolutePath::AbsolutePath(path) catch {
+    _ => fail("ownership resolved target must be absolute")
   }
-  { path: path.normalize() }
+  { path: absolute }
 }
 
 ///|
 pub impl Compare for OwnershipResolvedTarget with fn compare(self, other) {
-  self.path.to_string().lexical_compare(other.path.to_string())
+  @x_path.Path::to_string(self.path).lexical_compare(
+    @x_path.Path::to_string(other.path),
+  )
 }
 
 ///|
 pub struct OwnershipManagedRoot {
-  path : @path.Path
+  path : @x_path.AbsolutePath
 } derive(Eq)
 
 ///|
 pub fn OwnershipManagedRoot::OwnershipManagedRoot(
   path : @path.Path,
 ) -> OwnershipManagedRoot raise {
-  guard path.is_absolute() else {
-    fail("ownership managed root must be absolute")
+  let absolute = @x_path.AbsolutePath::AbsolutePath(path) catch {
+    _ => fail("ownership managed root must be absolute")
   }
-  { path: path.normalize() }
+  { path: absolute }
 }
 
 ///|
 pub impl Compare for OwnershipManagedRoot with fn compare(self, other) {
-  self.path.to_string().lexical_compare(other.path.to_string())
+  @x_path.Path::to_string(self.path).lexical_compare(
+    @x_path.Path::to_string(other.path),
+  )
 }
 
 ///|
@@ -178,7 +186,7 @@ pub fn OwnershipEntry::OwnershipEntry(
   managed_root : OwnershipManagedRoot,
   source : OwnershipSource,
 ) -> OwnershipEntry raise {
-  guard link.path.dirname() == managed_root.path else {
+  guard link.path.path.dirname() == managed_root.path.path else {
     fail("ownership link must be a direct child of its managed root")
   }
   { link, symlink_target, resolved_target, managed_root, source }
@@ -219,24 +227,26 @@ pub struct OwnershipState {
 
 ///|
 pub struct OwnershipLinkIdentity {
-  path : @path.Path
+  path : @x_path.AbsolutePath
 } derive(Eq)
 
 ///|
 pub impl Compare for OwnershipLinkIdentity with fn compare(self, other) {
-  self.path.to_string().lexical_compare(other.path.to_string())
+  @x_path.Path::to_string(self.path).lexical_compare(
+    @x_path.Path::to_string(other.path),
+  )
 }
 
 ///|
 pub fn OwnershipLinkIdentity::OwnershipLinkIdentity(
-  path : @path.Path,
+  path : @x_path.AbsolutePath,
 ) -> OwnershipLinkIdentity {
-  { path: path.normalize() }
+  { path, }
 }
 
 ///|
 pub impl Hash for OwnershipLinkIdentity with fn hash_combine(self, hasher) {
-  self.path.to_string().hash_combine(hasher)
+  Hash::hash_combine(@x_path.Path::to_string(self.path), hasher)
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec.mbt
@@ -128,21 +128,21 @@ pub impl ToJson for OwnershipSource with fn to_json(self) -> Json {
 
 ///|
 pub impl FromJson for OwnershipLink with fn from_json(json, path) {
-  let value : String = @json.from_json(json, path~)
-  OwnershipLink::OwnershipLink(@path.Path(value)) catch {
+  let absolute : @x_path.AbsolutePath = @json.from_json(json, path~)
+  OwnershipLink::OwnershipLink(absolute.path) catch {
     _ => raise @json.JsonDecodeError((path, "ownership link must be absolute"))
   }
 }
 
 ///|
 pub impl ToJson for OwnershipLink with fn to_json(self) -> Json {
-  self.path.to_string().to_json()
+  self.path.to_json()
 }
 
 ///|
 pub impl FromJson for OwnershipResolvedTarget with fn from_json(json, path) {
-  let value : String = @json.from_json(json, path~)
-  OwnershipResolvedTarget::OwnershipResolvedTarget(@path.Path(value)) catch {
+  let absolute : @x_path.AbsolutePath = @json.from_json(json, path~)
+  OwnershipResolvedTarget::OwnershipResolvedTarget(absolute.path) catch {
     _ =>
       raise @json.JsonDecodeError(
         (path, "ownership resolved target must be absolute"),
@@ -152,13 +152,13 @@ pub impl FromJson for OwnershipResolvedTarget with fn from_json(json, path) {
 
 ///|
 pub impl ToJson for OwnershipResolvedTarget with fn to_json(self) -> Json {
-  self.path.to_string().to_json()
+  self.path.to_json()
 }
 
 ///|
 pub impl FromJson for OwnershipManagedRoot with fn from_json(json, path) {
-  let value : String = @json.from_json(json, path~)
-  OwnershipManagedRoot::OwnershipManagedRoot(@path.Path(value)) catch {
+  let absolute : @x_path.AbsolutePath = @json.from_json(json, path~)
+  OwnershipManagedRoot::OwnershipManagedRoot(absolute.path) catch {
     _ =>
       raise @json.JsonDecodeError(
         (path, "ownership managed root must be absolute"),
@@ -168,7 +168,7 @@ pub impl FromJson for OwnershipManagedRoot with fn from_json(json, path) {
 
 ///|
 pub impl ToJson for OwnershipManagedRoot with fn to_json(self) -> Json {
-  self.path.to_string().to_json()
+  self.path.to_json()
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_codec_wbtest.mbt
@@ -78,6 +78,21 @@ test "OwnershipState ToJson::to_json - round trips local ownership metadata" {
 }
 
 ///|
+test "OwnershipState ToJson::to_json - preserves literal symlink targets" {
+  for target in ["a/../b", "/absolute/target"] {
+    let text = "{\"version\":\"1\",\"entries\":[{" +
+      "\"link\":\"/home/alice/project/.agents/skills/sync\"," +
+      "\"symlinkTarget\":\"\{target}\"," +
+      "\"resolvedTarget\":\"/home/alice/.cache/c-plugin/skills/sync\"," +
+      "\"managedRoot\":\"/home/alice/project/.agents/skills\"," +
+      "\"source\":{\"type\":\"github\",\"repository\":\"openai/codex\"," +
+      "\"plugin\":\"c-plugin\",\"skill\":\"sync\"}}]}"
+    let state : OwnershipState = @json.from_json(@json.parse(text))
+    inspect(ToJson::to_json(state).stringify(), content=text)
+  }
+}
+
+///|
 test "OwnershipState ToJson::to_json - sorts entries by link" {
   let text =
     #|{"version":"1","entries":[{"link":"/home/alice/project/.agents/skills/z-last","symlinkTarget":"../../../cache/skills/z-last","resolvedTarget":"/home/alice/.cache/c-plugin/skills/z-last","managedRoot":"/home/alice/project/.agents/skills","source":{"type":"github","repository":"openai/codex","plugin":"c-plugin","skill":"z-last"}},{"link":"/home/alice/project/.agents/skills/a-first","symlinkTarget":"../../../cache/skills/a-first","resolvedTarget":"/home/alice/.cache/c-plugin/skills/a-first","managedRoot":"/home/alice/project/.agents/skills","source":{"type":"github","repository":"openai/codex","plugin":"c-plugin","skill":"a-first"}}]}

--- a/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/ownership_state_wbtest.mbt
@@ -93,7 +93,7 @@ test "OwnershipEntry Compare::compare - uses every Eq field as a tie breaker" {
   let changed_symlink = ownership_entry_with(
     link,
     "../../../other-cache/skills/sync",
-    base.resolved_target.path,
+    base.resolved_target.path.path,
     base.source,
   )
   let changed_target = ownership_entry_with(
@@ -105,7 +105,7 @@ test "OwnershipEntry Compare::compare - uses every Eq field as a tie breaker" {
   let changed_source = ownership_entry_with(
     link,
     base.symlink_target,
-    base.resolved_target.path,
+    base.resolved_target.path.path,
     OwnershipSource::from_local(
       LocalOwnershipSource::LocalOwnershipSource(
         RelativeSourcePath::RelativeSourcePath("vendor/c-plugin"),
@@ -136,7 +136,7 @@ test "OwnershipEntry OwnershipEntry - normalizes absolute paths but preserves sy
     "/home/alice/project/.agents/skills/../skills/sync",
   )
   inspect(
-    entry.link.path.to_string(),
+    entry.link.path.path.to_string(),
     content="/home/alice/project/.agents/skills/sync",
   )
   inspect(
@@ -144,11 +144,11 @@ test "OwnershipEntry OwnershipEntry - normalizes absolute paths but preserves sy
     content="../../../cache/skills/sync",
   )
   inspect(
-    entry.resolved_target.path.to_string(),
+    entry.resolved_target.path.path.to_string(),
     content="/home/alice/.cache/c-plugin/skills/sync",
   )
   inspect(
-    entry.managed_root.path.to_string(),
+    entry.managed_root.path.path.to_string(),
     content="/home/alice/project/.agents/skills",
   )
 }
@@ -182,9 +182,13 @@ test "OwnershipState equality - ignores entry order" {
 ///|
 test "OwnershipLinkIdentity Compare::compare - uses normalized lexical path order" {
   let first = OwnershipLinkIdentity(
-    "/home/alice/project/.agents/skills/other/../alpha",
+    OwnershipLink::OwnershipLink(
+      "/home/alice/project/.agents/skills/other/../alpha",
+    ).path,
   )
-  let last = OwnershipLinkIdentity("/home/alice/project/.agents/skills/z")
+  let last = OwnershipLinkIdentity(
+    OwnershipLink::OwnershipLink("/home/alice/project/.agents/skills/z").path,
+  )
   inspect(first.compare(last), content="-1")
 }
 

--- a/mbt/app/c-plugin-v2/src/runtime.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime.mbt
@@ -41,7 +41,7 @@ pub fn Runtime::Runtime(
 pub fn Runtime::project_lock_path(
   self : Runtime,
 ) -> @path.Path raise RuntimePathsError {
-  self.paths.project_lock_path(self.paths.cwd)
+  self.paths.project_lock_path(self.paths.cwd.path)
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/runtime_paths.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime_paths.mbt
@@ -5,18 +5,19 @@ pub(all) suberror RuntimePathsError {
 
 ///|
 pub struct RuntimePaths {
-  home : @path.Path
-  cwd : @path.Path
-  cache_root : @path.Path
+  home : @x_path.AbsolutePath
+  cwd : @x_path.AbsolutePath
+  cache_root : @x_path.AbsolutePath
 }
 
 ///|
 fn normalized_absolute_root(
   name : String,
   path : @path.Path,
-) -> @path.Path raise RuntimePathsError {
-  guard path.is_absolute() else { raise RelativeRoot(name~, path~) }
-  path.normalize()
+) -> @x_path.AbsolutePath raise RuntimePathsError {
+  @x_path.AbsolutePath::AbsolutePath(path) catch {
+    _ => raise RelativeRoot(name~, path~)
+  }
 }
 
 ///|
@@ -38,14 +39,14 @@ pub fn RuntimePaths::project_lock_path(
   project_root : @path.Path,
 ) -> @path.Path raise RuntimePathsError {
   ignore(self)
-  normalized_absolute_root("project root", project_root).join(
+  normalized_absolute_root("project root", project_root).path.join(
     "c-plugin-lock.json",
   )
 }
 
 ///|
 pub fn RuntimePaths::global_lock_path(self : RuntimePaths) -> @path.Path {
-  self.home.join("c-plugin-lock.json")
+  self.home.path.join("c-plugin-lock.json")
 }
 
 ///|
@@ -55,7 +56,7 @@ pub fn RuntimePaths::project_ownership_state_path(
 ) -> OwnershipStatePath raise {
   ignore(self)
   OwnershipStatePath::OwnershipStatePath(
-    normalized_absolute_root("project root", project_root)
+    normalized_absolute_root("project root", project_root).path
     .join(".agents")
     .join("c-plugin-state.json"),
   )
@@ -66,7 +67,7 @@ pub fn RuntimePaths::global_ownership_state_path(
   self : RuntimePaths,
 ) -> OwnershipStatePath raise {
   OwnershipStatePath::OwnershipStatePath(
-    self.home.join(".agents").join("c-plugin-state.json"),
+    self.home.path.join(".agents").join("c-plugin-state.json"),
   )
 }
 
@@ -76,7 +77,7 @@ pub fn RuntimePaths::project_managed_skill_root(
   project_root : @path.Path,
 ) -> @path.Path raise RuntimePathsError {
   ignore(self)
-  normalized_absolute_root("project root", project_root)
+  normalized_absolute_root("project root", project_root).path
   .join(".agents")
   .join("skills")
 }
@@ -85,5 +86,5 @@ pub fn RuntimePaths::project_managed_skill_root(
 pub fn RuntimePaths::global_managed_skill_root(
   self : RuntimePaths,
 ) -> @path.Path {
-  self.home.join(".agents").join("skills")
+  self.home.path.join(".agents").join("skills")
 }

--- a/mbt/app/c-plugin-v2/src/runtime_paths_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime_paths_wbtest.mbt
@@ -3,9 +3,12 @@ test "RuntimePaths RuntimePaths - normalizes injected synthetic roots" {
   let paths = RuntimePaths::RuntimePaths(
     "/synthetic/home/./workspace/..", "/synthetic/work/../work/project", "/synthetic/cache/./repositories",
   )
-  inspect(paths.home.to_string(), content="/synthetic/home")
-  inspect(paths.cwd.to_string(), content="/synthetic/work/project")
-  inspect(paths.cache_root.to_string(), content="/synthetic/cache/repositories")
+  inspect(paths.home.path.to_string(), content="/synthetic/home")
+  inspect(paths.cwd.path.to_string(), content="/synthetic/work/project")
+  inspect(
+    paths.cache_root.path.to_string(),
+    content="/synthetic/cache/repositories",
+  )
 }
 
 ///|
@@ -56,7 +59,10 @@ test "RuntimePaths RuntimePaths - retains the injected cache root" {
   let paths = RuntimePaths::RuntimePaths(
     "/synthetic/home", "/synthetic/work", "/synthetic/cache/repositories",
   )
-  inspect(paths.cache_root.to_string(), content="/synthetic/cache/repositories")
+  inspect(
+    paths.cache_root.path.to_string(),
+    content="/synthetic/cache/repositories",
+  )
 }
 
 ///|

--- a/mbt/app/c-plugin-v2/src/runtime_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/runtime_wbtest.mbt
@@ -10,11 +10,13 @@ async test "Runtime discover_locks - injects synthetic runtime paths" {
     paths~,
     discover_locks_api=fn(runtime_paths, _options) {
       received = [
-        runtime_paths.home,
-        runtime_paths.cwd,
-        runtime_paths.cache_root,
+        runtime_paths.home.path,
+        runtime_paths.cwd.path,
+        runtime_paths.cache_root.path,
       ]
-      ReadOnlyArray::from_array([runtime_paths.cwd.join("c-plugin-lock.json")])
+      ReadOnlyArray::from_array([
+        runtime_paths.cwd.path.join("c-plugin-lock.json"),
+      ])
     },
     load_lock=fn(_path) { lock },
     create_lock_exclusive=fn(_path, _lock) { () },

--- a/mbt/app/c-plugin-v2/src/sync_ownership.mbt
+++ b/mbt/app/c-plugin-v2/src/sync_ownership.mbt
@@ -8,7 +8,7 @@ fn managed_skill_roots_for_sync(
     ManagedSkillRoot::ManagedSkillRoot(lock_root.join(".agents").join("skills")),
   ]
   for target in lock.targets {
-    let path = lock_root.join(target.path).normalize()
+    let path = lock_root.join(target.path.path).normalize()
     roots.push(ManagedSkillRoot::ManagedSkillRoot(path))
   }
   @immut_hashset.HashSet(roots)
@@ -19,9 +19,10 @@ async fn validate_managed_root_for_sync(
   lock_root : @path.Path,
   managed_root : ManagedSkillRoot,
 ) -> Unit {
-  guard path_is_within(lock_root, managed_root.path) else {
+  let managed_root_path = managed_root.path.path
+  guard path_is_within(lock_root, managed_root_path) else {
     raise SyncError::InvalidPath(
-      path=managed_root.path,
+      path=managed_root_path,
       reason="managed root must remain below the lock root",
     )
   }
@@ -29,7 +30,7 @@ async fn validate_managed_root_for_sync(
     error =>
       raise SyncError::InvalidPath(path=lock_root, reason=error.to_string())
   }
-  let mut existing_path = managed_root.path
+  let mut existing_path = managed_root_path
   while true {
     let kind = try
       @fs.kind(existing_path.to_string(), follow_symlink=false)
@@ -38,7 +39,7 @@ async fn validate_managed_root_for_sync(
         let parent = existing_path.dirname()
         guard parent != existing_path else {
           raise SyncError::InvalidPath(
-            path=managed_root.path,
+            path=managed_root_path,
             reason="managed root has no existing directory ancestor",
           )
         }
@@ -68,7 +69,7 @@ async fn validate_managed_root_for_sync(
     }
     guard path_is_within(physical_lock_root, physical_existing) else {
       raise SyncError::InvalidPath(
-        path=managed_root.path,
+        path=managed_root_path,
         reason="managed root resolves outside the lock root",
       )
     }
@@ -100,7 +101,7 @@ async fn load_previous_ownership_for_sync(
   runtime : Runtime,
   state_path : OwnershipStatePath,
 ) -> PreviousOwnership {
-  try runtime.load_ownership_state(state_path.path) catch {
+  try runtime.load_ownership_state(state_path.path.path) catch {
     StateStoreError::NotFound(_) => PreviousOwnership::Missing
     StateStoreError::Decode(path=_, reason~) =>
       PreviousOwnership::Corrupt(reason~)
@@ -120,7 +121,7 @@ async fn validate_previous_ownership_for_sync(
       for pair in state.entries.to_array() {
         let entry = pair.1
         let managed_root = ManagedSkillRoot::ManagedSkillRoot(
-          entry.managed_root.path,
+          entry.managed_root.path.path,
         ) catch {
           error =>
             return Corrupt(reason="invalid recorded managed root: \{error}")

--- a/mbt/app/c-plugin-v2/src/sync_repository_resolution.mbt
+++ b/mbt/app/c-plugin-v2/src/sync_repository_resolution.mbt
@@ -30,6 +30,8 @@ fn skill_resolution_error_reason(error : SkillResolutionError) -> String {
     IO(path~, reason~) => "skill resolution I/O at \{path}: \{reason}"
     InvalidSkillName(path~, reason~) =>
       "invalid skill name at \{path}: \{reason}"
+    InvalidSkillPath(path~, reason~) =>
+      "invalid skill path at \{path}: \{reason}"
   }
 }
 
@@ -47,7 +49,7 @@ async fn resolve_repository_for_sync(
     Local(local_repository) => {
       let repository_path = lock_path
         .dirname()
-        .join(local_repository.path.path)
+        .join(local_repository.path.path.path)
         .normalize()
       let repository_root = RepositoryRoot::RepositoryRoot(repository_path) catch {
         error =>

--- a/mbt/flake.lock
+++ b/mbt/flake.lock
@@ -3,11 +3,11 @@
     "moon-registry": {
       "flake": false,
       "locked": {
-        "lastModified": 1786419373,
-        "narHash": "sha256-r8O1ZFqQj9btE/Z9UtbRtBEUWQw8Ms8DuB0kBRQPL9M=",
+        "lastModified": 1786474266,
+        "narHash": "sha256-rDJbO96x+PzmimvjlLF5Jjuz6UpFyjR+ke5g3FRNtV8=",
         "ref": "refs/heads/main",
-        "rev": "4630af617b7f738f1065f0e4e50b7d6c7e3c7633",
-        "revCount": 12222,
+        "rev": "9b87e7da71380816be3a7aa30c66898cb0a2c2d1",
+        "revCount": 12392,
         "type": "git",
         "url": "https://mooncakes.io/git/index"
       },


### PR DESCRIPTION
## 概要

- [TOT-187](https://linear.app/totto2727/issue/TOT-187/c-plugin-v2-m3-follow-up-totto2727x-path-value-typesへ移行する)
- Stack base: [PR #321](https://github.com/totto2727-org/monorepo/pull/321) (`codex/tot-157-force-collisions`)
- c-plugin-v2内で重複していた絶対・相対pathの検証と正規化を、`totto2727/x@0.3.0/path.AbsolutePath`および`RelativePath`を基盤とする実装へ移行しました。
- JSONの`ToJson`/`FromJson`は共有型へ委譲し、c-plugin-v2固有のparent traversal・backslash拒否はraw値に対して正規化前に維持します。
- ownership stateの`symlinkTarget`はpath値ではなくsymlinkへ書いたliteral payloadであるため、wire互換を守る明示的な例外としてraw `Path`を維持します。

## 実装フロー

```mermaid
flowchart TD
  A[CLIまたはJSONのpath入力] --> B{domain固有のraw検証が必要か}
  B -->|yes| C[parent traversal等を正規化前に拒否]
  B -->|no| D[共有path constructor / FromJson]
  C --> D
  D --> E[AbsolutePathまたはRelativePath]
  E --> F[c-plugin-v2 domain wrapper]
  F --> G{利用境界}
  G -->|JSON| H[共有ToJson]
  G -->|filesystem I/O| I[inner Pathを明示的に渡す]
  G -->|domain planning| J[検証済み型のまま伝播]
```

## 主な変更

- RuntimePaths、cache scope、repository/managed root、ownership link/root/resolved target、lock内relative path、resolved skill pathを共有path値型へ移行しました。
- lock/ownership/cache codecを共有型のJSON実装へ委譲しました。
- `ResolvedSkill.skill_path`を`AbsolutePath`へ変更し、resolutionからplanningまで絶対path不変条件を保持します。
- Mooncakes registry lockとNix package dependencyを`totto2727/x@0.3.0`へ更新しました。
- 英日設計READMEへpath layerと公式versioned APIを追記しました。

## テスト条件

```mermaid
flowchart TD
  A[path値移行] --> B[format / native check]
  B --> C[package tests 185/185]
  C --> D[full MoonBit tests 307/307]
  D --> E[Nix isolated build]
  E --> F[real CLI help/version]
  F --> G{入力ケース}
  G -->|正常・正規化| H[lock/state/symlinkをread-back]
  G -->|absolute・parent traversal| I[nonzeroかつbyte不変]
  G -->|literal symlinkTarget| J[非正規relative・absoluteをverbatim往復]
  H --> K[Docker全E2E]
  I --> K
  J --> K
```

## 検証

- `moon fmt --check mbt/app/c-plugin-v2`
- `moon check mbt/app/c-plugin-v2/src --target native`
- `moon test mbt/app/c-plugin-v2/src --target native --no-parallelize`: 185/185
- full MoonBit suite: 307/307
- `nix build ./mbt#c-plugin-v2 --no-link --print-out-paths`
- Nix build済み実バイナリの`--help` / `--version`
- 実CLIで正常・正規化・absolute/traversal拒否・no-mutation・ownership wire互換を確認
- `bash mbt/app/c-plugin-v2/src/e2e/run.sh`: 全leaf PASS、host isolation PASS
- exact SHA `b4ff5f5f5014e7911b3debf902663fd2d71826a0`に対する目的・コード品質・セキュリティ・依存/契約・手動QAレビューとランタイム監査: 全PASS

## 変更量

41 files / 421 additions / 331 deletionsです。単純な機能追加ではなく、lock、ownership state、runtime paths、cache identity、reconciliation、全call site/testを同じ型境界へ揃える一括変換のため、500行基準の許容例外に該当します。

## 参照

- [Mooncakes `totto2727/x@0.3.0/path`](https://mooncakes.io/docs/totto2727/x@0.3.0/path)
- [Mooncakes manifest API](https://mooncakes.io/api/v0/manifest/totto2727/x)
- [公開source](https://github.com/totto2727-org/x/blob/56c41323e6f54ed53bf228f741dfea25d724e9b7/src/path/path.mbt)

## CI status

- Latest commit SHA: `a2925050`
- Latest `check` job: success (run id: `31554173373`, attempt: 2)
- Retry history:
  - commit `b4ff5f5f`: failure (unrelated codex-sdk cancellation cleanup race; five change-owned deprecation warnings also found)
  - commit `a2925050`: canonical hash API update, success
