### PR TITLE
Kanata設定を組織fork参照へ切り替える

### DIFF
--- a/nix/macos/flake.lock
+++ b/nix/macos/flake.lock
@@ -111,15 +111,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1774518106,
-        "narHash": "sha256-4z//Ue34K/Of5fC7ZowQVhYUSBpqR9JOuaXy49J5IdI=",
-        "owner": "ryoppippi",
+        "lastModified": 1787455518,
+        "narHash": "sha256-Igf417ncHU5dYcHuzS7wUtWv7XlRojCIdr8eOWEyjiE=",
+        "owner": "totto2727-org",
         "repo": "kanata-darwin-nix",
-        "rev": "8e0a7d91f859dfc805a81be2226f04cd1220abec",
+        "rev": "a65e4e9779e0ed7622c49a19865d323336f5bfb9",
         "type": "github"
       },
       "original": {
-        "owner": "ryoppippi",
+        "owner": "totto2727-org",
         "repo": "kanata-darwin-nix",
         "type": "github"
       }

--- a/nix/macos/flake.nix
+++ b/nix/macos/flake.nix
@@ -33,7 +33,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     kanata-darwin-nix = {
-      url = "github:ryoppippi/kanata-darwin-nix";
+      url = "github:totto2727-org/kanata-darwin-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -84,14 +84,7 @@
             (
               (import ../share/home-manager.nix { inherit username homedir; })
               // {
-                system = (import ../share/darwin-system.nix { inherit username; }) // {
-                  activationScripts.preActivation.text = ''
-                    # launchd loads the Kanata jobs before the upstream module's
-                    # post-activation script creates these permission-stable paths.
-                    /bin/ln -sf ${pkgs.kanata}/bin/kanata /Applications/kanata
-                    /bin/ln -sf ${pkgs.kanata-vk-agent}/bin/kanata-vk-agent /Applications/kanata-vk-agent
-                  '';
-                };
+                system = import ../share/darwin-system.nix { inherit username; };
 
                 services = {
                   kanata = {
@@ -99,7 +92,6 @@
                     keyboards = {
                       default = {
                         configFile = ./kanata.kbd;
-                        extraArgs = [ "--no-wait" ];
                         port = 5829;
                         vkAgent.enable = true;
                       };


### PR DESCRIPTION
## 概要

- Kanata flake入力を`totto2727-org/kanata-darwin-nix`へ切り替えました。
- fork側でマージしたactivation順序修正commitをlockしています。
- monorepo内に置いていた同等の`preActivation`と`extraArgs`回避策を削除しました。

## 参照するfork側修正

- https://github.com/totto2727-org/kanata-darwin-nix/pull/1
- merge commit: `a65e4e9779e0ed7622c49a19865d323336f5bfb9`

fork側モジュールがlaunchd読込前にsymlinkを作成し、Kanata daemonへ`--no-wait`を付与します。回帰チェックもfork側へ追加済みです。

## 検証

- `nixfmt --check nix/macos/flake.nix`
- `nix flake check ./nix/macos --print-build-logs`
- `nix build ./nix/macos#darwinConfigurations.totto2727-macos.system --no-link`
- `/Applications/kanata --check --cfg ./nix/macos/kanata.kbd`
- 最終activationでsymlink作成がlaunchd設定より前にあり、生成plistに`--no-wait`が含まれることを確認