### PR TITLE
Effect CLIとVite+ APIを利用するmdts CLIを追加

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -101,6 +101,24 @@
         "wrangler": "catalog:cloudflare",
       },
     },
+    "js/app/mdts": {
+      "name": "mdts",
+      "version": "0.0.0",
+      "bin": {
+        "mdts": "./src/cli.ts",
+      },
+      "dependencies": {
+        "@comark/html": "catalog:markdown",
+        "effect": "catalog:effect",
+        "vite": "catalog:",
+        "vite-plugin-mdts": "workspace:*",
+        "vite-plus": "catalog:",
+      },
+      "devDependencies": {
+        "@totto2727/fp": "workspace:*",
+        "@types/node": "catalog:types",
+      },
+    },
     "js/app/rss-graphql": {
       "name": "@app/rss-graphql",
       "devDependencies": {
@@ -120,6 +138,7 @@
       "name": "vite-plugin-mdts-example",
       "devDependencies": {
         "@totto2727/fp": "workspace:*",
+        "mdts": "workspace:*",
         "vite": "catalog:",
         "vite-plugin-mdts": "workspace:*",
       },
@@ -306,6 +325,9 @@
     "lint": {
       "ultracite": "7.10.2",
     },
+    "markdown": {
+      "@comark/html": "^0.6.2",
+    },
     "pulumi": {
       "@pulumi/aws": "^7.0.0",
       "@pulumi/awsx": "^3.0.0",
@@ -384,6 +406,8 @@
     "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260804.1", "https://npm.flatt.tech/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260804.1.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-7lswfarBZ7xkHpTFrNb74ExwOltIalVaASc+GOYfCNtnwFxK/JZSVByfm/hnZEBtrHU7fMY2z7dYT64rwS0pHg=="],
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260804.1", "https://npm.flatt.tech/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260804.1.tgz", { "os": "win32", "cpu": "x64" }, "sha512-GOgRWYtxISN5rAWfx3K7zubt3xEn0/ZPFrbcLL+GwT4ouCKyNoHqfT1cPNB6Nx7t8BHEjnuTG7gkHO4Wd5ORdg=="],
+
+    "@comark/html": ["@comark/html@0.6.2", "https://npm.flatt.tech/@comark/html/-/html-0.6.2.tgz", { "dependencies": { "comark": "0.6.2" }, "peerDependencies": { "beautiful-mermaid": ">=1.0", "katex": ">=0.16", "shiki": "^4.3.1" }, "optionalPeers": ["beautiful-mermaid", "katex", "shiki"] }, "sha512-ke1/rxpgsrRdfx/4LFURFQCqc2Bv/eVZd+Eenk8x/8IX4346HOGReiWuWWs11mpzHibkKFaPq56zWsnn7Eu8lw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "https://npm.flatt.tech/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -1111,6 +1135,10 @@
 
     "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "https://npm.flatt.tech/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
 
+    "@types/linkify-it": ["@types/linkify-it@5.0.0", "https://npm.flatt.tech/@types/linkify-it/-/linkify-it-5.0.0.tgz", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
+
+    "@types/mdurl": ["@types/mdurl@2.0.0", "https://npm.flatt.tech/@types/mdurl/-/mdurl-2.0.0.tgz", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
+
     "@types/node": ["@types/node@25.9.5", "https://npm.flatt.tech/@types/node/-/node-25.9.5.tgz", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg=="],
 
     "@types/seedrandom": ["@types/seedrandom@3.0.8", "https://npm.flatt.tech/@types/seedrandom/-/seedrandom-3.0.8.tgz", {}, "sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ=="],
@@ -1267,6 +1295,8 @@
 
     "color-name": ["color-name@1.1.4", "https://npm.flatt.tech/color-name/-/color-name-1.1.4.tgz", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "comark": ["comark@0.6.2", "https://npm.flatt.tech/comark/-/comark-0.6.2.tgz", { "dependencies": { "entities": "^8.0.0", "htmlparser2": "^12.0.0", "js-yaml": "^5.2.1", "markdown-exit": "1.1.0-beta.2" }, "peerDependencies": { "beautiful-mermaid": "^1.1.3", "katex": "^0.17.0", "rangi": "^2.2.0", "shiki": "^4.3.1" }, "optionalPeers": ["beautiful-mermaid", "katex", "rangi", "shiki"] }, "sha512-hlWa7KlGPfRxovQavnHZlLlTUKrfwE7/o4ewCY0FzqFtRvVT8VdslrumQwELIiK9utsurpoSWCBFj1yVMtDOtw=="],
+
     "commander": ["commander@15.0.0", "https://npm.flatt.tech/commander/-/commander-15.0.0.tgz", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "common-ancestor-path": ["common-ancestor-path@2.0.0", "https://npm.flatt.tech/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
@@ -1295,11 +1325,21 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "https://npm.flatt.tech/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "dom-serializer": ["dom-serializer@3.1.1", "https://npm.flatt.tech/dom-serializer/-/dom-serializer-3.1.1.tgz", { "dependencies": { "domelementtype": "^3.0.0", "domhandler": "^6.0.0", "entities": "^8.0.0" } }, "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw=="],
+
+    "domelementtype": ["domelementtype@3.0.0", "https://npm.flatt.tech/domelementtype/-/domelementtype-3.0.0.tgz", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "domhandler": ["domhandler@6.0.1", "https://npm.flatt.tech/domhandler/-/domhandler-6.0.1.tgz", { "dependencies": { "domelementtype": "^3.0.0" } }, "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg=="],
+
+    "domutils": ["domutils@4.0.2", "https://npm.flatt.tech/domutils/-/domutils-4.0.2.tgz", { "dependencies": { "dom-serializer": "^3.0.0", "domelementtype": "^3.0.0", "domhandler": "^6.0.0" } }, "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA=="],
+
     "effect": ["effect@4.0.0-beta.65", "https://npm.flatt.tech/effect/-/effect-4.0.0-beta.65.tgz", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-QYKvQPAj3CmtsvWkHQww15wX4KG2gNsszDWEcOO5sZCMknp66u6Si/Opmt3wwWCwsyvRmDAdIg+JIz5qzbbFIw=="],
 
     "effect-hono": ["effect-hono@workspace:js/package/effect-hono"],
 
     "emoji-regex": ["emoji-regex@8.0.0", "https://npm.flatt.tech/emoji-regex/-/emoji-regex-8.0.0.tgz", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "entities": ["entities@8.0.0", "https://npm.flatt.tech/entities/-/entities-8.0.0.tgz", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "env-paths": ["env-paths@2.2.1", "https://npm.flatt.tech/env-paths/-/env-paths-2.2.1.tgz", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -1374,6 +1414,8 @@
     "hosted-git-info": ["hosted-git-info@9.0.3", "https://npm.flatt.tech/hosted-git-info/-/hosted-git-info-9.0.3.tgz", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
 
     "html-escaper": ["html-escaper@2.0.2", "https://npm.flatt.tech/html-escaper/-/html-escaper-2.0.2.tgz", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "htmlparser2": ["htmlparser2@12.0.0", "https://npm.flatt.tech/htmlparser2/-/htmlparser2-12.0.0.tgz", { "dependencies": { "domelementtype": "^3.0.0", "domhandler": "^6.0.0", "domutils": "^4.0.2", "entities": "^8.0.0" } }, "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "https://npm.flatt.tech/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
@@ -1463,6 +1505,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "https://npm.flatt.tech/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
+    "linkify-it": ["linkify-it@5.0.2", "https://npm.flatt.tech/linkify-it/-/linkify-it-5.0.2.tgz", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q=="],
+
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "https://npm.flatt.tech/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
     "long": ["long@5.3.2", "https://npm.flatt.tech/long/-/long-5.3.2.tgz", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
@@ -1478,6 +1522,12 @@
     "make-dir": ["make-dir@4.0.0", "https://npm.flatt.tech/make-dir/-/make-dir-4.0.0.tgz", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "make-fetch-happen": ["make-fetch-happen@15.0.6", "https://npm.flatt.tech/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/agent": "^4.0.0", "@npmcli/redact": "^4.0.0", "cacache": "^20.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^5.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^6.0.0", "ssri": "^13.0.0" } }, "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw=="],
+
+    "markdown-exit": ["markdown-exit@1.1.0-beta.2", "https://npm.flatt.tech/markdown-exit/-/markdown-exit-1.1.0-beta.2.tgz", { "dependencies": { "@types/linkify-it": "^5.0.0", "@types/mdurl": "^2.0.0", "entities": "^7.0.0", "linkify-it": "^5.0.1", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" } }, "sha512-8CzMGVlFZ4DEfnc8KU+4ycUW2SIOuiXqCHD7z51ecVEi/weyc0f2ylQbCm4KoKuVlTZSuMUMnWT0hTyquZ7anQ=="],
+
+    "mdts": ["mdts@workspace:js/app/mdts"],
+
+    "mdurl": ["mdurl@2.1.0", "https://npm.flatt.tech/mdurl/-/mdurl-2.1.0.tgz", {}, "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg=="],
 
     "merge-stream": ["merge-stream@2.0.0", "https://npm.flatt.tech/merge-stream/-/merge-stream-2.0.0.tgz", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
@@ -1615,6 +1665,8 @@
 
     "protobufjs": ["protobufjs@7.6.5", "https://npm.flatt.tech/protobufjs/-/protobufjs-7.6.5.tgz", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
+    "punycode.js": ["punycode.js@2.3.1", "https://npm.flatt.tech/punycode.js/-/punycode.js-2.3.1.tgz", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
     "pure-rand": ["pure-rand@8.4.2", "https://npm.flatt.tech/pure-rand/-/pure-rand-8.4.2.tgz", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "pvtsutils": ["pvtsutils@1.3.6", "https://npm.flatt.tech/pvtsutils/-/pvtsutils-1.3.6.tgz", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
@@ -1742,6 +1794,8 @@
     "type-fest": ["type-fest@5.8.0", "https://npm.flatt.tech/type-fest/-/type-fest-5.8.0.tgz", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
 
     "typescript": ["typescript@5.9.3", "https://npm.flatt.tech/typescript/-/typescript-5.9.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "https://npm.flatt.tech/uc.micro/-/uc.micro-2.1.0.tgz", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "ultracite": ["ultracite@7.10.2", "https://npm.flatt.tech/ultracite/-/ultracite-7.10.2.tgz", { "dependencies": { "@clack/prompts": "^1.5.1", "commander": "^15.0.0", "cross-spawn": "^7.0.6", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.6", "yaml": "^2.9.0", "zod": "^4.4.3" }, "peerDependencies": { "oxfmt": ">=0.1.0", "oxlint": "^1.0.0" }, "optionalPeers": ["oxfmt", "oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-WP1Hu/BKy/BDgntaiU33uq2Y8hKL2gEO5li2wfg7XFvmlyIkGDEy8qbWg7GHsxTEjEpWOAKpyFSF8aqc3JNEGQ=="],
 
@@ -1895,7 +1949,11 @@
 
     "@vitest/browser/ws": ["ws@8.21.3", "https://npm.flatt.tech/ws/-/ws-8.21.3.tgz", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
+    "comark/js-yaml": ["js-yaml@5.4.1", "https://npm.flatt.tech/js-yaml/-/js-yaml-5.4.1.tgz", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.mjs" } }, "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ=="],
+
     "libsql/detect-libc": ["detect-libc@2.0.2", "https://npm.flatt.tech/detect-libc/-/detect-libc-2.0.2.tgz", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
+
+    "markdown-exit/entities": ["entities@7.0.1", "https://npm.flatt.tech/entities/-/entities-7.0.1.tgz", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "miniflare/undici": ["undici@7.29.0", "https://npm.flatt.tech/undici/-/undici-7.29.0.tgz", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -109,6 +109,7 @@
       },
       "dependencies": {
         "@comark/html": "catalog:markdown",
+        "@effect/platform-node": "catalog:effect",
         "effect": "catalog:effect",
         "vite": "catalog:",
         "vite-plugin-mdts": "workspace:*",

--- a/js/app/mdts/README.md
+++ b/js/app/mdts/README.md
@@ -1,6 +1,6 @@
 # mdts CLI
 
-`mdts` builds `.md.ts` documents with Vite+ and serves an HTML preview rendered by Comark.
+`mdts` uses Effect's CLI API to build `.md.ts` documents with Vite+ and serve an HTML preview rendered by Comark.
 
 ## Configuration
 
@@ -29,4 +29,4 @@ mdts build
 mdts preview
 ```
 
-`mdts build` writes the generated Markdown files to `output`. `mdts preview` starts a Vite development server whose `index.html` lists every generated Markdown document and renders the selected document with `@comark/html`.
+`mdts build` writes the generated Markdown files to `output`. `mdts preview` starts a Vite development server whose `index.html` lists every generated Markdown document and renders the selected document with `@comark/html`. Documents use normal URL paths such as `/guide.md` and `/reference/api.md`, including direct navigation and browser history.

--- a/js/app/mdts/README.md
+++ b/js/app/mdts/README.md
@@ -1,0 +1,32 @@
+# mdts CLI
+
+`mdts` builds `.md.ts` documents with Vite+ and serves an HTML preview rendered by Comark.
+
+## Configuration
+
+Create `mdts.config.ts` in the project root. Both fields are optional and default to `content` and `dist`.
+
+```ts
+import { defineConfig } from 'mdts'
+
+export default defineConfig({
+  input: './content',
+  output: './dist',
+  vite: {
+    server: {
+      port: 4173,
+    },
+  },
+})
+```
+
+The CLI loads only `mdts.config.ts`. It passes `configFile: false` to Vite+, so an existing `vite.config.ts` is ignored. The optional `vite` object is merged into the CLI defaults, while the project root, Markdown input, output directory, internal plugins, and disabled Vite config discovery remain owned by `mdts`.
+
+## Commands
+
+```bash
+mdts build
+mdts preview
+```
+
+`mdts build` writes the generated Markdown files to `output`. `mdts preview` starts a Vite development server whose `index.html` lists every generated Markdown document and renders the selected document with `@comark/html`.

--- a/js/app/mdts/package.json
+++ b/js/app/mdts/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mdts",
+  "version": "0.0.0",
+  "private": true,
+  "bin": {
+    "mdts": "./src/cli.ts"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/config.ts"
+  },
+  "dependencies": {
+    "@comark/html": "catalog:markdown",
+    "effect": "catalog:effect",
+    "vite": "catalog:",
+    "vite-plugin-mdts": "workspace:*",
+    "vite-plus": "catalog:"
+  },
+  "devDependencies": {
+    "@totto2727/fp": "workspace:*",
+    "@types/node": "catalog:types"
+  }
+}

--- a/js/app/mdts/package.json
+++ b/js/app/mdts/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@comark/html": "catalog:markdown",
+    "@effect/platform-node": "catalog:effect",
     "effect": "catalog:effect",
     "vite": "catalog:",
     "vite-plugin-mdts": "workspace:*",

--- a/js/app/mdts/src/__fixtures__/basic/content/guide.md.ts
+++ b/js/app/mdts/src/__fixtures__/basic/content/guide.md.ts
@@ -1,0 +1,12 @@
+import { md } from 'vite-plugin-mdts'
+
+import apiReference from './reference/api.md.ts?link'
+
+export const meta = {
+  title: 'Guide',
+}
+
+export default md`# Guide
+
+Read the ${apiReference}.
+`

--- a/js/app/mdts/src/__fixtures__/basic/content/reference/api.md.ts
+++ b/js/app/mdts/src/__fixtures__/basic/content/reference/api.md.ts
@@ -1,0 +1,10 @@
+import { md } from 'vite-plugin-mdts'
+
+export const meta = {
+  title: 'API Reference',
+}
+
+export default md`# API Reference
+
+The API is ready.
+`

--- a/js/app/mdts/src/__fixtures__/basic/mdts.config.ts
+++ b/js/app/mdts/src/__fixtures__/basic/mdts.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'mdts'
+
+export default defineConfig({
+  input: './content',
+  output: './dist',
+  vite: {
+    logLevel: 'silent',
+    server: {
+      port: 0,
+      strictPort: true,
+    },
+  },
+})

--- a/js/app/mdts/src/__fixtures__/basic/vite.config.ts
+++ b/js/app/mdts/src/__fixtures__/basic/vite.config.ts
@@ -1,0 +1,1 @@
+throw new Error('mdts must ignore vite.config.ts')

--- a/js/app/mdts/src/build.ts
+++ b/js/app/mdts/src/build.ts
@@ -1,0 +1,70 @@
+import { markdown } from 'vite-plugin-mdts'
+import { build, mergeConfig } from 'vite-plus'
+import type { InlineConfig, Plugin } from 'vite-plus'
+
+import { loadMdtsConfig } from './config.ts'
+import type { ResolvedMdtsConfig } from './config.ts'
+
+const buildEntryId = 'virtual:mdts/build-entry'
+const resolvedBuildEntryId = '\0mdts:build-entry'
+
+interface MdtsCommandOptions {
+  readonly configFile?: string
+  readonly root: string
+}
+
+const buildEntryPlugin = (): Plugin => ({
+  generateBundle(_options, bundle) {
+    for (const [fileName, output] of Object.entries(bundle)) {
+      if (output.type === 'chunk' && output.facadeModuleId === resolvedBuildEntryId) {
+        Reflect.deleteProperty(bundle, fileName)
+      }
+    }
+  },
+  load(id) {
+    return id === resolvedBuildEntryId ? 'export {}\n' : undefined
+  },
+  name: 'mdts-build-entry',
+  resolveId(id) {
+    return id === buildEntryId ? resolvedBuildEntryId : undefined
+  },
+})
+
+export const resolveMdtsViteConfig = (config: ResolvedMdtsConfig, commandConfig: InlineConfig): InlineConfig => {
+  const baseConfig: InlineConfig = {
+    configFile: false,
+    plugins: [markdown({ directory: config.input })],
+    publicDir: false,
+    root: config.root,
+  }
+  const merged = mergeConfig(mergeConfig(baseConfig, config.vite), commandConfig)
+
+  return {
+    ...merged,
+    configFile: false,
+    publicDir: false,
+    root: config.root,
+  }
+}
+
+export const buildMarkdown = async (options: MdtsCommandOptions): Promise<void> => {
+  const config = await loadMdtsConfig({ command: 'build', ...options })
+  const userBuild = config.vite.build
+  const userRolldownOptions = userBuild?.rolldownOptions
+
+  await build(
+    resolveMdtsViteConfig(config, {
+      build: {
+        ...userBuild,
+        emptyOutDir: true,
+        outDir: config.output,
+        rolldownOptions: {
+          ...userRolldownOptions,
+          input: buildEntryId,
+        },
+        write: true,
+      },
+      plugins: [buildEntryPlugin()],
+    }),
+  )
+}

--- a/js/app/mdts/src/cli.ts
+++ b/js/app/mdts/src/cli.ts
@@ -1,59 +1,46 @@
 #!/usr/bin/env node
 
-import { parseArgs } from 'node:util'
-
-import { Predicate } from 'effect'
+import { NodeRuntime, NodeServices } from '@effect/platform-node'
+import { Effect, Option } from 'effect'
+import { Command, Flag } from 'effect/unstable/cli'
 
 import { buildMarkdown } from './build.ts'
 import { createMarkdownPreview } from './preview.ts'
 
-const help = `mdts
+const configFlag = Flag.file('config').pipe(
+  Flag.withAlias('c'),
+  Flag.withDescription('Path to mdts.config.ts'),
+  Flag.optional,
+)
 
-Usage:
-  mdts build [--config <file>]
-  mdts preview [--config <file>]
-`
+const commandOptions = (config: Option.Option<string>) => ({
+  configFile: Option.getOrUndefined(config),
+  root: process.cwd(),
+})
 
-const main = async (): Promise<void> => {
-  const [command, ...args] = process.argv.slice(2)
-  if (Predicate.isNullish(command) || command === '--help' || command === '-h') {
-    process.stdout.write(help)
-    return
-  }
+const buildCommand = Command.make('build', { config: configFlag }, ({ config }) =>
+  Effect.tryPromise(() => buildMarkdown(commandOptions(config))),
+).pipe(Command.withDescription('Build Markdown documents'))
 
-  const parsed = parseArgs({
-    allowPositionals: false,
-    args,
-    options: {
-      config: { short: 'c', type: 'string' },
-      help: { short: 'h', type: 'boolean' },
-    },
-    strict: true,
-  })
-  if (parsed.values.help === true) {
-    process.stdout.write(help)
-    return
-  }
+const previewCommand = Command.make('preview', { config: configFlag }, ({ config }) =>
+  Effect.acquireRelease(
+    Effect.tryPromise(async () => {
+      const server = await createMarkdownPreview(commandOptions(config))
+      await server.listen()
+      server.printUrls()
+      server.bindCLIShortcuts({ print: true })
+      return server
+    }),
+    (server) => Effect.promise(() => server.close()),
+  ).pipe(Effect.andThen(Effect.never), Effect.scoped),
+).pipe(Command.withDescription('Preview Markdown documents'))
 
-  const options = {
-    configFile: parsed.values.config,
-    root: process.cwd(),
-  }
+const mdtsCommand = Command.make('mdts').pipe(
+  Command.withDescription('Build and preview Markdown documents'),
+  Command.withSubcommands([buildCommand, previewCommand]),
+)
 
-  if (command === 'build') {
-    await buildMarkdown(options)
-    return
-  }
+const program = Command.run(mdtsCommand, { version: '0.0.0' }).pipe(Effect.provide(NodeServices.layer))
 
-  if (command === 'preview') {
-    const server = await createMarkdownPreview(options)
-    await server.listen()
-    server.printUrls()
-    server.bindCLIShortcuts({ print: true })
-    return
-  }
-
-  throw new TypeError(`unknown mdts command: ${command}`)
-}
-
-await main()
+// oxlint-disable-next-line rules/no-effect-runtime-run -- CLI entrypoint executes the top-level mdts workflow once.
+NodeRuntime.runMain(program)

--- a/js/app/mdts/src/cli.ts
+++ b/js/app/mdts/src/cli.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import { parseArgs } from 'node:util'
+
+import { Predicate } from 'effect'
+
+import { buildMarkdown } from './build.ts'
+import { createMarkdownPreview } from './preview.ts'
+
+const help = `mdts
+
+Usage:
+  mdts build [--config <file>]
+  mdts preview [--config <file>]
+`
+
+const main = async (): Promise<void> => {
+  const [command, ...args] = process.argv.slice(2)
+  if (Predicate.isNullish(command) || command === '--help' || command === '-h') {
+    process.stdout.write(help)
+    return
+  }
+
+  const parsed = parseArgs({
+    allowPositionals: false,
+    args,
+    options: {
+      config: { short: 'c', type: 'string' },
+      help: { short: 'h', type: 'boolean' },
+    },
+    strict: true,
+  })
+  if (parsed.values.help === true) {
+    process.stdout.write(help)
+    return
+  }
+
+  const options = {
+    configFile: parsed.values.config,
+    root: process.cwd(),
+  }
+
+  if (command === 'build') {
+    await buildMarkdown(options)
+    return
+  }
+
+  if (command === 'preview') {
+    const server = await createMarkdownPreview(options)
+    await server.listen()
+    server.printUrls()
+    server.bindCLIShortcuts({ print: true })
+    return
+  }
+
+  throw new TypeError(`unknown mdts command: ${command}`)
+}
+
+await main()

--- a/js/app/mdts/src/config.ts
+++ b/js/app/mdts/src/config.ts
@@ -1,0 +1,88 @@
+import { Predicate, String } from 'effect'
+import { loadConfigFromFile, normalizePath } from 'vite-plus'
+import type { ConfigEnv, UserConfig } from 'vite-plus'
+
+const defaultConfigFile = 'mdts.config.ts'
+const defaultInput = 'content'
+const defaultOutput = 'dist'
+
+export interface MdtsConfig {
+  readonly input?: string
+  readonly output?: string
+  readonly vite?: UserConfig
+}
+
+export interface ResolvedMdtsConfig {
+  readonly configFile: string
+  readonly input: string
+  readonly output: string
+  readonly root: string
+  readonly vite: UserConfig
+}
+
+interface LoadMdtsConfigOptions {
+  readonly command: ConfigEnv['command']
+  readonly configFile?: string
+  readonly root: string
+}
+
+export const defineConfig = (config: MdtsConfig): MdtsConfig => config
+
+const resolveInput = (input: string | undefined): string => {
+  const rawInput = input ?? defaultInput
+  const normalized = normalizePath(rawInput).replace(/^\.\//u, '').replace(/\/$/u, '')
+  if (normalized.startsWith('/') || /^[A-Za-z]:\//u.test(normalized)) {
+    throw new TypeError('mdts input must be relative to the project root')
+  }
+  if (normalized.split('/').includes('..')) {
+    throw new TypeError('mdts input must stay within the project root')
+  }
+
+  return normalized
+}
+
+const resolveOutput = (output: string | undefined): string => {
+  const resolved = output ?? defaultOutput
+  if (String.isEmpty(resolved)) {
+    throw new TypeError('mdts output must not be empty')
+  }
+  return resolved
+}
+
+const resolveUserConfig = (value: unknown): MdtsConfig => {
+  if (!Predicate.isObject(value) || Array.isArray(value)) {
+    throw new TypeError('mdts.config.ts must export a configuration object')
+  }
+  return value
+}
+
+export const loadMdtsConfig = async (options: LoadMdtsConfigOptions): Promise<ResolvedMdtsConfig> => {
+  const requestedConfigFile = normalizePath(options.configFile ?? defaultConfigFile)
+  const normalizedRoot = normalizePath(options.root).replace(/\/$/u, '')
+  const configFile =
+    requestedConfigFile.startsWith('/') || /^[A-Za-z]:\//u.test(requestedConfigFile)
+      ? requestedConfigFile
+      : `${normalizedRoot}/${requestedConfigFile}`
+  const loaded = await loadConfigFromFile(
+    {
+      command: options.command,
+      isPreview: options.command === 'serve',
+      isSsrBuild: false,
+      mode: options.command === 'build' ? 'production' : 'development',
+    },
+    configFile,
+    options.root,
+  )
+  if (Predicate.isNullish(loaded)) {
+    throw new TypeError(`could not load mdts config: ${configFile}`)
+  }
+  const config = resolveUserConfig(loaded.config)
+
+  return {
+    configFile: loaded.path,
+    input: resolveInput(config.input),
+    output: resolveOutput(config.output),
+    root: options.root,
+    vite: config.vite ?? {},
+  }
+}

--- a/js/app/mdts/src/mdts.test.ts
+++ b/js/app/mdts/src/mdts.test.ts
@@ -2,7 +2,8 @@ import { readFile, readdir, rm } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 
 import { createHtmlRenderer } from '@comark/html'
-import { Predicate } from 'effect'
+import { Effect, Predicate } from 'effect'
+import { FetchHttpClient, HttpClient } from 'effect/unstable/http'
 import { markdownDocumentsId } from 'vite-plugin-mdts'
 import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
 
@@ -66,6 +67,34 @@ describe('mdts', () => {
       await expect(renderHtml(reference)).resolves.toBe(
         '<h1 id="api-reference">API Reference</h1>\n<p>The API is ready.</p>',
       )
+    } finally {
+      await server.close()
+    }
+  })
+
+  test('serves preview HTML at normal document paths', async () => {
+    // Given
+    const server = await createMarkdownPreview({ root: projectRoot })
+
+    try {
+      await server.listen()
+      const previewUrl = server.resolvedUrls?.local[0]
+      if (Predicate.isNullish(previewUrl)) {
+        throw new TypeError('expected a preview URL')
+      }
+
+      // When
+      const requestDocument = Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const response = yield* client.get(new URL('/reference/api.md', previewUrl).href)
+        return { body: yield* response.text, status: response.status }
+      }).pipe(Effect.provide(FetchHttpClient.layer))
+      // oxlint-disable-next-line rules/no-effect-runtime-run -- Test boundary executes one preview HTTP request workflow.
+      const response = await Effect.runPromise(requestDocument)
+
+      // Then
+      expect(response.status).toBe(200)
+      expect(response.body).toContain('<title>mdts preview</title>')
     } finally {
       await server.close()
     }

--- a/js/app/mdts/src/mdts.test.ts
+++ b/js/app/mdts/src/mdts.test.ts
@@ -1,0 +1,73 @@
+import { readFile, readdir, rm } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+import { createHtmlRenderer } from '@comark/html'
+import { Predicate } from 'effect'
+import { markdownDocumentsId } from 'vite-plugin-mdts'
+import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
+
+import { buildMarkdown } from './build.ts'
+import { createMarkdownPreview } from './preview.ts'
+
+const projectRoot = fileURLToPath(new URL('__fixtures__/basic/', import.meta.url))
+const outputDirectory = fileURLToPath(new URL('__fixtures__/basic/dist/', import.meta.url))
+
+const cleanOutput = (): Promise<void> => rm(outputDirectory, { force: true, recursive: true })
+
+const moduleSource = (value: unknown): string => {
+  if (!Predicate.isObject(value)) {
+    throw new TypeError('expected a Markdown module')
+  }
+  const source = Reflect.get(value, 'default')
+  if (!Predicate.isString(source)) {
+    throw new TypeError('expected a Markdown default export')
+  }
+  return source
+}
+
+beforeEach(cleanOutput)
+afterEach(cleanOutput)
+
+describe('mdts', () => {
+  test('builds Markdown assets without loading vite.config.ts', async () => {
+    // When
+    await buildMarkdown({ root: projectRoot })
+
+    // Then
+    const guide = await readFile(`${outputDirectory}/guide.md`, 'utf-8')
+    const reference = await readFile(`${outputDirectory}/reference/api.md`, 'utf-8')
+    const outputs = await readdir(outputDirectory, { recursive: true })
+
+    expect(guide).toBe('# Guide\n\nRead the [API Reference](reference/api.md).\n')
+    expect(reference).toBe('# API Reference\n\nThe API is ready.\n')
+    expect(outputs).not.toContain('index.html')
+    expect(outputs.every((fileName) => !fileName.endsWith('.js'))).toBe(true)
+  })
+
+  test('loads preview documents for Comark HTML rendering', async () => {
+    // Given
+    const server = await createMarkdownPreview({ root: projectRoot })
+
+    try {
+      // When
+      const loaded = await server.ssrLoadModule(markdownDocumentsId)
+      const modules: unknown = loaded.default
+      if (!Predicate.isObject(modules)) {
+        throw new TypeError('expected the Markdown document collection')
+      }
+      const renderHtml = createHtmlRenderer()
+      const guide = moduleSource(Reflect.get(modules, '/content/guide.md.ts'))
+      const reference = moduleSource(Reflect.get(modules, '/content/reference/api.md.ts'))
+
+      // Then
+      await expect(renderHtml(guide)).resolves.toBe(
+        '<h1 id="guide">Guide</h1>\n<p>Read the <a href="reference/api.md">API Reference</a>.</p>',
+      )
+      await expect(renderHtml(reference)).resolves.toBe(
+        '<h1 id="api-reference">API Reference</h1>\n<p>The API is ready.</p>',
+      )
+    } finally {
+      await server.close()
+    }
+  })
+})

--- a/js/app/mdts/src/preview.ts
+++ b/js/app/mdts/src/preview.ts
@@ -70,8 +70,29 @@ const app = document.querySelector('#app')
 let documents = []
 
 const selectedFileName = () => {
-  const requested = decodeURIComponent(window.location.hash.slice(1))
+  const requested = window.location.pathname
+    .slice(1)
+    .split('/')
+    .map(decodeURIComponent)
+    .join('/')
   return documents.some((document) => document.fileName === requested) ? requested : documents[0]?.fileName
+}
+
+const documentPath = (fileName) =>
+  '/' + fileName.split('/').map(encodeURIComponent).join('/')
+
+const navigateToDocument = (event) => {
+  const link = event.target instanceof Element ? event.target.closest('a') : undefined
+  const href = link?.getAttribute('href')
+  if (!href || href.startsWith('#') || /^[a-z]+:/u.test(href)) return
+
+  const target = new URL(href, window.location.href)
+  const fileName = target.pathname.slice(1).split('/').map(decodeURIComponent).join('/')
+  if (documents.some((document) => document.fileName === fileName)) {
+    event.preventDefault()
+    window.history.pushState({}, '', documentPath(fileName))
+    render()
+  }
 }
 
 const render = () => {
@@ -90,29 +111,19 @@ const render = () => {
   for (const entry of documents) {
     const item = document.createElement('li')
     const link = document.createElement('a')
-    link.href = '#' + encodeURIComponent(entry.fileName)
+    link.href = documentPath(entry.fileName)
     link.textContent = entry.fileName
     if (entry.fileName === selected) link.setAttribute('aria-current', 'page')
     item.append(link)
     list.append(item)
   }
   navigation.append(list)
+  navigation.addEventListener('click', navigateToDocument)
 
   const main = document.createElement('main')
   const article = document.createElement('article')
   article.innerHTML = documents.find((document) => document.fileName === selected).html
-  article.addEventListener('click', (event) => {
-    const link = event.target.closest('a')
-    const href = link?.getAttribute('href')
-    if (!href || href.startsWith('#') || /^[a-z]+:/u.test(href)) return
-
-    const target = new URL(href, 'https://mdts.local/' + selected)
-    const fileName = target.pathname.slice(1)
-    if (documents.some((document) => document.fileName === fileName)) {
-      event.preventDefault()
-      window.location.hash = encodeURIComponent(fileName)
-    }
-  })
+  article.addEventListener('click', navigateToDocument)
   main.append(article)
   app.replaceChildren(navigation, main)
 }
@@ -129,7 +140,7 @@ const load = async () => {
   }
 }
 
-window.addEventListener('hashchange', render)
+window.addEventListener('popstate', render)
 await load()
 `
 
@@ -162,7 +173,7 @@ const previewPlugin = (input: string): Plugin => {
         void (async () => {
           try {
             const url = new URL(request.url ?? '/', 'http://mdts.local')
-            if (url.pathname === '/' || url.pathname === '/index.html') {
+            if (url.pathname === '/' || url.pathname === '/index.html' || url.pathname.endsWith('.md')) {
               const html = await server.transformIndexHtml(url.pathname, indexHtml)
               response.statusCode = 200
               response.setHeader('Content-Type', 'text/html; charset=utf-8')

--- a/js/app/mdts/src/preview.ts
+++ b/js/app/mdts/src/preview.ts
@@ -1,0 +1,237 @@
+import { createHtmlRenderer } from '@comark/html'
+import { Predicate, String } from 'effect'
+import { markdownDocumentsId } from 'vite-plugin-mdts'
+import { createServer, normalizePath } from 'vite-plus'
+import type { Plugin, ViteDevServer } from 'vite-plus'
+
+import { resolveMdtsViteConfig } from './build.ts'
+import { loadMdtsConfig } from './config.ts'
+
+const documentsEndpoint = '/__mdts/documents'
+const previewClientId = '/@mdts/client'
+const resolvedPreviewClientId = '\0mdts:preview-client'
+
+interface MdtsPreviewOptions {
+  readonly configFile?: string
+  readonly root: string
+}
+
+interface DocumentModule {
+  readonly default?: unknown
+}
+
+interface PreviewDocument {
+  readonly fileName: string
+  readonly html: string
+}
+
+const indexHtml = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>mdts preview</title>
+    <style>
+      :root { font-family: ui-sans-serif, system-ui, sans-serif; color: #18212f; background: #f6f7f9; }
+      * { box-sizing: border-box; }
+      body { margin: 0; }
+      .layout { display: grid; grid-template-columns: minmax(15rem, 22rem) minmax(0, 1fr); min-height: 100vh; }
+      nav { padding: 2rem 1.5rem; border-right: 1px solid #d9dee7; background: #fff; }
+      nav h1 { margin: 0 0 1.5rem; font-size: 1.25rem; }
+      nav ul { display: grid; gap: 0.35rem; padding: 0; margin: 0; list-style: none; }
+      nav a { display: block; padding: 0.65rem 0.75rem; border-radius: 0.5rem; color: inherit; text-decoration: none; overflow-wrap: anywhere; }
+      nav a:hover, nav a[aria-current="page"] { background: #edf2ff; color: #2849a8; }
+      main { width: min(100%, 60rem); padding: 3rem clamp(1.5rem, 5vw, 5rem); }
+      article { line-height: 1.7; }
+      article img { max-width: 100%; }
+      article pre { overflow: auto; padding: 1rem; border-radius: 0.5rem; background: #1f2937; color: #f9fafb; }
+      article code { font-family: ui-monospace, monospace; }
+      .empty, .error { padding: 1rem; border-radius: 0.5rem; background: #fff; }
+      .error { color: #b42318; }
+      @media (max-width: 760px) { .layout { grid-template-columns: 1fr; } nav { border-right: 0; border-bottom: 1px solid #d9dee7; } main { padding-top: 2rem; } }
+      @media (prefers-color-scheme: dark) {
+        :root { color: #e6eaf0; background: #111827; }
+        nav { background: #18212f; border-color: #344054; }
+        nav a:hover, nav a[aria-current="page"] { background: #263b6a; color: #dbe6ff; }
+        .empty, .error { background: #18212f; }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app" class="layout"><main><p>Loading Markdown documents…</p></main></div>
+    <script type="module" src="${previewClientId}"></script>
+  </body>
+</html>
+`
+
+const previewClientSource = `const endpoint = ${JSON.stringify(documentsEndpoint)}
+const app = document.querySelector('#app')
+let documents = []
+
+const selectedFileName = () => {
+  const requested = decodeURIComponent(window.location.hash.slice(1))
+  return documents.some((document) => document.fileName === requested) ? requested : documents[0]?.fileName
+}
+
+const render = () => {
+  const selected = selectedFileName()
+  if (!selected) {
+    app.innerHTML = '<main><p class="empty">No .md.ts documents were found.</p></main>'
+    return
+  }
+
+  const navigation = document.createElement('nav')
+  const heading = document.createElement('h1')
+  heading.textContent = 'Markdown documents'
+  navigation.append(heading)
+
+  const list = document.createElement('ul')
+  for (const entry of documents) {
+    const item = document.createElement('li')
+    const link = document.createElement('a')
+    link.href = '#' + encodeURIComponent(entry.fileName)
+    link.textContent = entry.fileName
+    if (entry.fileName === selected) link.setAttribute('aria-current', 'page')
+    item.append(link)
+    list.append(item)
+  }
+  navigation.append(list)
+
+  const main = document.createElement('main')
+  const article = document.createElement('article')
+  article.innerHTML = documents.find((document) => document.fileName === selected).html
+  article.addEventListener('click', (event) => {
+    const link = event.target.closest('a')
+    const href = link?.getAttribute('href')
+    if (!href || href.startsWith('#') || /^[a-z]+:/u.test(href)) return
+
+    const target = new URL(href, 'https://mdts.local/' + selected)
+    const fileName = target.pathname.slice(1)
+    if (documents.some((document) => document.fileName === fileName)) {
+      event.preventDefault()
+      window.location.hash = encodeURIComponent(fileName)
+    }
+  })
+  main.append(article)
+  app.replaceChildren(navigation, main)
+}
+
+const load = async () => {
+  try {
+    const response = await fetch(endpoint, { cache: 'no-store' })
+    if (!response.ok) throw new Error(await response.text())
+    documents = await response.json()
+    render()
+  } catch (error) {
+    app.innerHTML = '<main><pre class="error"></pre></main>'
+    app.querySelector('.error').textContent = error instanceof Error ? error.message : String(error)
+  }
+}
+
+window.addEventListener('hashchange', render)
+await load()
+`
+
+const markdownSource = (value: unknown): string | undefined => {
+  if (Predicate.isString(value)) {
+    return value
+  }
+  if (Predicate.isObject(value)) {
+    const source = (value as DocumentModule).default
+    return Predicate.isString(source) ? source : undefined
+  }
+  return undefined
+}
+
+const outputFileName = (modulePath: string, input: string): string | undefined => {
+  const normalizedPath = normalizePath(modulePath)
+  const prefix = String.isEmpty(input) ? '/' : `/${input}/`
+  if (!normalizedPath.startsWith(prefix) || !normalizedPath.endsWith('.md.ts')) {
+    return undefined
+  }
+  return `${normalizedPath.slice(prefix.length, -'.md.ts'.length)}.md`
+}
+
+const previewPlugin = (input: string): Plugin => {
+  const renderHtml = createHtmlRenderer()
+
+  return {
+    configureServer(server) {
+      server.middlewares.use((request, response, next) => {
+        void (async () => {
+          try {
+            const url = new URL(request.url ?? '/', 'http://mdts.local')
+            if (url.pathname === '/' || url.pathname === '/index.html') {
+              const html = await server.transformIndexHtml(url.pathname, indexHtml)
+              response.statusCode = 200
+              response.setHeader('Content-Type', 'text/html; charset=utf-8')
+              response.end(html)
+              return
+            }
+
+            if (url.pathname !== documentsEndpoint) {
+              next()
+              return
+            }
+
+            const loaded = await server.ssrLoadModule(markdownDocumentsId)
+            const modules: unknown = loaded.default
+            if (!Predicate.isObject(modules) || Array.isArray(modules)) {
+              throw new TypeError('vite-plugin-mdts returned an invalid document collection')
+            }
+
+            const documents = await Promise.all(
+              Object.entries(modules).map(async ([modulePath, module]): Promise<PreviewDocument | undefined> => {
+                const fileName = outputFileName(modulePath, input)
+                const source = markdownSource(module)
+                if (Predicate.isNullish(fileName) || Predicate.isNullish(source)) {
+                  return undefined
+                }
+                return { fileName, html: await renderHtml(source) }
+              }),
+            )
+            const responseBody = documents
+              .flatMap((document) => (Predicate.isNullish(document) ? [] : [document]))
+              .toSorted((left, right) => left.fileName.localeCompare(right.fileName))
+
+            response.statusCode = 200
+            response.setHeader('Cache-Control', 'no-store')
+            response.setHeader('Content-Type', 'application/json; charset=utf-8')
+            response.end(JSON.stringify(responseBody))
+          } catch (error) {
+            next(error)
+          }
+        })()
+      })
+    },
+    handleHotUpdate(context) {
+      const sourceDirectory = String.isEmpty(input)
+        ? context.server.config.root
+        : `${context.server.config.root}/${input}`
+      const fileName = normalizePath(context.file)
+      if (fileName.startsWith(`${normalizePath(sourceDirectory)}/`) && fileName.endsWith('.md.ts')) {
+        context.server.ws.send({ type: 'full-reload' })
+        return []
+      }
+      return context.modules
+    },
+    load(id) {
+      return id === resolvedPreviewClientId ? previewClientSource : undefined
+    },
+    name: 'mdts-preview',
+    resolveId(id) {
+      return id === previewClientId ? resolvedPreviewClientId : undefined
+    },
+  }
+}
+
+export const createMarkdownPreview = async (options: MdtsPreviewOptions): Promise<ViteDevServer> => {
+  const config = await loadMdtsConfig({ command: 'serve', ...options })
+  return await createServer(
+    resolveMdtsViteConfig(config, {
+      appType: 'custom',
+      plugins: [previewPlugin(config.input)],
+    }),
+  )
+}

--- a/js/app/mdts/tsconfig.json
+++ b/js/app/mdts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": ["@totto2727/fp/tsconfig/vite"],
+  "compilerOptions": {
+    "types": ["node", "vite-plugin-mdts/client"]
+  }
+}

--- a/js/app/vite-plugin-mdts-example/mdts.config.ts
+++ b/js/app/vite-plugin-mdts-example/mdts.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'mdts'
+
+export default defineConfig({
+  input: './content',
+  output: './dist',
+})

--- a/js/app/vite-plugin-mdts-example/package.json
+++ b/js/app/vite-plugin-mdts-example/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "devDependencies": {
     "@totto2727/fp": "workspace:*",
+    "mdts": "workspace:*",
     "vite": "catalog:",
     "vite-plugin-mdts": "workspace:*"
   }

--- a/js/package/vite-plugin-mdts/src/index.ts
+++ b/js/package/vite-plugin-mdts/src/index.ts
@@ -18,6 +18,7 @@ export interface MarkdownPluginOptions {
 }
 
 interface MarkdownPluginState {
+  command: 'build' | 'serve'
   directory: string
   root: string
   sourceDirectory: string
@@ -30,7 +31,7 @@ interface RenderMarkdownLinkOptions {
   readonly state: MarkdownPluginState
 }
 
-const virtualDocumentsId = 'virtual:vite-plugin-mdts/documents'
+export const markdownDocumentsId = 'virtual:vite-plugin-mdts/documents'
 const resolvedVirtualDocumentsId = '\0vite-plugin-mdts:documents'
 
 export const md = (strings: TemplateStringsArray, ...values: readonly MarkdownTemplateValue[]): string =>
@@ -80,14 +81,16 @@ const renderMarkdownLink = (options: RenderMarkdownLinkOptions): string => {
 }
 
 export const markdown = (options: MarkdownPluginOptions): Plugin => {
-  const state: MarkdownPluginState = { directory: '', root: '', sourceDirectory: '' }
+  const state: MarkdownPluginState = { command: 'build', directory: '', root: '', sourceDirectory: '' }
 
   return {
-    apply: 'build',
     buildStart() {
-      this.emitFile({ id: virtualDocumentsId, type: 'chunk' })
+      if (state.command === 'build') {
+        this.emitFile({ id: markdownDocumentsId, type: 'chunk' })
+      }
     },
     configResolved(config) {
+      state.command = config.command
       state.root = normalizePath(config.root).replace(/\/$/u, '')
       state.directory = normalizeDirectory(options.directory)
       state.sourceDirectory = String.isEmpty(state.directory) ? state.root : `${state.root}/${state.directory}`
@@ -117,7 +120,7 @@ export const markdown = (options: MarkdownPluginOptions): Plugin => {
     },
     name: 'vite-plugin-mdts',
     async resolveId(source, importer) {
-      if (source === virtualDocumentsId) {
+      if (source === markdownDocumentsId) {
         return resolvedVirtualDocumentsId
       }
 
@@ -165,7 +168,9 @@ export const markdown = (options: MarkdownPluginOptions): Plugin => {
         },
       })
 
-      this.emitFile({ fileName, source: compiled.source, type: 'asset' })
+      if (state.command === 'build') {
+        this.emitFile({ fileName, source: compiled.source, type: 'asset' })
+      }
       return { code: compiled.code, map: null }
     },
   }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "lint": {
       "ultracite": "7.10.2"
     },
+    "markdown": {
+      "@comark/html": "^0.6.2"
+    },
     "pulumi": {
       "@pulumi/aws": "^7.0.0",
       "@pulumi/awsx": "^3.0.0",


### PR DESCRIPTION
## 概要

名称変更PR #343 はマージ済みです。

- `js/app/mdts` に独立した `mdts` CLIを追加しました。
- コマンド、flag、help、version処理はEffect v4の `effect/unstable/cli` で実装しています。
- `mdts build` はVite+のprogrammatic `build` APIで `.md.ts` をMarkdownへ生成します。
- `mdts preview` はVite+の `createServer` APIで開発serverを起動し、Effectのscopeでserver lifecycleを管理します。
- previewの `index.html` は生成対象Markdownを一覧表示し、選択した文書を `@comark/html` でHTML描画します。
- 文書は `/guide.md` や `/reference/api.md` の通常URLでroutingし、直接アクセス、reload、browser historyに対応します。
- `.md.ts` の変更時はfull reloadし、ブラウザ表示へリアルタイム反映します。

## 設定

`mdts.config.ts` だけを明示的にロードします。既存の `vite.config.ts` は読み込みません。

```ts
import { defineConfig } from 'mdts'

export default defineConfig({
  input: './content',
  output: './dist',
  vite: {
    server: {
      port: 4173,
    },
  },
})
```

- `input` default: `content`
- `output` default: `dist`
- `vite` はCLI内蔵のVite設定へmergeします。
- project root、config discovery無効化、Markdown plugin、build entry、outputはCLI側のinvariantとして維持します。

## 実装内容

- `vite-plugin-mdts` をserve時にも `.md.ts` からMarkdown文字列moduleへtransformできるようにしました。
- build時だけMarkdown assetをemitし、serve時はVite SSR module graphから文書を取得します。
- preview server側でComark HTML rendererを再利用し、document一覧JSONをindex clientへ返します。
- preview clientはHistory APIで通常URLへ遷移し、serverはdocument pathへの直接requestでもpreview HTMLを返します。
- exampleへ `mdts.config.ts` とCLI依存を追加しました。
- fixture内の `vite.config.ts` は意図的にthrowし、CLIが無視することを統合テストしています。

## 検証

- `vp run --no-cache js:check`
- `vp run --no-cache js:test`（46 files / 255 tests）
- `vp test run js/app/mdts/src/mdts.test.ts`（3 tests）
- `cd js/app/vite-plugin-mdts-example && vp exec mdts --help`
- `cd js/app/vite-plugin-mdts-example && vp exec mdts build -c mdts.config.ts`
- Playwrightでpreviewを実ブラウザ確認
  - `/` で `guide.md` と `reference/api.md` の一覧表示
  - `/reference/api.md` への通常URL遷移
  - document pathでの直接reload
  - browser backによる文書復元
  - Comarkによる見出し、段落、linkのHTML描画
  - console error 0件

## 参考

- [Effect v4 CLI API source](https://github.com/Effect-TS/effect-smol/tree/main/packages/effect/src/unstable/cli)
- [Vite JavaScript API](https://vite.dev/guide/api-javascript.html)
- [Vite Shared Options](https://vite.dev/config/shared-options.html)
- [Comark HTML renderer](https://comark.dev/rendering/html)

## CI status

- Latest commit SHA: `fa55175`
- Latest `check` job: success（run id: `33251776000`、attempt: 1）
- CodeQL: success
- Retry history: none
