### PR TITLE
fix(c-plugin): 初回 skill add のディレクトリ競合を解消

### DIFF
--- a/mbt/app/c-plugin/src/sync_service.mbt
+++ b/mbt/app/c-plugin/src/sync_service.mbt
@@ -231,6 +231,11 @@ async fn sync_lock(agents : String, lock : LockFile) -> Unit {
     .flat_map(resolved => resolved.iter())
     .collect()
     |> deduplicate_resolved_skills
+  for root in managed_skill_roots(agents, lock.skill_dirs) {
+    if !@fs.exists(root) {
+      @fs.mkdir(root, recursive=true)
+    }
+  }
   @async.all(
     skills.map(skill => {
       () => {

--- a/mbt/app/c-plugin/src/sync_service_wbtest.mbt
+++ b/mbt/app/c-plugin/src/sync_service_wbtest.mbt
@@ -146,6 +146,51 @@ async test "create_skill_link overwrites existing symlink" {
 }
 
 ///|
+async test "sync_lock - creates every first skill link without a directory race" {
+  let root = @fs.tmpdir(prefix="c-plugin-sync-concurrent-")
+  let agents = @path.Path::join(root, ".agents").to_string()
+  let repo = @path.Path::join(root, "repository").to_string()
+  @fs.mkdir(agents, recursive=true)
+  @test_support.write_claude_marketplace(repo)
+  @test_support.write_skill(repo, "first")
+  @test_support.write_skill(repo, "second")
+  write_lock(agents, {
+    skill_dirs: [],
+    repositories: [
+      {
+        source_type: RepositoryLocal,
+        source: "./repository",
+        marketplace_kind: Claude,
+        commit_hash: None,
+        plugins: [
+          {
+            name: "plugin-a",
+            path: "plugins/plugin-a",
+            enabled_skills: ["first", "second"],
+          },
+        ],
+      },
+    ],
+  })
+  sync_lock(agents, read_lock(agents))
+  assert_true(
+    @fs.kind(
+      (agents |> @path.Path::join("skills") |> @path.Path::join("first")).to_string(),
+      follow_symlink=false,
+    ) ==
+    @fs.FileKind::SymLink,
+  )
+  assert_true(
+    @fs.kind(
+      (agents |> @path.Path::join("skills") |> @path.Path::join("second")).to_string(),
+      follow_symlink=false,
+    ) ==
+    @fs.FileKind::SymLink,
+  )
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
 async test "clear_managed_links removes only symlinks from managed skill dirs" {
   let root = @fs.tmpdir(prefix="c-plugin-link-clear-")
   let agents = @path.Path::join(root, ".agents").to_string()


### PR DESCRIPTION
## 概要

初回の `c-plugin skill add totto2727-org/agent` で複数スキルのリンク作成が同じ `.agents/skills` を並列作成し、`File exists` で失敗する競合を解消します。

## 変更内容

- `sync_lock` がリンク作成を並列化する前に、管理対象のスキルルートを直列に作成します。
- 初回追加で複数スキルを同期する回帰テストを追加します。

```mermaid
flowchart LR
  A[初回 skill add] --> B[マーケットプレイスのスキル解決]
  B --> C[管理スキルルートを直列に作成]
  C --> D[各スキルリンクを並列作成]
  D --> E[ロックファイルとリンクが完成]
```

## 検証

- `moon test mbt/app/c-plugin/src --target native`（32 passed）
- `moon fmt --check mbt/app/c-plugin/src`
- `moon check mbt/app/c-plugin/src --target native`
- クリーンな `HOME` / プロジェクトで `nix run <worktree>/mbt#c-plugin -- init` の直後に `skill add totto2727-org/agent` を一度だけ実行し、成功・ロックファイル・23本のスキルリンクを確認

## レビュー依頼

- `sync_lock` が共有ディレクトリを直列に初期化した後も、スキルごとのリンク作成が並列のままであることを確認してください。
- 回帰テストが初回の複数スキル同期パスをカバーし、公開CLIの fresh `init` → `skill add` シナリオは別途手動で検証済みであることを確認してください。

## 参照

- 報告された再現手順: fresh directory → `c-plugin init` → `c-plugin skill add totto2727-org/agent`
- Commit: `ed3ddae83e1419afce7f6c8f3753810d1a9c2cb8`

## マージ順

1. [CI remediation PR #340](https://github.com/totto2727-org/monorepo/pull/340) は `MERGED` 済みです（最終SHA: `4c680e5a570ca70f0350db47d0d4863cc376009a`）。
2. 本PR #339 は #340 のマージ後の `main` に対して **4 commits behind / 1 ahead** の状態です。
3. #340 マージ前に実行された本PRの既存 `check` 失敗は、#340 前の状態に対する結果です。`main` を同期し、#339 の変更を含む exact head SHA でCIを再実行してからレビュー・マージしてください。

#340 の変更内容は、MoonBit compiler / overlay / registry compatibility と c-plugin-v2 の Admiral/Lens pin 同期を含みます。