### PR TITLE
npmPackageからmoonxを利用可能にする

### DIFF
--- a/nix/npm-package/flake.nix
+++ b/nix/npm-package/flake.nix
@@ -3,10 +3,19 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    moonbit-overlay = {
+      url = "github:totto2727-org/moonbit-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
-    { self, nixpkgs, ... }:
+    {
+      self,
+      nixpkgs,
+      moonbit-overlay,
+      ...
+    }:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -21,6 +30,7 @@
         system:
         import ./lib/npm-utils.nix {
           pkgs = nixpkgs.legacyPackages.${system};
+          moonbit = moonbit-overlay.packages.${system}.moonbit_latest;
         }
       );
     in

--- a/nix/npm-package/lib/npm-utils.nix
+++ b/nix/npm-package/lib/npm-utils.nix
@@ -1,4 +1,4 @@
-{ pkgs }:
+{ pkgs, moonbit }:
 
 {
   npmPackage =
@@ -9,6 +9,7 @@
       runtime ? "bun",
       registry ? if runtime == "uv" then "https://pypi.flatt.tech/simple/" else "https://npm.flatt.tech",
       additionalArgs ? "",
+      target ? "native",
     }:
     let
       packageSpec = "${packageName}@${version}";
@@ -30,6 +31,10 @@
           export UV_DEFAULT_INDEX=${registry}
           export PATH="${pkgs.lib.makeBinPath [ pkgs.uv ]}:$PATH"
           exec ${pkgs.uv}/bin/uvx ${additionalArgs} ${packageSpec} "$@"
+        '';
+        moon = ''
+          export PATH="${pkgs.lib.makeBinPath [ moonbit ]}:$PATH"
+          exec ${moonbit}/bin/moonx --target ${target} ${additionalArgs} ${packageSpec} "$@"
         '';
       };
       script =


### PR DESCRIPTION
#### Context

MoonBit の `npx` 相当である `moonx` を既存の `npmPackage` ラッパーから利用できるようにし、実行バックエンドを利用側で選択可能にします。

#### TL;DR

_`runtime = "moon"` と `target` を追加し、既定の native または明示した wasm で Mooncakes CLI を実行します。_

#### Summary

- `totto2727-org/moonbit-overlay` から最新の `moonx` を取得します
- `runtime = "moon"` を既存の node・bun・uv と同じラッパー API に追加します
- `target` は既定を `native` とし、指定値を `moonx --target` へ直接渡します

#### 処理フロー

```mermaid
flowchart LR
  A["npmPackage の宣言"] --> B["moonbit-overlay の moonx"]
  B --> C["moonx --target native または wasm"]
  C --> D["Mooncakes CLI"]
```

#### レビュワーへの依頼

- `runtime = "moon"` の命名が既存の `node` / `bun` / `uv` と整合するか確認してください
- `target` を独自解釈せず `moonx` へ直接渡す最小構成を確認してください

#### 参考文献

- https://github.com/moonbitlang/moon/blob/main/docs/dev/reference/moonx.md
- https://github.com/totto2727-org/moonbit-overlay

#### Alternatives

- `target` を Nix 側で列挙検証する案は、`moonx` の CLI 仕様を重複実装するため採用していません

#### Test Plan

- [x] `nixfmt --check nix/npm-package/flake.nix nix/npm-package/lib/npm-utils.nix`
- [x] `nix flake check ./nix/npm-package --no-write-lock-file`
- [x] native と wasm の生成ラッパーで `proton_cli 0.2.1` を実行
