### PR TITLE
fix(mbt): x 0.4.50 と Nix compiler を整合

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,16 +49,16 @@
     "moon-registry": {
       "flake": false,
       "locked": {
-        "lastModified": 1785603255,
-        "narHash": "sha256-67FBhlO53KoEgXq4qkze/WiQZ1ZSk3gUTKFB396y/Us=",
+        "lastModified": 1787107903,
+        "narHash": "sha256-/t89hdhfhBEgPsbDbGap0kZpEoab0nZbBGEPrKWou24=",
         "ref": "refs/heads/main",
-        "rev": "37ce111fab93e63aa09bf4f154e6fae85faf4286",
-        "revCount": 11790,
+        "rev": "c9c84f5ec832ad3ba7ffae330c6dad14775437fa",
+        "revCount": 13008,
         "type": "git",
         "url": "https://mooncakes.io/git/index"
       },
       "original": {
-        "rev": "37ce111fab93e63aa09bf4f154e6fae85faf4286",
+        "rev": "c9c84f5ec832ad3ba7ffae330c6dad14775437fa",
         "type": "git",
         "url": "https://mooncakes.io/git/index"
       }
@@ -72,11 +72,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1786405461,
-        "narHash": "sha256-ytIkFvnobH7aPeaZ4A17oGToT1BEw1y+G/Lm9WiywF8=",
+        "lastModified": 1787478024,
+        "narHash": "sha256-2iYqSLgI6orNKAvIyKncAFFvfP6lzkcT2/g/hyEyOO0=",
         "owner": "totto2727",
         "repo": "moonbit-overlay",
-        "rev": "0165be284b800ccfe336d9083c4ab87e64f7ac40",
+        "rev": "6bf553e6349a68f0d27fc741ceb3da70ac573b6f",
         "type": "github"
       },
       "original": {
@@ -87,12 +87,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
-        "revCount": 1049422,
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "revCount": 1059570,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1049422%2Brev-f13ff45afd1bb73e640eaa08a7066dbed07e3238/019fe37d-02f5-75c1-a6ac-d62d08878e10/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1059570%2Brev-2c423e03bbafcff28bfadc6781a4a8257f205cb5/01a02a8f-3451-79e3-b07d-567cd000a289/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785945821,
-        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785912940,
-        "narHash": "sha256-PhoxeWN+MaL2qTDy/YxwR/Qhj12iCp/cK7fECfI+34o=",
+        "lastModified": 1786516249,
+        "narHash": "sha256-twFkEmzNkHuNH1VTucx6yd0DdFbOzxutxSlYwGVICxs=",
         "owner": "ryoppippi",
         "repo": "nix-vite-plus",
-        "rev": "323c9a6baa7f340d5b3e33f096e8464807d6dc88",
+        "rev": "b26a41f6f9406dc490c8b5b6bf1f17668befe011",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -49,16 +49,16 @@
     "moon-registry": {
       "flake": false,
       "locked": {
-        "lastModified": 1787107903,
-        "narHash": "sha256-/t89hdhfhBEgPsbDbGap0kZpEoab0nZbBGEPrKWou24=",
+        "lastModified": 1785603255,
+        "narHash": "sha256-67FBhlO53KoEgXq4qkze/WiQZ1ZSk3gUTKFB396y/Us=",
         "ref": "refs/heads/main",
-        "rev": "c9c84f5ec832ad3ba7ffae330c6dad14775437fa",
-        "revCount": 13008,
+        "rev": "37ce111fab93e63aa09bf4f154e6fae85faf4286",
+        "revCount": 11790,
         "type": "git",
         "url": "https://mooncakes.io/git/index"
       },
       "original": {
-        "rev": "c9c84f5ec832ad3ba7ffae330c6dad14775437fa",
+        "rev": "37ce111fab93e63aa09bf4f154e6fae85faf4286",
         "type": "git",
         "url": "https://mooncakes.io/git/index"
       }
@@ -72,11 +72,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1787478024,
-        "narHash": "sha256-2iYqSLgI6orNKAvIyKncAFFvfP6lzkcT2/g/hyEyOO0=",
+        "lastModified": 1786405461,
+        "narHash": "sha256-ytIkFvnobH7aPeaZ4A17oGToT1BEw1y+G/Lm9WiywF8=",
         "owner": "totto2727",
         "repo": "moonbit-overlay",
-        "rev": "6bf553e6349a68f0d27fc741ceb3da70ac573b6f",
+        "rev": "0165be284b800ccfe336d9083c4ab87e64f7ac40",
         "type": "github"
       },
       "original": {
@@ -87,12 +87,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
-        "revCount": 1059570,
+        "lastModified": 1786106723,
+        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "revCount": 1049422,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1059570%2Brev-2c423e03bbafcff28bfadc6781a4a8257f205cb5/01a02a8f-3451-79e3-b07d-567cd000a289/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1049422%2Brev-f13ff45afd1bb73e640eaa08a7066dbed07e3238/019fe37d-02f5-75c1-a6ac-d62d08878e10/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786901030,
-        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
+        "lastModified": 1785945821,
+        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
+        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786516249,
-        "narHash": "sha256-twFkEmzNkHuNH1VTucx6yd0DdFbOzxutxSlYwGVICxs=",
+        "lastModified": 1785912940,
+        "narHash": "sha256-PhoxeWN+MaL2qTDy/YxwR/Qhj12iCp/cK7fECfI+34o=",
         "owner": "ryoppippi",
         "repo": "nix-vite-plus",
-        "rev": "b26a41f6f9406dc490c8b5b6bf1f17668befe011",
+        "rev": "323c9a6baa7f340d5b3e33f096e8464807d6dc88",
         "type": "github"
       },
       "original": {

--- a/mbt/app/c-plugin-v2/moon.mod
+++ b/mbt/app/c-plugin-v2/moon.mod
@@ -22,7 +22,7 @@ import {
   "mizchi/tui@0.10.0",
   "moonbitlang/async@0.20.3",
   "moonbitlang/x@0.4.50",
-  "totto2727/admiral@0.6.1",
+  "totto2727/admiral@0.6.2",
   "totto2727/lens@0.4.2",
   "totto2727/target-file-discovery@0.2.1",
 }

--- a/mbt/app/c-plugin-v2/moon.mod
+++ b/mbt/app/c-plugin-v2/moon.mod
@@ -21,7 +21,7 @@ import {
   "mizchi/bit_osfs@0.45.6",
   "mizchi/tui@0.10.0",
   "moonbitlang/async@0.20.3",
-  "moonbitlang/x@0.4.47",
+  "moonbitlang/x@0.4.50",
   "totto2727/admiral@0.6.1",
   "totto2727/lens@0.4.2",
   "totto2727/target-file-discovery@0.2.1",

--- a/mbt/app/c-plugin-v2/package.nix
+++ b/mbt/app/c-plugin-v2/package.nix
@@ -11,7 +11,7 @@ let
     "mizchi/bit_osfs" = "0.45.6";
     "mizchi/tui" = "0.10.0";
     "moonbitlang/async" = "0.20.3";
-    "moonbitlang/x" = "0.4.47";
+    "moonbitlang/x" = "0.4.50";
     "shu-kitamura/sha256" = "0.1.1";
     "totto2727/admiral" = "0.6.2";
     "totto2727/lens" = "0.4.0";

--- a/mbt/app/c-plugin-v2/package.nix
+++ b/mbt/app/c-plugin-v2/package.nix
@@ -14,7 +14,7 @@ let
     "moonbitlang/x" = "0.4.50";
     "shu-kitamura/sha256" = "0.1.1";
     "totto2727/admiral" = "0.6.2";
-    "totto2727/lens" = "0.4.0";
+    "totto2727/lens" = "0.4.2";
     "totto2727/target-file-discovery" = "0.2.1";
   };
   cachedRegistry = moonPlatform.buildCachedRegistry {

--- a/mbt/app/c-plugin/moon.mod
+++ b/mbt/app/c-plugin/moon.mod
@@ -10,7 +10,7 @@ import {
   "totto2727/admiral@0.6.2",
   "totto2727/lens@0.4.0",
   "totto2727/target-file-discovery@0.2.1",
-  "moonbitlang/x@0.4.47",
+  "moonbitlang/x@0.4.50",
   "moonbitlang/async@0.20.3",
 }
 

--- a/mbt/app/c-plugin/package.nix
+++ b/mbt/app/c-plugin/package.nix
@@ -8,7 +8,7 @@
 let
   dependencies = {
     "moonbitlang/async" = "0.20.3";
-    "moonbitlang/x" = "0.4.47";
+    "moonbitlang/x" = "0.4.50";
     "totto2727/admiral" = "0.6.2";
     "totto2727/lens" = "0.4.0";
     "totto2727/target-file-discovery" = "0.2.1";

--- a/mbt/flake.lock
+++ b/mbt/flake.lock
@@ -16,19 +16,37 @@
         "url": "https://mooncakes.io/git/index"
       }
     },
+    "moon-registry_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787107903,
+        "narHash": "sha256-/t89hdhfhBEgPsbDbGap0kZpEoab0nZbBGEPrKWou24=",
+        "ref": "refs/heads/main",
+        "rev": "c9c84f5ec832ad3ba7ffae330c6dad14775437fa",
+        "revCount": 13008,
+        "type": "git",
+        "url": "https://mooncakes.io/git/index"
+      },
+      "original": {
+        "rev": "c9c84f5ec832ad3ba7ffae330c6dad14775437fa",
+        "type": "git",
+        "url": "https://mooncakes.io/git/index"
+      }
+    },
     "moonbit-overlay": {
       "inputs": {
+        "moon-registry": "moon-registry_2",
         "nixpkgs": [
           "nixpkgs"
         ],
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785646155,
-        "narHash": "sha256-YJ3h+lLqHj25vGq/xS9yVJ1ap03Avn9Fzm078lXQc1I=",
+        "lastModified": 1787478125,
+        "narHash": "sha256-eGDr1Vo5REYP4gOJy0bZav2z/Yffm1YEEk/F7dWTGF0=",
         "owner": "totto2727",
         "repo": "moonbit-overlay",
-        "rev": "1424434f0ef134b99aaa71bd446d1bf0306dbe65",
+        "rev": "b5a3d3a65105a011742cc3f029fc93c0ad539df5",
         "type": "github"
       },
       "original": {
@@ -66,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {

--- a/mbt/flake.lock
+++ b/mbt/flake.lock
@@ -3,11 +3,11 @@
     "moon-registry": {
       "flake": false,
       "locked": {
-        "lastModified": 1786351871,
-        "narHash": "sha256-55SgNYr7YFm134+t8RGSH02eskwOykjCOOP8SfC99B0=",
+        "lastModified": 1787489193,
+        "narHash": "sha256-OZcDjTkavjDLCrvTkrw4PfP6Uz1CwPAXESQjYzs95b8=",
         "ref": "refs/heads/main",
-        "rev": "e6d628e537263a2740f6dbb0c14f38df2e9bd2ca",
-        "revCount": 12165,
+        "rev": "256d48baa8b2a9f770ac9fd4608e3d9655c5370d",
+        "revCount": 13463,
         "type": "git",
         "url": "https://mooncakes.io/git/index"
       },


### PR DESCRIPTION
## 概要

`moonbitlang/x@0.4.50` へ更新し、Nix の source build が root と同じ MoonBit 0.1.20260819 を使用するよう `mbt/flake.lock` の MoonBit overlay を更新しました。

旧 overlay では x の `crypto/sm3.mbt` が現在の compiler と互換でなく、`c-plugin-v2` の Git-source Nix build が失敗していました。x 0.4.50 は lexscan の非互換を解消します。更新後 overlay では旧 `admiral 0.6.1` の constructor API が不適合になるため、manifest と Nix 定義を `admiral 0.6.2`、`lens 0.4.2` に揃えました。

```mermaid
flowchart LR
  Root[root flake: Moon 0.1.20260819] --> Overlay[mbt moonbit-overlay]
  Overlay --> NixBuild[c-plugin / c-plugin-v2 Nix build]
  Registry[moon registry] --> X[moonbitlang/x 0.4.50]
  X --> NixBuild
```

## 変更範囲

- `mbt/flake.lock` の root `moon-registry`: `e6d628e5` → `256d48ba`。これは `moonbitlang/x@0.4.50` を解決する registry 更新です。
- `mbt/flake.lock` の toolchain graph: moonbit-overlay `1424434f` → `b5a3d3a6`、overlay が固定する registry edge `c9c84f5e`、treefmt-nix `db947814` → `27b3b12a`。root `nixpkgs` は `61b7c44c` のままです。
- `c-plugin` / `c-plugin-v2`: `moonbitlang/x@0.4.50`。
- `c-plugin-v2`: `moon.mod` と `package.nix` の direct pin を `admiral@0.6.2`、`lens@0.4.2` に同期。

## 検証

- `nix build --no-link --no-write-lock-file git+file://…?dir=mbt&rev=4c680e5…#c-plugin …#c-plugin-v2` → `EXIT=0`
- 更新した Nix toolchain: `moon 0.1.20260819 (fc2a4ee 2026-08-19)`
- `moon check mbt/app/c-plugin/src --target native` と `moon check mbt/app/c-plugin-v2/src --target native` → `EXIT=0`
- `vp run ci` → `EXIT=0`

詳細な再現手順と出力は `.omo/evidence/moonbit-x-050-exact-source-compat-2026-08-23.md` に記録しています。

## レビュー依頼

- `mbt/flake.lock` の root registry と MoonBit compiler / overlay registry の各更新が、x 0.4.50 互換の範囲に留まることを確認してください。
- `c-plugin-v2` の manifest と Nix direct dependency pin が一致することを確認してください。

Refs: #339, #340