### PR TITLE
feat(nix): package pass-cli

### DIFF
--- a/nix/macos-work/flake.lock
+++ b/nix/macos-work/flake.lock
@@ -1,5 +1,51 @@
 {
   "nodes": {
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "vite-plus-overlay",
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1784665499,
+        "narHash": "sha256-9BMxlTxCCDAeoNLtb1a/st7udtTIJep+wpUzquA29VU=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "0f2a1f0b6f42cebe3b149bf62d38754c5e0e9729",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "vite-plus-overlay",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -17,6 +63,61 @@
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/nix-community/home-manager/%2A"
+      }
+    },
+    "local-packages": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "path": "../share/packages",
+        "type": "path"
+      },
+      "original": {
+        "path": "../share/packages",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "moon-registry": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787107903,
+        "narHash": "sha256-/t89hdhfhBEgPsbDbGap0kZpEoab0nZbBGEPrKWou24=",
+        "ref": "refs/heads/main",
+        "rev": "c9c84f5ec832ad3ba7ffae330c6dad14775437fa",
+        "revCount": 13008,
+        "type": "git",
+        "url": "https://mooncakes.io/git/index"
+      },
+      "original": {
+        "rev": "c9c84f5ec832ad3ba7ffae330c6dad14775437fa",
+        "type": "git",
+        "url": "https://mooncakes.io/git/index"
+      }
+    },
+    "moonbit-overlay": {
+      "inputs": {
+        "moon-registry": "moon-registry",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1787368352,
+        "narHash": "sha256-dAj5AVj6vyONbZNPhJjQhuTze4fVUVmHYTk4eFqA3Dw=",
+        "owner": "totto2727",
+        "repo": "moonbit-overlay",
+        "rev": "475dceb66e55ab83d79d681e744a897d2e106574",
+        "type": "github"
+      },
+      "original": {
+        "owner": "totto2727",
+        "repo": "moonbit-overlay",
+        "type": "github"
       }
     },
     "nix-darwin": {
@@ -54,6 +155,9 @@
     },
     "npmpkgs": {
       "inputs": {
+        "moonbit-overlay": [
+          "moonbit-overlay"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -71,9 +175,91 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "local-packages": "local-packages",
+        "moonbit-overlay": "moonbit-overlay",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
-        "npmpkgs": "npmpkgs"
+        "npmpkgs": "npmpkgs",
+        "vite-plus-overlay": "vite-plus-overlay"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1776166891,
+        "narHash": "sha256-bI8yrEGjrohR5hkQox7UrxDH7XqrYMwI8SL/LrJ1+S8=",
+        "owner": "nix-systems",
+        "repo": "triplet",
+        "rev": "6de7bc09397911ce03636afbcf6118745ab2cda0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "triplet",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "moonbit-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "vite-plus-overlay",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "vite-plus-overlay": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786516249,
+        "narHash": "sha256-twFkEmzNkHuNH1VTucx6yd0DdFbOzxutxSlYwGVICxs=",
+        "owner": "ryoppippi",
+        "repo": "nix-vite-plus",
+        "rev": "b26a41f6f9406dc490c8b5b6bf1f17668befe011",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryoppippi",
+        "repo": "nix-vite-plus",
+        "type": "github"
       }
     }
   },

