### PR TITLE
mizchi/bit adapter contractを追加する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
       id-token: write

--- a/mbt/app/c-plugin-v2/moon.mod
+++ b/mbt/app/c-plugin-v2/moon.mod
@@ -18,6 +18,7 @@ supported_targets = "native"
 
 import {
   "mizchi/bit_lib@0.45.6",
+  "mizchi/bit_object@0.45.6",
   "mizchi/bit_osfs@0.45.6",
   "mizchi/tui@0.10.0",
   "moonbitlang/async@0.20.3",

--- a/mbt/app/c-plugin-v2/package.nix
+++ b/mbt/app/c-plugin-v2/package.nix
@@ -8,6 +8,7 @@
 let
   dependencies = {
     "mizchi/bit_lib" = "0.45.6";
+    "mizchi/bit_object" = "0.45.6";
     "mizchi/bit_osfs" = "0.45.6";
     "mizchi/tui" = "0.10.0";
     "moonbitlang/async" = "0.20.3";

--- a/mbt/app/c-plugin-v2/src/bit_repository_store.mbt
+++ b/mbt/app/c-plugin-v2/src/bit_repository_store.mbt
@@ -1,0 +1,246 @@
+///|
+/// Repository operations exposed by the bit-backed store.
+pub(all) enum BitRepositoryOperation {
+  Clone
+  Fetch
+  ResolveDefaultBranch
+  CheckoutCommit
+  ResolveHeadCommit
+} derive(Debug, Eq)
+
+///|
+/// A bit operation failed at the c-plugin repository boundary.
+pub(all) suberror BitRepositoryStoreError {
+  OperationFailed(
+    operation~ : BitRepositoryOperation,
+    path~ : @x_path.AbsolutePath?,
+    reason~ : String
+  )
+} derive(Debug, Eq)
+
+///|
+/// The remote default branch name and the commit currently referenced by it.
+pub struct ResolvedDefaultBranch {
+  name : String
+  commit : CommitId
+} derive(Eq)
+
+///|
+/// Create a resolved default branch value without changing its branch name.
+pub fn ResolvedDefaultBranch::ResolvedDefaultBranch(
+  name : String,
+  commit : CommitId,
+) -> ResolvedDefaultBranch {
+  { name, commit }
+}
+
+///|
+/// Injectable repository operations backed by mizchi/bit in production.
+pub struct BitRepositoryStore {
+  clone_repository_api : async (GitHubRepository, @x_path.AbsolutePath) -> CommitId? raise BitRepositoryStoreError
+  fetch_repository_api : async (GitHubRepository, @x_path.AbsolutePath) -> CommitId? raise BitRepositoryStoreError
+  resolve_default_branch_api : async (GitHubRepository) -> ResolvedDefaultBranch? raise BitRepositoryStoreError
+  checkout_commit_api : async (@x_path.AbsolutePath, CommitId) -> CommitId raise BitRepositoryStoreError
+  resolve_head_commit_api : async (@x_path.AbsolutePath) -> CommitId? raise BitRepositoryStoreError
+}
+
+///|
+/// Create a repository store from explicit operation callbacks.
+pub fn BitRepositoryStore::BitRepositoryStore(
+  clone_repository_api~ : async (GitHubRepository, @x_path.AbsolutePath) -> CommitId? raise BitRepositoryStoreError,
+  fetch_repository_api~ : async (GitHubRepository, @x_path.AbsolutePath) -> CommitId? raise BitRepositoryStoreError,
+  resolve_default_branch_api~ : async (GitHubRepository) -> ResolvedDefaultBranch? raise BitRepositoryStoreError,
+  checkout_commit_api~ : async (@x_path.AbsolutePath, CommitId) -> CommitId raise BitRepositoryStoreError,
+  resolve_head_commit_api~ : async (@x_path.AbsolutePath) -> CommitId? raise BitRepositoryStoreError,
+) -> BitRepositoryStore {
+  {
+    clone_repository_api,
+    fetch_repository_api,
+    resolve_default_branch_api,
+    checkout_commit_api,
+    resolve_head_commit_api,
+  }
+}
+
+///|
+/// Clone a GitHub repository into the caller-provided lock-scoped absolute cache path.
+pub async fn BitRepositoryStore::clone_repository(
+  self : BitRepositoryStore,
+  repository : GitHubRepository,
+  path : @x_path.AbsolutePath,
+) -> CommitId? raise BitRepositoryStoreError {
+  (self.clone_repository_api)(repository, path)
+}
+
+///|
+/// Fetch a GitHub repository in the caller-provided lock-scoped absolute cache path.
+pub async fn BitRepositoryStore::fetch_repository(
+  self : BitRepositoryStore,
+  repository : GitHubRepository,
+  path : @x_path.AbsolutePath,
+) -> CommitId? raise BitRepositoryStoreError {
+  (self.fetch_repository_api)(repository, path)
+}
+
+///|
+/// Resolve the remote HEAD into its branch name and commit.
+pub async fn BitRepositoryStore::resolve_default_branch(
+  self : BitRepositoryStore,
+  repository : GitHubRepository,
+) -> ResolvedDefaultBranch? raise BitRepositoryStoreError {
+  (self.resolve_default_branch_api)(repository)
+}
+
+///|
+/// Check out a pinned commit in the caller-provided lock-scoped absolute cache path.
+pub async fn BitRepositoryStore::checkout_commit(
+  self : BitRepositoryStore,
+  path : @x_path.AbsolutePath,
+  commit : CommitId,
+) -> CommitId raise BitRepositoryStoreError {
+  (self.checkout_commit_api)(path, commit)
+}
+
+///|
+/// Resolve the current HEAD commit in the caller-provided lock-scoped absolute cache path.
+pub async fn BitRepositoryStore::resolve_head_commit(
+  self : BitRepositoryStore,
+  path : @x_path.AbsolutePath,
+) -> CommitId? raise BitRepositoryStoreError {
+  (self.resolve_head_commit_api)(path)
+}
+
+///|
+fn bit_repository_remote_url(repository : GitHubRepository) -> String {
+  "https://github.com/\{repository.route()}.git"
+}
+
+///|
+fn commit_id_from_bit(
+  object_id : @bit_object.ObjectId,
+  operation : BitRepositoryOperation,
+  path : @x_path.AbsolutePath?,
+) -> CommitId raise BitRepositoryStoreError {
+  CommitId::CommitId(object_id.to_hex()) catch {
+    error =>
+      raise BitRepositoryStoreError::OperationFailed(
+        operation~,
+        path~,
+        reason=error.to_string(),
+      )
+  }
+}
+
+///|
+/// Create the production store backed by the pinned mizchi/bit libraries.
+pub fn BitRepositoryStore::production() -> BitRepositoryStore {
+  let filesystem = @bit_osfs.OsFs::new()
+  BitRepositoryStore::BitRepositoryStore(
+    clone_repository_api=(repository, path) => {
+      let result = @bit_native.clone_http(
+        filesystem,
+        filesystem,
+        bit_repository_remote_url(repository),
+        path.path.to_string(),
+        false,
+      ) catch {
+        error =>
+          raise BitRepositoryStoreError::OperationFailed(
+            operation=Clone,
+            path=Some(path),
+            reason=error.to_string(),
+          )
+      }
+      match result {
+        None => None
+        Some(object_id) =>
+          Some(commit_id_from_bit(object_id, Clone, Some(path)))
+      }
+    },
+    fetch_repository_api=(repository, path) => {
+      let result = @bit_native.pull_http(
+        filesystem,
+        filesystem,
+        path.path.to_string(),
+        bit_repository_remote_url(repository),
+        false,
+        rebase=false,
+      ) catch {
+        error =>
+          raise BitRepositoryStoreError::OperationFailed(
+            operation=Fetch,
+            path=Some(path),
+            reason=error.to_string(),
+          )
+      }
+      match result {
+        None => None
+        Some(object_id) =>
+          Some(commit_id_from_bit(object_id, Fetch, Some(path)))
+      }
+    },
+    resolve_default_branch_api=repository => {
+      let result = @bit_native.resolve_remote_ref_id(
+        bit_repository_remote_url(repository),
+        "HEAD",
+      ) catch {
+        error =>
+          raise BitRepositoryStoreError::OperationFailed(
+            operation=ResolveDefaultBranch,
+            path=None,
+            reason=error.to_string(),
+          )
+      }
+      match result {
+        None => None
+        Some((_object_id, None)) =>
+          raise BitRepositoryStoreError::OperationFailed(
+            operation=ResolveDefaultBranch,
+            path=None,
+            reason="remote HEAD did not resolve to a default branch",
+          )
+        Some((object_id, Some(name))) => {
+          let commit = commit_id_from_bit(object_id, ResolveDefaultBranch, None)
+          Some(ResolvedDefaultBranch::ResolvedDefaultBranch(name, commit))
+        }
+      }
+    },
+    checkout_commit_api=(path, commit) => {
+      let object_id = @bit_lib.checkout(
+        filesystem,
+        filesystem,
+        path.path.to_string(),
+        commit.value,
+        detach=true,
+        update_worktree=true,
+        update_index=true,
+      ) catch {
+        error =>
+          raise BitRepositoryStoreError::OperationFailed(
+            operation=CheckoutCommit,
+            path=Some(path),
+            reason=error.to_string(),
+          )
+      }
+      commit_id_from_bit(object_id, CheckoutCommit, Some(path))
+    },
+    resolve_head_commit_api=path => {
+      let result = @bit_lib.resolve_head_commit(
+        filesystem,
+        path.path.join(".git").to_string(),
+      ) catch {
+        error =>
+          raise BitRepositoryStoreError::OperationFailed(
+            operation=ResolveHeadCommit,
+            path=Some(path),
+            reason=error.to_string(),
+          )
+      }
+      match result {
+        None => None
+        Some(object_id) =>
+          Some(commit_id_from_bit(object_id, ResolveHeadCommit, Some(path)))
+      }
+    },
+  )
+}

--- a/mbt/app/c-plugin-v2/src/bit_repository_store_wbtest.mbt
+++ b/mbt/app/c-plugin-v2/src/bit_repository_store_wbtest.mbt
@@ -1,0 +1,234 @@
+///|
+async fn expect_bit_repository_store_error(
+  action : async () -> Unit raise BitRepositoryStoreError,
+  operation : BitRepositoryOperation,
+  path : @x_path.AbsolutePath?,
+  reason : String,
+) -> Unit {
+  try action() catch {
+    BitRepositoryStoreError::OperationFailed(
+      operation=actual_operation,
+      path=actual_path,
+      reason=actual_reason
+    ) => {
+      inspect(actual_operation == operation, content="true")
+      inspect(actual_path == path, content="true")
+      inspect(actual_reason, content=reason)
+    }
+  } noraise {
+    _ => fail("bit repository operation must fail")
+  }
+}
+
+///|
+async test "BitRepositoryStore forwarding 1 - preserves typed inputs and results" {
+  let repository = GitHubRepository::from_route("openai/codex")
+  let cache_path = @x_path.AbsolutePath::AbsolutePath(
+    "/synthetic/cache/scope/openai/codex",
+  )
+  let first_commit = CommitId::CommitId(
+    "1111111111111111111111111111111111111111",
+  )
+  let second_commit = CommitId::CommitId(
+    "2222222222222222222222222222222222222222",
+  )
+  let default_branch = ResolvedDefaultBranch::ResolvedDefaultBranch(
+    "main", second_commit,
+  )
+  let events : Array[String] = []
+  let repositories : Array[GitHubRepository] = []
+  let paths : Array[@x_path.AbsolutePath] = []
+  let commits : Array[CommitId] = []
+  let store = BitRepositoryStore::BitRepositoryStore(
+    clone_repository_api=(received_repository, received_path) => {
+      events.push("clone")
+      repositories.push(received_repository)
+      paths.push(received_path)
+      Some(first_commit)
+    },
+    fetch_repository_api=(received_repository, received_path) => {
+      events.push("fetch")
+      repositories.push(received_repository)
+      paths.push(received_path)
+      Some(second_commit)
+    },
+    resolve_default_branch_api=received_repository => {
+      events.push("default-branch")
+      repositories.push(received_repository)
+      Some(default_branch)
+    },
+    checkout_commit_api=(received_path, received_commit) => {
+      events.push("checkout")
+      paths.push(received_path)
+      commits.push(received_commit)
+      first_commit
+    },
+    resolve_head_commit_api=received_path => {
+      events.push("head")
+      paths.push(received_path)
+      Some(first_commit)
+    },
+  )
+
+  inspect(
+    store.clone_repository(repository, cache_path) == Some(first_commit),
+    content="true",
+  )
+  inspect(
+    store.fetch_repository(repository, cache_path) == Some(second_commit),
+    content="true",
+  )
+  inspect(
+    store.resolve_default_branch(repository) == Some(default_branch),
+    content="true",
+  )
+  inspect(
+    store.checkout_commit(cache_path, first_commit) == first_commit,
+    content="true",
+  )
+  inspect(
+    store.resolve_head_commit(cache_path) == Some(first_commit),
+    content="true",
+  )
+  debug_inspect(
+    events,
+    content="[\"clone\", \"fetch\", \"default-branch\", \"checkout\", \"head\"]",
+  )
+  inspect(repositories.length(), content="3")
+  inspect(repositories.all(received => received == repository), content="true")
+  inspect(paths.length(), content="4")
+  inspect(paths.all(received => received == cache_path), content="true")
+  inspect(commits.length(), content="1")
+  inspect(commits[0] == first_commit, content="true")
+}
+
+///|
+async test "BitRepositoryStore forwarding 2 - preserves absent commits and branches" {
+  let repository = GitHubRepository::from_route("openai/codex")
+  let cache_path = @x_path.AbsolutePath::AbsolutePath(
+    "/synthetic/cache/scope/openai/codex",
+  )
+  let commit = CommitId::CommitId("1111111111111111111111111111111111111111")
+  let store = BitRepositoryStore::BitRepositoryStore(
+    clone_repository_api=(_repository, _path) => None,
+    fetch_repository_api=(_repository, _path) => None,
+    resolve_default_branch_api=_repository => None,
+    checkout_commit_api=(_path, _commit) => commit,
+    resolve_head_commit_api=_path => None,
+  )
+
+  inspect(
+    store.clone_repository(repository, cache_path) is None,
+    content="true",
+  )
+  inspect(
+    store.fetch_repository(repository, cache_path) is None,
+    content="true",
+  )
+  inspect(store.resolve_default_branch(repository) is None, content="true")
+  inspect(store.resolve_head_commit(cache_path) is None, content="true")
+}
+
+///|
+async test "BitRepositoryStore forwarding 3 - propagates each injected typed failure" {
+  let repository = GitHubRepository::from_route("openai/codex")
+  let cache_path = @x_path.AbsolutePath::AbsolutePath(
+    "/synthetic/cache/scope/openai/codex",
+  )
+  let commit = CommitId::CommitId("1111111111111111111111111111111111111111")
+  let events : Array[String] = []
+  let store = BitRepositoryStore::BitRepositoryStore(
+    clone_repository_api=(_repository, path) => {
+      events.push("clone")
+      raise BitRepositoryStoreError::OperationFailed(
+        operation=Clone,
+        path=Some(path),
+        reason="clone failed",
+      )
+    },
+    fetch_repository_api=(_repository, path) => {
+      events.push("fetch")
+      raise BitRepositoryStoreError::OperationFailed(
+        operation=Fetch,
+        path=Some(path),
+        reason="fetch failed",
+      )
+    },
+    resolve_default_branch_api=_repository => {
+      events.push("default-branch")
+      raise BitRepositoryStoreError::OperationFailed(
+        operation=ResolveDefaultBranch,
+        path=None,
+        reason="default branch failed",
+      )
+    },
+    checkout_commit_api=(path, _commit) => {
+      events.push("checkout")
+      raise BitRepositoryStoreError::OperationFailed(
+        operation=CheckoutCommit,
+        path=Some(path),
+        reason="checkout failed",
+      )
+    },
+    resolve_head_commit_api=path => {
+      events.push("head")
+      raise BitRepositoryStoreError::OperationFailed(
+        operation=ResolveHeadCommit,
+        path=Some(path),
+        reason="head failed",
+      )
+    },
+  )
+
+  expect_bit_repository_store_error(
+    () => store.clone_repository(repository, cache_path) |> ignore,
+    Clone,
+    Some(cache_path),
+    "clone failed",
+  )
+  expect_bit_repository_store_error(
+    () => store.fetch_repository(repository, cache_path) |> ignore,
+    Fetch,
+    Some(cache_path),
+    "fetch failed",
+  )
+  expect_bit_repository_store_error(
+    () => store.resolve_default_branch(repository) |> ignore,
+    ResolveDefaultBranch,
+    None,
+    "default branch failed",
+  )
+  expect_bit_repository_store_error(
+    () => store.checkout_commit(cache_path, commit) |> ignore,
+    CheckoutCommit,
+    Some(cache_path),
+    "checkout failed",
+  )
+  expect_bit_repository_store_error(
+    () => store.resolve_head_commit(cache_path) |> ignore,
+    ResolveHeadCommit,
+    Some(cache_path),
+    "head failed",
+  )
+  debug_inspect(
+    events,
+    content="[\"clone\", \"fetch\", \"default-branch\", \"checkout\", \"head\"]",
+  )
+}
+
+///|
+async test "BitRepositoryStore production - resolves an empty local repository without a HEAD commit" {
+  @async.with_task_group() <| group => {
+    let root : @path.Path = @fs.tmpdir(prefix="c-plugin-v2-bit-store-")
+    group.add_defer(() => @fs.rmdir(root.to_string(), recursive=true))
+    let filesystem = @bit_osfs.OsFs::new()
+    @bit_lib.init_repo(filesystem, root.to_string())
+    let absolute_root = @x_path.AbsolutePath::AbsolutePath(root)
+
+    inspect(
+      BitRepositoryStore::production().resolve_head_commit(absolute_root)
+      is None,
+      content="true",
+    )
+  }
+}

--- a/mbt/app/c-plugin-v2/src/moon.pkg
+++ b/mbt/app/c-plugin-v2/src/moon.pkg
@@ -1,4 +1,8 @@
 import {
+  "mizchi/bit_lib",
+  "mizchi/bit_lib/native" @bit_native,
+  "mizchi/bit_object",
+  "mizchi/bit_osfs",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/os_error",
@@ -16,9 +20,6 @@ import {
 }
 
 import {
-  "mizchi/bit_lib",
-  "mizchi/bit_lib/native" @bit_native,
-  "mizchi/bit_osfs",
   "mizchi/tui",
 } for "wbtest"
 


### PR DESCRIPTION
## 概要

[TOT-125](https://linear.app/totto2727/issue/TOT-125/c-plugin-v2-m4-g0-mizchibit-adapter-contractを固定する) の実装です。

B1で互換性を確認済みの `mizchi/bit@0.45.6` のみを使い、clone / fetch / remote HEAD解決 / commit checkout / local HEAD解決をc-plugin runtimeへ注入する型付き `BitRepositoryStore` contractを追加します。Git subprocessは起動せず、c-plugin側では `GitHubRepository`、caller-provided lock-scoped `AbsolutePath`、`CommitId`、operation-tagged errorだけを扱います。

このPRは [#325](https://github.com/totto2727-org/monorepo/pull/325) の上に積んだStacked PRです。#325の後にレビュー・mergeしてください。

## 処理フロー

```mermaid
flowchart LR
    Runtime["c-plugin runtime"] --> Store["BitRepositoryStore"]
    Store --> Clone["clone_repository"]
    Store --> Fetch["fetch_repository"]
    Store --> RemoteHead["resolve_default_branch"]
    Store --> Checkout["checkout_commit"]
    Store --> LocalHead["resolve_head_commit"]
    Clone & Fetch & RemoteHead & Checkout & LocalHead --> Bit["mizchi/bit 0.45.6"]
    Bit --> Typed["CommitId? / ResolvedDefaultBranch? / typed error"]
```

## 変更内容

- 5 operationの最小 async callback recordを `BitRepositoryStore` として定義
- production adapterを `bit_lib` / `bit_object` / `bit_osfs@0.45.6` に接続
- GitHub remote URLを既存のvalidated owner/repositoryから固定生成
- remote HEADの戻り値をbranch name（例: `main`）とcommitに正規化
- dependency errorをoperation/path/reason付き `BitRepositoryStoreError` に変換
- success、absence、全operation failure、実filesystem adapterをcontract testで固定
- `moon.mod` と `package.nix` のdirect dependencyを同じ0.45.6へ揃える
- cold bit buildと親layerのDocker E2Eを同じworkspace CIで完走させるため、このstack layerのjob timeoutを25分へ延長

## レビュワーへの依頼

- callback recordがG0に必要な5 operationだけに閉じているか
- lock-scoped `AbsolutePath` と `CommitId` がbit boundaryまで保持されているか
- `HEAD` 解決がbranch refではなくbranch nameとして一貫しているか
- dependency errorのoperation分類とabsenceの `None` が後続G1/G2で扱いやすいか
- Git subprocess、余分なcache policy、cancellation abstractionを追加していないか

## 検証

- `moon fmt --check mbt/app/c-plugin-v2/src`: PASS
- `moon check --target native --deny-warn mbt/app/c-plugin-v2/src`: PASS
- focused adapter tests: 4/4 PASS
- full c-plugin-v2 native tests: 189/189 PASS
- real mizchi/bit runtime audit: clone / `main` resolution / checkout / detached HEAD / empty repository / 404 error normalization PASS
- `nix build ./mbt#c-plugin-v2 --no-link --print-out-paths`: PASS
- Nix binary `--help` / `--version`: PASS（0.1.0）
- exact diff: 6 files、487 additions + 4 deletions = 491 changed lines
- exact SHA: `dff65b26fc54ccc9333c7b328d158ce33ca1c5e6`
- CI: 15分上限のrun `32544983717`はcold aggregate実行中にcancelled。25分上限のexact-SHA run `32545832540`はSUCCESS（6m32s）
- G0はleaf commandを追加しないためclean-container E2EはN/A（LinearのDelivery invariantに明記）

## 参考文献

- [TOT-125](https://linear.app/totto2727/issue/TOT-125/c-plugin-v2-m4-g0-mizchibit-adapter-contractを固定する)
- [Stack base PR #325](https://github.com/totto2727-org/monorepo/pull/325)
- [mizchi/bit v0.45.6](https://github.com/bit-vcs/bit/releases/tag/v0.45.6)
- [bit_lib v0.45.6 source](https://github.com/bit-vcs/bit/tree/v0.45.6/modules/bit_lib/src)
