### PR TITLE
AGENTSテンプレートの箇条書きを簡潔化

### DIFF
--- a/.agents/skills/share-artifact/agents/sample.md
+++ b/.agents/skills/share-artifact/agents/sample.md
@@ -11,13 +11,11 @@ plugins/  Distributable plugins
 ### Execution rules
 
 - Run commands from the repository root.
-
 - Use vp for project tasks.
 
 ### Standard tasks
 
 - `vp run check` — Run checks.
-
 - `vp run test` — Run tests.
 
 ## Architecture
@@ -33,7 +31,6 @@ plugins/  Distributable plugins
 ## Development tools
 
 - **Vite+**: Runs repository tasks.
-
 - **MoonBit**: Checks MoonBit packages.
 
 ## Package-specific rules

--- a/.agents/skills/share-artifact/agents/spec.md
+++ b/.agents/skills/share-artifact/agents/spec.md
@@ -29,6 +29,8 @@ Render the sibling [template.md](template.md) as `AGENTS.md`. The minimum form u
 
 The minimum form may be extended with repository-specific AI and developer sections, provided the required sections stay ordered, the extension does not become an end-user getting-started guide, and it retains the sibling [template.md](template.md) and [sample.md](sample.md) as the current authoring references.
 
+Render consecutive single-paragraph bullet items as a tight list without blank lines between items. Keep one blank line before and after the list so adjacent headings and paragraphs remain distinct.
+
 End the file with this exact provenance footer without a heading:
 
 ```markdown

--- a/.agents/skills/share-artifact/agents/template.md
+++ b/.agents/skills/share-artifact/agents/template.md
@@ -11,49 +11,34 @@
 ### Execution rules
 
 {% for rule in execution_rules -%}
-
 - {{ rule }}
-
-{% endfor -%}
-
+{% endfor %}
 ### Standard tasks
 
 {% for task in standard_tasks -%}
-
 - `{{ task.command }}` — {{ task.description }}
-
-{% endfor -%}
-
+{% endfor %}
 ## Architecture
 
 {% for section in architecture_sections -%}
-
 ### {{ section.title }}
 
 {% for item in section['items'] -%}
-
 - {{ item }}
-
+{% endfor %}
 {% endfor -%}
-{% endfor -%}
-
 ## Development tools
 
 {% for tool in development_tools -%}
-
 - **{{ tool.name }}**: {{ tool.description }}
-
-{% endfor -%}
-
+{% endfor %}
 {% if package_rules -%}
 
 ## Package-specific rules
 
 {% for rule in package_rules -%}
-
 - {{ rule }}
-
-{% endfor -%}
+{% endfor %}
 {% endif -%}
 
 {% if is_moonbit -%}
@@ -61,5 +46,6 @@
 ## MoonBit README maintenance
 
 Keep the canonical end-user content in the physical `README.mbt.md` file and maintain `README.md` as the relative symlink `README.md -> README.mbt.md`. Validate supported MoonBit blocks with `moon check README.mbt.md` and `moon test README.mbt.md`. Never render canonical-file or symlink-maintenance instructions into the end-user README.
-{% endif %}
+
+{% endif -%}
 _This AGENTS.md was generated from the [share-artifact skill](https://raw.githubusercontent.com/totto2727-org/agent/refs/heads/main/plugins/totto2727-coding/skills/share-artifact/SKILL.md) and [AGENTS template](https://raw.githubusercontent.com/totto2727-org/agent/refs/heads/main/plugins/totto2727-coding/skills/share-artifact/agents/template.md)._


### PR DESCRIPTION
## 概要

- AGENTSの連続する単一段落の箇条書きをtight listとして描画する規則を仕様へ追加しました。
- Jinja templateから項目間の不要な空行を除去しました。
- sampleを更新し、templateからbyte一致で再生成できる状態を維持しました。
- heading、optional section、provenance footerの前後には必要な空行を残しています。

## 処理フロー

```mermaid
flowchart LR
    A[AGENTS specification] --> B[Tight-list rule]
    B --> C[Jinja template]
    C --> D[Rendered sample]
    C --> E[Project AGENTS.md]
```

## 検証

- Jinja `StrictUndefined`によるsampleのbyte一致: PASS
- package rules / MoonBit sectionの有無を含むrender matrix: PASS
- required context欠落時の`UndefinedError`: PASS
- loose-list patternが残っていないこと: PASS
- `git diff --check`: PASS

## レビュワーへの依頼

- 単一段落の連続した箇条書きだけがtight listになっているか確認してください。
- heading、paragraph、provenance footerの区切りに必要な空行が維持されているか確認してください。
- templateとsampleの再現性が保たれているか確認してください。

## 参考文献

- [CommonMark list items](https://spec.commonmark.org/0.31.2/#list-items)
- [Jinja whitespace control](https://jinja.palletsprojects.com/en/stable/templates/#whitespace-control)
