### PR TITLE
root Vite設定をformatter出力へ合わせる

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,10 +64,7 @@ export default defineConfig({
       },
       check: {
         command: '',
-        dependsOn: [
-          'js:check',
-          'mbt:check',
-        ],
+        dependsOn: ['js:check', 'mbt:check'],
       },
       ci: {
         command: '',
@@ -75,10 +72,7 @@ export default defineConfig({
       },
       fix: {
         command: '',
-        dependsOn: [
-          'js:fix',
-          'mbt:fix',
-        ],
+        dependsOn: ['js:fix', 'mbt:fix'],
       },
       'js:check': {
         command: 'vp check',
@@ -124,10 +118,7 @@ export default defineConfig({
       },
       test: {
         command: '',
-        dependsOn: [
-          'js:test',
-          'mbt:test',
-        ],
+        dependsOn: ['js:test', 'mbt:test'],
       },
       'w:build': {
         command: 'vp run -r build',


### PR DESCRIPTION
## 概要

root `vite.config.ts`を現在のformatter出力へ合わせました。

## 理由

mainに残っていたformatting差分により、Kanata fork参照PRを含む無関係なPRのworkspace CIが失敗していました。Kanata変更とは分離したPRです。

## 検証

- `vp run js:fix`
- `vp run --no-cache check`