### PR TITLE
npm-packageの対応プラットフォームを3種に限定

### DIFF
--- a/nix/npm-package/flake.nix
+++ b/nix/npm-package/flake.nix
@@ -20,7 +20,6 @@
       supportedSystems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
 


### PR DESCRIPTION
## 概要

- `nix/npm-package` の公開対象を `x86_64-linux`、`aarch64-linux`、`aarch64-darwin` の3システムに限定します。
- 利用対象外のIntel Mac向け `x86_64-darwin` 出力を削除します。
- Windows向け出力は従来どおり追加しません。

## 処理フロー

```mermaid
flowchart TD
    A["npm-package flake"] --> B{"supportedSystems"}
    B --> C["x86_64-linux"]
    B --> D["aarch64-linux"]
    B --> E["aarch64-darwin"]
    B -.->|"not exported"| F["x86_64-darwin / Windows"]
```

## 検証

- `lib` の属性名が `aarch64-darwin`、`aarch64-linux`、`x86_64-linux` の3種だけであることを評価
- 3システムの `npmPackage` がすべて関数として評価できることを確認
- ARM対応版moonbit-overlayを入力上書きした `nix flake check --no-build`
- ARM MacとARM64 Linux Dockerでsmoke packageを実ビルド
- x86-64 Linuxはderivation評価に成功。Docker Desktop上の実ビルドはエミュレーション環境のseccomp BPF制約で停止
- `nixfmt --check nix/npm-package/flake.nix`
- `git diff --check`

## 依存関係

- ARM LinuxのMoon runtimeは [moonbit-overlay PR #10](https://github.com/totto2727-org/moonbit-overlay/pull/10) に依存します。
- このPRはmoonbit-overlay PR #10のマージ後にマージしてください。入力は既定ブランチを追従するため、一時的なfeature branch pinは追加しません。

## CI status

- Latest commit SHA: `29eec6c47fe3c1ded3427a23a4cf3c69ab6065f9`
- Latest checks: [`CI` success](https://github.com/totto2727-org/monorepo/actions/runs/32574788109)
- Retry history: none

## レビュアーへの依頼

- 公開対象がLinux x86-64/ARM64とARM Macの3種だけになっていることを確認してください。
- `npmPackage` のAPIやruntime選択に変更がないことを確認してください。

## 参考文献

- [moonbit-overlay PR #10](https://github.com/totto2727-org/moonbit-overlay/pull/10)
- [Nix system identifiers](https://nixos.org/manual/nixpkgs/unstable/#sec-cross-system)
