### PR TITLE
macOSのKanata起動停止を防ぐ

### DIFF
--- a/nix/macos/flake.lock
+++ b/nix/macos/flake.lock
@@ -104,6 +104,26 @@
         "url": "https://flakehub.com/f/nix-community/home-manager/0.1"
       }
     },
+    "kanata-darwin-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774518106,
+        "narHash": "sha256-4z//Ue34K/Of5fC7ZowQVhYUSBpqR9JOuaXy49J5IdI=",
+        "owner": "ryoppippi",
+        "repo": "kanata-darwin-nix",
+        "rev": "8e0a7d91f859dfc805a81be2226f04cd1220abec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryoppippi",
+        "repo": "kanata-darwin-nix",
+        "type": "github"
+      }
+    },
     "local-packages": {
       "inputs": {
         "nixpkgs": [
@@ -215,6 +235,7 @@
       "inputs": {
         "codex-overlay": "codex-overlay",
         "home-manager": "home-manager",
+        "kanata-darwin-nix": "kanata-darwin-nix",
         "local-packages": "local-packages",
         "moonbit-overlay": "moonbit-overlay",
         "nix-darwin": "nix-darwin",

--- a/nix/macos/flake.nix
+++ b/nix/macos/flake.nix
@@ -32,6 +32,10 @@
       url = "github:sadjow/codex-cli-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    kanata-darwin-nix = {
+      url = "github:ryoppippi/kanata-darwin-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -45,6 +49,7 @@
       moonbit-overlay,
       vite-plus-overlay,
       codex-overlay,
+      kanata-darwin-nix,
     }:
     let
       hostname = "totto2727-macos";
@@ -59,6 +64,7 @@
           moonbit-overlay.overlays.default
           vite-plus-overlay.overlays.default
           codex-overlay.overlays.default
+          kanata-darwin-nix.overlays.default
         ];
       };
       npm = npmpkgs.lib.${pkgs.system}.npmPackage;
@@ -73,52 +79,74 @@
             {
               nix.enable = false;
             }
-            {
-              system = import ../share/darwin-system.nix { inherit username; };
-              homebrew = (import ../share/homebrew.nix) // {
-                brews = (import ../share/brews.nix) ++ [
-                  "mas"
-                  "tailscale"
-                  "incus"
-                  "talosctl"
-                  "cloudflared"
-                  "pulumi"
-                ];
-                casks = (import ../share/casks.nix) ++ [
-                  # Browser
-                  "zen"
-                  "brave-browser"
-                  # Coding
-                  "zed"
-                  "orbstack"
-                  "chatgpt"
-                  # Game
-                  "heroic"
-                  # Utility
-                  "discord"
-                  "thunderbird"
-                  "notion-calendar"
-                  "1password"
-                  "raycast"
-                  "Logi-options+"
-                  "nordvpn"
-                  "cleanmymac"
-                  "balenaetcher"
-                ];
-                masApps = {
-                  "Kindle" = 302584613;
-                  "Mp3tag" = 1532597159;
-                  "Prime Video" = 545519333;
-                  "Slack for Desktop" = 803453959;
-                  "Tailscale" = 1475387142;
-                  "Steam Link" = 1246969117;
-                };
-              };
-            }
             home-manager.darwinModules.home-manager
