### PR TITLE
npmPackageからGo CLIを実行可能にする

### DIFF
--- a/nix/npm-package/lib/npm-utils.nix
+++ b/nix/npm-package/lib/npm-utils.nix
@@ -32,6 +32,10 @@
           export PATH="${pkgs.lib.makeBinPath [ pkgs.uv ]}:$PATH"
           exec ${pkgs.uv}/bin/uvx ${additionalArgs} ${packageSpec} "$@"
         '';
+        go = ''
+          export PATH="${pkgs.lib.makeBinPath [ pkgs.go ]}:$PATH"
+          exec ${pkgs.go}/bin/go run ${additionalArgs} ${packageSpec} "$@"
+        '';
         moon = ''
           export PATH="${pkgs.lib.makeBinPath [ moonbit ]}:$PATH"
           exec ${moonbit}/bin/moonx --target ${target} ${additionalArgs} ${packageSpec} "$@"


### PR DESCRIPTION
## 概要

`npmPackage` に `go run` を利用する `go` runtime を追加しました。

`packageName` と `version` から `github.com/example/tool@latest` 形式の module query を作り、既存 runtime と同じ wrapper API で Go CLI を実行できます。

## 処理フロー

```mermaid
flowchart LR
  Config["npmPackage config"] --> Runtime["runtime = go"]
  Runtime --> Spec["packageName@version"]
  Spec --> GoRun["go run package@version"]
  Args["wrapper arguments"] --> GoRun
```

## 主な変更

- `runtime = "go"` を追加
- Nixpkgs の Go toolchain を wrapper の PATH に追加
- `additionalArgs` を module query の前、実行時引数を module query の後へ転送
- 既存の `version = "latest"` を Go module query にも適用

## 動作確認

- `nixfmt --check nix/npm-package/lib/npm-utils.nix`
- `nix flake check path:$PWD/nix/npm-package --no-build`
- 生成した Nix wrapper から `github.com/totto2727-org/atlas-to-kysely@latest --help` を実行
- `git diff --check`

## CI status

- Latest commit SHA: `1975fe63978171c748fae5fb6f26726bb8a9d515`
- Latest `check` job: success ([run 32569462869](https://github.com/totto2727-org/monorepo/actions/runs/32569462869), attempt: 1)
- Retry history: none

## レビュワーへの依頼

- `additionalArgs`、module query、実行時引数の順序が `go run` の CLI 契約に合っているか確認してください。
- 既存 runtime と同じ API で Go CLI を扱う方針が適切か確認してください。

## 参考文献

- [go run command](https://pkg.go.dev/cmd/go#hdr-Compile_and_run_Go_program)
- [Module-aware commands](https://go.dev/ref/mod#mod-commands)
