### PR TITLE
Just のデフォルトレシピを一覧表示専用にする

### DIFF
--- a/.agents/skills/share-coding/SKILL.md
+++ b/.agents/skills/share-coding/SKILL.md
@@ -83,6 +83,10 @@ Prefer small local changes and composable units. Extract a shared abstraction on
 
 Choose explicit control flow over compact cleverness. Comments explain non-obvious reasons and constraints; the code itself explains what it does.
 
+## Just defaults
+
+When a repository uses Just, make the default recipe display the available recipes with a recipe body that runs `@just --list`. Do not make the default recipe run checks, builds, tests, setup, or any other operational command.
+
 ## Consistency
 
 Look for prior art in the same package before introducing a new pattern. Record the reason close to the decision when a deliberate divergence is necessary.


### PR DESCRIPTION
#### Context

Just のデフォルトレシピが運用コマンドを暗黙に実行すると、レシピ一覧を確認したいだけの利用者にも副作用が発生します。

#### TL;DR

_Just のデフォルトレシピを `@just --list` による一覧表示専用として文書化します。_

#### Summary

- `share-coding` に Just のデフォルトレシピ規則を追加しました。
- デフォルトレシピの recipe body は `@just --list` だけを実行します。
- checks、builds、tests、setup などの運用コマンドをデフォルトから除外します。

#### Alternatives

- デフォルトでチェックやビルドを実行する案は、一覧確認時の予期しない副作用を避けるため採用しませんでした。
- 規則を追加しない案は、リポジトリごとの Just 定義で安全な既定動作を揃えられないため採用しませんでした。

#### Test Plan

- [x] `uv run --with pyyaml python3 /Users/totto2727/proj/zeroclaw/.claude/skills/skill-creator/scripts/quick_validate.py .agents/skills/share-coding`
- [x] `git diff --check`
- [ ] Vite+ のコード／テストタスク（ドキュメントのみの変更のため未実行）

#### CI status

- Latest commit SHA: `a43ab981a7cf22cfdb7aa3b943bb15b7b59b7e1c`
- Latest `check` job: success (run id: `32268527686`, attempt: 1)
- CodeQL checks: success
- Retry history: none

#### 処理フロー

```mermaid
flowchart TD
  A[Just のデフォルトレシピを呼び出す] --> B[recipe body が @just --list を実行]
  B --> C[利用可能なレシピを表示]
  B -. 実行しない .-> D[checks / builds / tests / setup]
```

#### レビュワーへの依頼

デフォルトレシピが一覧表示だけを行い、運用コマンドを実行しないという規則の表現と適用範囲をご確認ください。

#### 参考資料

- `.agents/skills/share-coding/SKILL.md` の `Just defaults` セクション
- [Just manual: `--list`](https://just.systems/man/en/command-line-options.html)
