### PR TITLE
共有Nixパッケージにwtを追加する

### DIFF
--- a/nix/share/packages.nix
+++ b/nix/share/packages.nix
@@ -18,6 +18,12 @@ with pkgs;
   # Coding
   codex
   chezmoi
+  # MoonBit
+  (npm {
+    binName = "wt";
+    runtime = "moon";
+    packageName = "totto2727/wt";
+  })
   # npm
   (npm {
     binName = "ctx7";


### PR DESCRIPTION
## 概要

汎用的に利用できる自作 CLI として、MoonBit 製の `wt` を `nix/share/packages.nix` に追加しました。

共有パッケージの利用環境では `wt` wrapper が `moonx --target native totto2727/wt@latest` を実行します。

## 選定結果

- `wt`: Git worktree を扱う汎用 CLI で、最新 `moonx` による実行が成功するため追加
- `atlas-to-kysely`: 特定プロジェクトの Atlas / Kysely 構成に依存するため除外
- `e2e`: Go ライブラリであり実行可能 CLI ではないため除外
- `bw`: `cf` で代用できるため、依頼どおり除外
- `c-plugin`: 最新 `moonx` で公開依存 `moonbitlang/x@0.4.47` のビルドに失敗するため除外

## 処理フロー

```mermaid
flowchart LR
  Shared["nix/share/packages.nix"] --> Wrapper["npmPackage runtime = moon"]
  Wrapper --> Moonx["moonx --target native totto2727/wt@latest"]
  Moonx --> Wt["wt"]
```

## 主な変更

- 共有パッケージ一覧に `wt` wrapper を追加
- MoonBit runtime の既定値である native target を利用
- プロジェクト固有ツールや実行不能なツールは共有リストへ追加しない

## 動作確認

- `nixfmt --check nix/share/packages.nix`
- aarch64-darwin で共有パッケージ一覧全体を評価
- 共有リストから `wt` derivation を選択してビルド
- 生成された wrapper から `wt --help` を実行
- `git diff --check`

## CI status

- Latest commit SHA: `4eda330e73b060041c2a33fc1071e6e64287981e`
- Latest `check` job: success ([run 32569550690](https://github.com/totto2727-org/monorepo/actions/runs/32569550690), attempt: 1)
- Retry history: none

## レビュワーへの依頼

- `wt` が共有環境へ追加する汎用 CLI として適切か確認してください。
- 除外理由が共有パッケージの責務と一致しているか確認してください。

## 参考文献

- [totto2727-org/wt](https://github.com/totto2727-org/wt)
- [MoonBit `moonx` reference](https://github.com/moonbitlang/moon/blob/main/docs/dev/reference/moonx.md)
