### PR TITLE
nix: add cf browser rendering wrapper

### DIFF
--- a/nix/share/packages-scripts.nix
+++ b/nix/share/packages-scripts.nix
@@ -59,7 +59,6 @@ let
       npm {
         binName = "cf";
         packageName = "cf";
-        runtime = "node";
       }
     }/bin/cf "$@"
   '';

--- a/nix/share/packages-scripts.nix
+++ b/nix/share/packages-scripts.nix
@@ -49,6 +49,21 @@ let
     exec $HOME/.local/bin/bx "$@"
   '';
 
+  macos-cf = writeShellScriptBin "cf" ''
+    set -e
+
+    CLOUDFLARE_ACCOUNT_ID="$(pass-cli get cloudflare/account-id --quiet -f password)"
+    CLOUDFLARE_API_TOKEN="$(pass-cli get cloudflare/browser-rendering-api-key --quiet -f password)"
+    export CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN
+    exec ${
+      npm {
+        binName = "cf";
+        packageName = "cf";
+        runtime = "node";
+      }
+    }/bin/cf "$@"
+  '';
+
   macos-o = writeShellScriptBin "o" ''
     export LINEAR_API_KEY="$(pass-cli get linear/api-key --quiet -f password)"
     exec opencode "$@"
@@ -101,6 +116,7 @@ in
     exocortex-mcp
     docker-credential-gh
     macos-bx
+    (lib.hiPrio macos-cf)
     macos-o
     macos-c
     macos-linear-mcp

--- a/nix/share/packages.nix
+++ b/nix/share/packages.nix
@@ -24,6 +24,11 @@ with pkgs;
     packageName = "ctx7";
   })
   (npm {
+    binName = "cf";
+    packageName = "cf";
+    runtime = "node";
+  })
+  (npm {
     binName = "openshell";
     runtime = "uv";
     packageName = "openshell";

--- a/nix/share/packages.nix
+++ b/nix/share/packages.nix
@@ -26,7 +26,6 @@ with pkgs;
   (npm {
     binName = "cf";
     packageName = "cf";
-    runtime = "node";
   })
   (npm {
     binName = "openshell";


### PR DESCRIPTION
## Summary

- install the Cloudflare `cf` npm package through the shared Nix package list
- add a high-priority macOS `cf` wrapper that loads Cloudflare Browser Rendering credentials from `pass-cli`
- stop immediately if credential retrieval fails and keep credentials out of command arguments

## Validation

- `nix flake check --no-build`
- macOS flake dry-run evaluation
- review gate: goal, code quality, security, QA, and context checks passed