--- a/nix/macos-work/flake.nix
+++ b/nix/macos-work/flake.nix
@@ -14,6 +14,11 @@
     npmpkgs = {
       url = "path:../npm-package";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.moonbit-overlay.follows = "moonbit-overlay";
+    };
+    local-packages = {
+      url = "path:../share/packages";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
     moonbit-overlay = {
       url = "github:totto2727/moonbit-overlay";
@@ -30,6 +35,7 @@
       self,
       nixpkgs,
       npmpkgs,
+      local-packages,
       home-manager,
       nix-darwin,
       moonbit-overlay,
@@ -44,6 +50,7 @@
       pkgs = import nixpkgs {
         inherit system;
         overlays = [
+          local-packages.overlays.default
           moonbit-overlay.overlays.default
           vite-plus-overlay.overlays.default
         ];

--- a/nix/macos/flake.lock
+++ b/nix/macos/flake.lock
@@ -104,6 +104,22 @@
         "url": "https://flakehub.com/f/nix-community/home-manager/0.1"
       }
     },
+    "local-packages": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "path": "../share/packages",
+        "type": "path"
+      },
+      "original": {
+        "path": "../share/packages",
+        "type": "path"
+      },
+      "parent": []
+    },
     "moon-registry": {
       "flake": false,
       "locked": {
@@ -178,6 +194,9 @@
     },
     "npmpkgs": {
       "inputs": {
+        "moonbit-overlay": [
+          "moonbit-overlay"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -196,6 +215,7 @@
       "inputs": {
         "codex-overlay": "codex-overlay",
         "home-manager": "home-manager",
+        "local-packages": "local-packages",
         "moonbit-overlay": "moonbit-overlay",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",

--- a/nix/macos/flake.nix
+++ b/nix/macos/flake.nix
@@ -14,6 +14,11 @@
     npmpkgs = {
       url = "path:../npm-package";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.moonbit-overlay.follows = "moonbit-overlay";
+    };
+    local-packages = {
+      url = "path:../share/packages";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
     moonbit-overlay = {
       url = "github:totto2727/moonbit-overlay";
@@ -34,6 +39,7 @@
       self,
       nixpkgs,
       npmpkgs,
+      local-packages,
       home-manager,
       nix-darwin,
       moonbit-overlay,
@@ -49,6 +55,7 @@
       pkgs = import nixpkgs {
         inherit system;
         overlays = [
+          local-packages.overlays.default
           moonbit-overlay.overlays.default
           vite-plus-overlay.overlays.default
           codex-overlay.overlays.default

--- a/nix/share/packages-macos.nix
+++ b/nix/share/packages-macos.nix
@@ -2,4 +2,5 @@
 [
   pkgs.pinentry_mac
   pkgs.kanata-with-cmd
+  pkgs.pass-cli
 ]

--- a/nix/share/packages/flake.nix
+++ b/nix/share/packages/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "Locally packaged applications not available in nixpkgs";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      overlays.default = final: _prev: {
+        pass-cli = final.callPackage ./pass-cli.nix { };
+      };
+
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ self.overlays.default ];
+          };
+        in
+        {
+          inherit (pkgs) pass-cli;
+        }
+      );
+    };
+}

--- a/nix/share/packages/pass-cli.nix
+++ b/nix/share/packages/pass-cli.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+let
+  version = "0.20.0";
+  rev = "f42ade35716d6faa4ebeea1c426a307d386a2b77";
+in
+buildGoModule {
+  pname = "pass-cli";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "reyamira";
+    repo = "pass-cli";
+    rev = "v${version}";
+    hash = "sha256-1kDKxToQJrWc9VYjaVH0ow10ccUE+VHG0NfsCyanrKQ=";
+  };
+
+  vendorHash = "sha256-+EjavJi8uNIjcDaTEZpmR7ssZQ17HLv3HdoOGXzzGzA=";
+
+  env.CGO_ENABLED = "0";
+  subPackages = [ "." ];
+  tags = [ "netgo" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/arimxyer/pass-cli/cmd.version=${version}"
+    "-X=github.com/arimxyer/pass-cli/cmd.commit=${builtins.substring 0 7 rev}"
+    "-X=github.com/arimxyer/pass-cli/cmd.date=2026-07-02T04:23:34Z"
+  ];
+
+  preCheck = ''
+    export CI=true
+    export HOME="$TMPDIR"
+  '';
+
+  meta = {
+    description = "Secure, cross-platform CLI password and API key manager for developers";
+    homepage = "https://github.com/reyamira/pass-cli";
+    changelog = "https://github.com/reyamira/pass-cli/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "pass-cli";
+    platforms = lib.platforms.linux ++ [ "aarch64-darwin" ];
+  };
+}


### PR DESCRIPTION
## Summary

- add `nix/share/packages/flake.nix` with named `packages` outputs and a default overlay
- package pass-cli v0.20.0 with `buildGoModule`, fixed source/vendor hashes, release metadata, and upstream tests
- support Linux and Apple Silicon macOS, without an Intel macOS or default package output
- enable the local package overlay in both `macos` and `macos-work`, then install pass-cli through `packages-macos.nix`

## Validation

- built and ran `pass-cli version` through `share/packages#pass-cli`
- built and ran it through the `macos` overlay
- built and ran it through the `macos-work` overlay
- evaluated both complete nix-darwin configurations from a clean clone