+            kanata-darwin-nix.darwinModules.default
             (
               (import ../share/home-manager.nix { inherit username homedir; })
               // {
+                system = (import ../share/darwin-system.nix { inherit username; }) // {
+                  activationScripts.preActivation.text = ''
+                    # launchd loads the Kanata jobs before the upstream module's
+                    # post-activation script creates these permission-stable paths.
+                    /bin/ln -sf ${pkgs.kanata}/bin/kanata /Applications/kanata
+                    /bin/ln -sf ${pkgs.kanata-vk-agent}/bin/kanata-vk-agent /Applications/kanata-vk-agent
+                  '';
+                };
+
+                services = {
+                  kanata = {
+                    enable = true;
+                    keyboards = {
+                      default = {
+                        configFile = ./kanata.kbd;
+                        extraArgs = [ "--no-wait" ];
+                        port = 5829;
+                        vkAgent.enable = true;
+                      };
+                    };
+                  };
+                };
+
+                homebrew = (import ../share/homebrew.nix) // {
+                  brews = (import ../share/brews.nix) ++ [
+                    "mas"
+                    "tailscale"
+                    "incus"
+                    "talosctl"
+                    "cloudflared"
+                    "pulumi"
+                  ];
+                  casks = (import ../share/casks.nix) ++ [
+                    # Browser
+                    "zen"
+                    "brave-browser"
+                    # Coding
+                    "zed"
+                    "orbstack"
+                    "chatgpt"
+                    # Game
+                    "heroic"
+                    # Utility
+                    "discord"
+                    "thunderbird"
+                    "notion-calendar"
+                    "1password"
+                    "raycast"
+                    "Logi-options+"
+                    "nordvpn"
+                    "cleanmymac"
+                    "balenaetcher"
+                  ];
+                  masApps = {
+                    "Kindle" = 302584613;
+                    "Mp3tag" = 1532597159;
+                    "Prime Video" = 545519333;
+                    "Slack for Desktop" = 803453959;
+                    "Tailscale" = 1475387142;
+                    "Steam Link" = 1246969117;
+                  };
+                };
+
                 home-manager.backupFileExtension = "bak";
                 home-manager.users."${username}" = {
                   home.stateVersion = stateVersion;

--- a/nix/macos/kanata.kbd
+++ b/nix/macos/kanata.kbd
@@ -1,0 +1,15 @@
+;; https://jtroo.github.io?data=BQEwpgZgxhDmBQACRAHATgeymAzjgtAK4B2AtgIYopgj4DWYAnjoo7vAJTzyiQ5pREAIXJQ6OFKLDDR4gDbkcAC0QBhSjgAyWOjLEBHQhgAu0gKI4olaXNJhjiNHeNce4CArZpEAI0XSRMRwFZT1xSWw1DGJjTDlNSAcAAQsrajDDE2kk23tEJKd7V14IcjkAS0UkRFyHYGNKfCUMOVp0XBYAJgAGbsQevrBynEIa5y5kQrqGlCaWtrQO-t7lvrpyYnJHcerU60R6xubW-Ha8VYvgCihMRCGRxD3qDkfLay4uAB9vn9+-z5AAC5AvJFCpjICAIydADMiEIwNkwTBiAhAFYACxoxDwIEgiRSVFQyHYhH4iLSCGdABsAE5sbjEQYjKYiQAODHwpl0TKsiEw2lsnFAp6UqFovoI0VE6EY2nCwEAWXs5ASEAcEMh3U5COVDTVGsBaOp1IVetViXZAHY4bqVQaiVbIabGeaAErlWBKQ2QmGdLnuz3eok0q1mlUer2Gjnyu0NSPBiG03rdIA
+
+(defcfg
+  process-unmapped-keys yes
+)
+
+(defsrc Backspace Backslash CapsLock Backquote Escape lmet rmet)
+
+(deflayer base Backslash Backspace ControlLeft @Escape Backquote @lmet @rmet)
+
+(defalias
+  lmet (tap-hold-press 200 200 eisu lmet)
+  rmet (tap-hold-press 200 200 kana rmet)
+  Escape (tap-hold-press 200 200 (macro eisu Escape) Escape)
+)


### PR DESCRIPTION
## 概要

- Kanataとkanata-vk-agentをnix-darwinサービスとして設定しました。
- launchdがジョブを読む前に`/Applications`の安定したsymlinkを作成します。
- 起動失敗時に対話入力を待たないよう`--no-wait`を追加しました。

## 原因

kanata-darwin-nixは`/Applications/kanata`をpostActivationで作成しますが、nix-darwinはそれより前にlaunchdジョブを読み込みます。初回適用では実行ファイルが存在せず、launchdが`EX_CONFIG`でジョブを拒否した後、postActivation内の`launchctl kickstart -k`が完了しない状態になっていました。

上流実装: https://github.com/ryoppippi/kanata-darwin-nix/blob/8e0a7d91f859dfc805a81be2226f04cd1220abec/modules/darwin/default.nix

## 検証

- `nixfmt --check nix/macos/flake.nix`
- `nix build ./nix/macos#darwinConfigurations.totto2727-macos.system --no-link`
- `/Applications/kanata --check --cfg ./nix/macos/kanata.kbd`
- 生成されたactivationスクリプトでsymlink作成がlaunchd設定より前にあることを確認
- 生成されたplistに`--no-wait`が含まれることを確認

## 残りの確認

実機へのswitchはsudo認証が必要なため、マージ前に`sudo nix run nix-darwin -- switch --flake ./nix/macos`でサービス起動完了を確認してください。

## CI status

- Latest commit SHA: `45661ed`
- CI `check`: failure before repository checks (`setup-elixir`で`mix: command not found`)
- 同じ失敗をmainのrun 32614276895でも確認済み
- 追跡Issue: https://github.com/totto2727-org/monorepo/issues/336

## 実機適用経路の試行

- `sudo -n nix run nix-darwin -- switch --flake ./nix/macos`を実行
- 観測結果: `sudo: a password is required`、exit code 1
- switchは開始されず、現行の旧サービスは引き続き`spawn scheduled`、`EX_CONFIG`のままです。修正後世代の実サービス確認にはユーザーによるsudo認証が必要です。

## 追加の実パッケージ検証

- 実設定でKanata 1.10.1を代替ポート起動し、設定読込とprocessing loop到達を確認しました。
- ユーザー権限ではVirtualHIDのroot-onlyソケットでpermission deniedとなり終了しました。これはsystem LaunchDaemonとしてroot起動する必要性を確認する結果です。
- Karabiner VirtualHID system extensionは`activated enabled`、パッケージ6.9.0とManager実行ファイルも配置済みです。
- 存在しない設定を`--no-wait`付きで起動すると0.041秒、exit code 1で終了し、対話待ちやtimeoutは発生しませんでした。
- 最終system成果物内のdaemon/agent plistは`plutil -lint`成功、双方のポート5829が一致しています。
- root-only統合境界を越える最終確認だけはsudo認証が必要です。